### PR TITLE
[feat] Add rimba git worktree manager CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,23 @@ profile.cov
 go.work
 go.work.sum
 
+# Build output
+bin/
+dist/
+
 # env file
 .env
+
+# Rimba config (local to each repo)
+.rimba.toml
 
 # Editor/IDE
 # .idea/
 # .vscode/
+
+### Local configuration file (sdk path, etc) ###
+local.properties
+*local.properties
+*local.yml
+*local.xml
+*local.json

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,38 @@
+version: 2
+project_name: rimba
+
+builds:
+  - main: .
+    binary: rimba
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/lugassawan/rimba/cmd.version={{.Version}}
+      - -X github.com/lugassawan/rimba/cmd.commit={{.ShortCommit}}
+      - -X github.com/lugassawan/rimba/cmd.date={{.Date}}
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS  = -s -w \
+	-X github.com/lugassawan/rimba/cmd.version=$(VERSION) \
+	-X github.com/lugassawan/rimba/cmd.commit=$(COMMIT) \
+	-X github.com/lugassawan/rimba/cmd.date=$(DATE)
+
+.PHONY: build test test-short clean lint
+
+build:
+	go build -ldflags '$(LDFLAGS)' -o bin/rimba .
+
+test:
+	go test ./... -v -count=1
+
+test-short:
+	go test ./... -v -short -count=1
+
+clean:
+	rm -rf bin/
+
+lint:
+	golangci-lint run ./...

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/fileutil"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	addCmd.Flags().StringP("prefix", "p", "", "Branch prefix (default from config)")
+	addCmd.Flags().StringP("source", "s", "", "Source branch to create worktree from (default from config)")
+	_ = addCmd.RegisterFlagCompletionFunc("source", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return completeBranchNames(cmd, toComplete), cobra.ShellCompDirectiveNoFileComp
+	})
+	rootCmd.AddCommand(addCmd)
+}
+
+var addCmd = &cobra.Command{
+	Use:   "add <task>",
+	Short: "Create a new worktree for a task",
+	Long:  "Creates a new git worktree with a branch named <prefix><task> and copies dotfiles from the repo root.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		task := args[0]
+		cfg := config.FromContext(cmd.Context())
+		if cfg == nil {
+			return fmt.Errorf(errNoConfig)
+		}
+
+		r := &git.ExecRunner{}
+
+		repoRoot, err := git.RepoRoot(r)
+		if err != nil {
+			return err
+		}
+
+		prefix, _ := cmd.Flags().GetString("prefix")
+		if prefix == "" {
+			prefix = cfg.DefaultPrefix
+		}
+
+		source, _ := cmd.Flags().GetString("source")
+		if source == "" {
+			source = cfg.DefaultSource
+		}
+
+		branch := resolver.BranchName(prefix, task)
+		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
+		wtPath := resolver.WorktreePath(wtDir, branch)
+
+		// Validate
+		if git.BranchExists(r, branch) {
+			return fmt.Errorf("branch %q already exists", branch)
+		}
+		if _, err := os.Stat(wtPath); err == nil {
+			return fmt.Errorf("worktree path already exists: %s", wtPath)
+		}
+
+		// Create worktree
+		if err := git.AddWorktree(r, wtPath, branch, source); err != nil {
+			return err
+		}
+
+		// Copy dotfiles
+		copied, err := fileutil.CopyDotfiles(repoRoot, wtPath, cfg.CopyFiles)
+		if err != nil {
+			return fmt.Errorf("worktree created but failed to copy files: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Created worktree for task %q\n", task)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Branch: %s\n", branch)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Path:   %s\n", wtPath)
+		if len(copied) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "  Copied: %v\n", copied)
+		}
+
+		return nil
+	},
+}

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cleanCmd.Flags().Bool("dry-run", false, "Show what would be pruned without pruning")
+	rootCmd.AddCommand(cleanCmd)
+}
+
+var cleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Prune stale worktree references",
+	Long:  "Runs git worktree prune to clean up stale worktree references. Use --dry-run to preview.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		r := &git.ExecRunner{}
+
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		out, err := git.Prune(r, dryRun)
+		if err != nil {
+			return err
+		}
+
+		if out != "" {
+			fmt.Fprintln(cmd.OutOrStdout(), out)
+		} else if dryRun {
+			fmt.Fprintln(cmd.OutOrStdout(), "Nothing to prune.")
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), "Pruned stale worktree references.")
+		}
+
+		return nil
+	},
+}

--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/spf13/cobra"
+)
+
+// completeWorktreeTasks returns task names for shell completion.
+func completeWorktreeTasks(cmd *cobra.Command, toComplete string) []string {
+	cfg := config.FromContext(cmd.Context())
+	if cfg == nil {
+		return nil
+	}
+
+	r := &git.ExecRunner{}
+	entries, err := git.ListWorktrees(r)
+	if err != nil {
+		return nil
+	}
+
+	var tasks []string
+	for _, e := range entries {
+		if e.Bare || e.Branch == "" {
+			continue
+		}
+		task := resolver.TaskFromBranch(e.Branch, cfg.DefaultPrefix)
+		if strings.HasPrefix(task, toComplete) {
+			tasks = append(tasks, task)
+		}
+	}
+	return tasks
+}
+
+// completeBranchNames returns branch names for shell completion.
+func completeBranchNames(_ *cobra.Command, toComplete string) []string {
+	r := &git.ExecRunner{}
+	out, err := r.Run("branch", "--format=%(refname:short)")
+	if err != nil {
+		return nil
+	}
+
+	var branches []string
+	for b := range strings.SplitSeq(out, "\n") {
+		b = strings.TrimSpace(b)
+		if b != "" && strings.HasPrefix(b, toComplete) {
+			branches = append(branches, b)
+		}
+	}
+	return branches
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize rimba in the current repository",
+	Long:  "Detects the repository root, creates a .rimba.toml config file, and sets up the worktree directory.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		r := &git.ExecRunner{}
+
+		repoRoot, err := git.RepoRoot(r)
+		if err != nil {
+			return err
+		}
+
+		repoName, err := git.RepoName(r)
+		if err != nil {
+			return err
+		}
+
+		defaultBranch, err := git.DefaultBranch(r)
+		if err != nil {
+			return err
+		}
+
+		configPath := filepath.Join(repoRoot, configFileName)
+		if _, err := os.Stat(configPath); err == nil {
+			return fmt.Errorf(".rimba.toml already exists (use a text editor to modify it)")
+		}
+
+		cfg := config.DefaultConfig(repoName, defaultBranch)
+
+		if err := config.Save(configPath, cfg); err != nil {
+			return err
+		}
+
+		// Create the worktree directory
+		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
+		if err := os.MkdirAll(wtDir, 0755); err != nil {
+			return fmt.Errorf("failed to create worktree directory: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Initialized rimba in %s\n", repoRoot)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Config:       %s\n", configPath)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Worktree dir: %s\n", wtDir)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Source:       %s\n", defaultBranch)
+		fmt.Fprintf(cmd.OutOrStdout(), "\nTip: add .rimba.toml to .gitignore\n")
+
+		return nil
+	},
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all worktrees",
+	Long:  "Lists all git worktrees with their branch, path, and status (dirty, ahead/behind).",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := config.FromContext(cmd.Context())
+		if cfg == nil {
+			return fmt.Errorf(errNoConfig)
+		}
+
+		r := &git.ExecRunner{}
+
+		repoRoot, err := git.RepoRoot(r)
+		if err != nil {
+			return err
+		}
+
+		entries, err := git.ListWorktrees(r)
+		if err != nil {
+			return err
+		}
+
+		if len(entries) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No worktrees found.")
+			return nil
+		}
+
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "TASK\tBRANCH\tPATH\tSTATUS")
+
+		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
+
+		for _, e := range entries {
+			if e.Bare {
+				continue
+			}
+
+			task := resolver.TaskFromBranch(e.Branch, cfg.DefaultPrefix)
+
+			// Determine relative path for display
+			displayPath := e.Path
+			if rel, err := filepath.Rel(wtDir, e.Path); err == nil && len(rel) < len(displayPath) {
+				displayPath = rel
+			}
+
+			// Check status
+			status := ""
+			if dirty, err := git.IsDirty(r, e.Path); err == nil && dirty {
+				status = "[dirty]"
+			}
+
+			ahead, behind, _ := git.AheadBehind(r, e.Path)
+			if ahead > 0 || behind > 0 {
+				ab := fmt.Sprintf("[+%d/-%d]", ahead, behind)
+				if status != "" {
+					status += " " + ab
+				} else {
+					status = ab
+				}
+			}
+
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", task, e.Branch, displayPath, status)
+		}
+
+		return w.Flush()
+	},
+}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	removeCmd.Flags().Bool("branch", false, "Also delete the local branch")
+	removeCmd.Flags().BoolP("force", "f", false, "Force removal even if worktree is dirty")
+	rootCmd.AddCommand(removeCmd)
+}
+
+var removeCmd = &cobra.Command{
+	Use:   "remove <task>",
+	Short: "Remove a worktree",
+	Long:  "Removes the worktree for the given task. Use --branch to also delete the local branch.",
+	Args:  cobra.ExactArgs(1),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return completeWorktreeTasks(cmd, toComplete), cobra.ShellCompDirectiveNoFileComp
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		task := args[0]
+		cfg := config.FromContext(cmd.Context())
+		if cfg == nil {
+			return fmt.Errorf(errNoConfig)
+		}
+
+		r := &git.ExecRunner{}
+
+		repoRoot, err := git.RepoRoot(r)
+		if err != nil {
+			return err
+		}
+
+		// Try to find the worktree by scanning existing worktrees
+		entries, err := git.ListWorktrees(r)
+		if err != nil {
+			return err
+		}
+
+		var worktrees []resolver.WorktreeInfo
+		for _, e := range entries {
+			worktrees = append(worktrees, resolver.WorktreeInfo{
+				Path:   e.Path,
+				Branch: e.Branch,
+			})
+		}
+
+		wt, found := resolver.FindBranchForTask(task, worktrees, cfg.DefaultPrefix)
+		if !found {
+			// Try direct path resolution as fallback
+			branch := resolver.BranchName(cfg.DefaultPrefix, task)
+			wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
+			wtPath := resolver.WorktreePath(wtDir, branch)
+			return fmt.Errorf("worktree not found for task %q (expected path: %s)", task, wtPath)
+		}
+
+		force, _ := cmd.Flags().GetBool("force")
+		if err := git.RemoveWorktree(r, wt.Path, force); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree: %s\n", wt.Path)
+
+		deleteBranch, _ := cmd.Flags().GetBool("branch")
+		if deleteBranch {
+			if err := git.DeleteBranch(r, wt.Branch, force); err != nil {
+				return fmt.Errorf("worktree removed but failed to delete branch %q: %w", wt.Branch, err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted branch: %s\n", wt.Branch)
+		}
+
+		return nil
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"path/filepath"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/spf13/cobra"
+)
+
+const (
+	configFileName = ".rimba.toml"
+	errNoConfig    = "config not loaded (run 'rimba init' first)"
+)
+
+var rootCmd = &cobra.Command{
+	Use:          "rimba",
+	Short:        "Git worktree manager",
+	Long:         "Rimba simplifies git worktree management with auto-copying dotfiles, branch naming conventions, and worktree status dashboards.",
+	SilenceUsage: true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Skip config loading for init, version, and completion commands
+		if cmd.Name() == "init" || cmd.Name() == "version" || cmd.Name() == "completion" || cmd.Name() == "clean" {
+			return nil
+		}
+
+		r := &git.ExecRunner{}
+		repoRoot, err := git.RepoRoot(r)
+		if err != nil {
+			return err
+		}
+
+		cfg, err := config.Load(filepath.Join(repoRoot, configFileName))
+		if err != nil {
+			return err
+		}
+		cmd.SetContext(config.WithConfig(cmd.Context(), cfg))
+		return nil
+	},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Fprintf(cmd.OutOrStdout(), "rimba %s (commit: %s, built: %s)\n", version, commit, date)
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/lugassawan/rimba
+
+go 1.25.7
+
+require (
+	github.com/pelletier/go-toml/v2 v2.2.4
+	github.com/spf13/cobra v1.10.2
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+type Config struct {
+	WorktreeDir   string   `toml:"worktree_dir"`
+	DefaultPrefix string   `toml:"default_prefix"`
+	DefaultSource string   `toml:"default_source"`
+	CopyFiles     []string `toml:"copy_files"`
+}
+
+type ctxKey struct{}
+
+func DefaultConfig(repoName, defaultBranch string) *Config {
+	return &Config{
+		WorktreeDir:   "../" + repoName + "-worktrees",
+		DefaultPrefix: "feat/",
+		DefaultSource: defaultBranch,
+		CopyFiles:     []string{".env", ".env.local", ".envrc", ".tool-versions"},
+	}
+}
+
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("config not found: %w (run 'rimba init' first)", err)
+	}
+
+	var cfg Config
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func Save(path string, cfg *Config) error {
+	data, err := toml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func WithConfig(ctx context.Context, cfg *Config) context.Context {
+	return context.WithValue(ctx, ctxKey{}, cfg)
+}
+
+func FromContext(ctx context.Context) *Config {
+	cfg, _ := ctx.Value(ctxKey{}).(*Config)
+	return cfg
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,86 @@
+package config_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/config"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := config.DefaultConfig("myrepo", "main")
+
+	if cfg.WorktreeDir != "../myrepo-worktrees" {
+		t.Errorf("WorktreeDir = %q, want %q", cfg.WorktreeDir, "../myrepo-worktrees")
+	}
+	if cfg.DefaultPrefix != "feat/" {
+		t.Errorf("DefaultPrefix = %q, want %q", cfg.DefaultPrefix, "feat/")
+	}
+	if cfg.DefaultSource != "main" {
+		t.Errorf("DefaultSource = %q, want %q", cfg.DefaultSource, "main")
+	}
+	expected := []string{".env", ".env.local", ".envrc", ".tool-versions"}
+	if !reflect.DeepEqual(cfg.CopyFiles, expected) {
+		t.Errorf("CopyFiles = %v, want %v", cfg.CopyFiles, expected)
+	}
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".rimba.toml")
+
+	original := config.DefaultConfig("test-repo", "main")
+	if err := config.Save(path, original); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if !reflect.DeepEqual(original, loaded) {
+		t.Errorf("loaded config differs:\n  got:  %+v\n  want: %+v", loaded, original)
+	}
+}
+
+func TestLoadMissing(t *testing.T) {
+	_, err := config.Load("/nonexistent/.rimba.toml")
+	if err == nil {
+		t.Fatal("expected error for missing config")
+	}
+}
+
+func TestLoadInvalid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".rimba.toml")
+
+	if err := os.WriteFile(path, []byte("invalid = [[["), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := config.Load(path)
+	if err == nil {
+		t.Fatal("expected error for invalid TOML")
+	}
+}
+
+func TestContext(t *testing.T) {
+	cfg := config.DefaultConfig("test", "main")
+	ctx := config.WithConfig(context.Background(), cfg)
+	got := config.FromContext(ctx)
+
+	if got != cfg {
+		t.Error("FromContext did not return the stored config")
+	}
+}
+
+func TestFromContextNil(t *testing.T) {
+	got := config.FromContext(context.Background())
+	if got != nil {
+		t.Error("FromContext on empty context should return nil")
+	}
+}

--- a/internal/fileutil/copy.go
+++ b/internal/fileutil/copy.go
@@ -1,0 +1,49 @@
+package fileutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// CopyDotfiles copies the listed files from src directory to dst directory.
+// Missing source files are silently skipped. Returns the list of files actually copied.
+func CopyDotfiles(src, dst string, files []string) ([]string, error) {
+	var copied []string
+	for _, name := range files {
+		srcPath := filepath.Join(src, name)
+		dstPath := filepath.Join(dst, name)
+
+		if err := copyFile(srcPath, dstPath); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return copied, fmt.Errorf("copy %s: %w", name, err)
+		}
+		copied = append(copied, name)
+	}
+	return copied, nil
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/fileutil/copy_test.go
+++ b/internal/fileutil/copy_test.go
@@ -1,0 +1,68 @@
+package fileutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/fileutil"
+)
+
+func TestCopyDotfiles(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create some source files
+	os.WriteFile(filepath.Join(src, ".env"), []byte("SECRET=123"), 0644)
+	os.WriteFile(filepath.Join(src, ".envrc"), []byte("use nix"), 0644)
+	// .env.local does NOT exist — should be silently skipped
+
+	files := []string{".env", ".env.local", ".envrc", ".tool-versions"}
+	copied, err := fileutil.CopyDotfiles(src, dst, files)
+	if err != nil {
+		t.Fatalf("CopyDotfiles: %v", err)
+	}
+
+	want := []string{".env", ".envrc"}
+	if !reflect.DeepEqual(copied, want) {
+		t.Errorf("copied = %v, want %v", copied, want)
+	}
+
+	// Verify content
+	data, err := os.ReadFile(filepath.Join(dst, ".env"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "SECRET=123" {
+		t.Errorf(".env content = %q, want %q", data, "SECRET=123")
+	}
+
+	// Verify skipped file doesn't exist
+	if _, err := os.Stat(filepath.Join(dst, ".env.local")); !os.IsNotExist(err) {
+		t.Error(".env.local should not exist in dst")
+	}
+}
+
+func TestCopyDotfilesPreservesPermissions(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	os.WriteFile(filepath.Join(src, ".envrc"), []byte("use nix"), 0755)
+
+	copied, err := fileutil.CopyDotfiles(src, dst, []string{".envrc"})
+	if err != nil {
+		t.Fatalf("CopyDotfiles: %v", err)
+	}
+	if len(copied) != 1 {
+		t.Fatalf("expected 1 copied file, got %d", len(copied))
+	}
+
+	info, err := os.Stat(filepath.Join(dst, ".envrc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("mode = %o, want %o", info.Mode().Perm(), 0755)
+	}
+}

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -1,0 +1,62 @@
+package git
+
+import (
+	"strings"
+)
+
+// BranchExists checks whether a local branch exists.
+func BranchExists(r Runner, branch string) bool {
+	_, err := r.Run(cmdRevParse, flagVerify, refsHeadsPrefix+branch)
+	return err == nil
+}
+
+// DeleteBranch deletes a local branch. If force is true, uses -D instead of -d.
+func DeleteBranch(r Runner, branch string, force bool) error {
+	flag := "-d"
+	if force {
+		flag = "-D"
+	}
+	_, err := r.Run("branch", flag, branch)
+	return err
+}
+
+// IsDirty returns true if the working tree at the given directory has uncommitted changes.
+func IsDirty(r Runner, dir string) (bool, error) {
+	out, err := r.RunInDir(dir, "status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) != "", nil
+}
+
+// AheadBehind returns the ahead/behind counts of the current branch vs its upstream.
+// Returns (0, 0, nil) if there's no upstream configured.
+func AheadBehind(r Runner, dir string) (ahead, behind int, err error) {
+	out, err := r.RunInDir(dir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
+	if err != nil {
+		// No upstream or other error — treat as 0/0
+		return 0, 0, nil
+	}
+
+	parts := strings.Fields(out)
+	if len(parts) != 2 {
+		return 0, 0, nil
+	}
+
+	var a, b int
+	_, _ = parseCount(parts[0], &b)
+	_, _ = parseCount(parts[1], &a)
+	return a, b, nil
+}
+
+func parseCount(s string, v *int) (int, error) {
+	n := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			break
+		}
+		n = n*10 + int(c-'0')
+	}
+	*v = n
+	return n, nil
+}

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -1,0 +1,77 @@
+package git_test
+
+import (
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+func TestBranchExists(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	if !git.BranchExists(r, "main") {
+		t.Error("expected main branch to exist")
+	}
+
+	if git.BranchExists(r, "nonexistent") {
+		t.Error("expected nonexistent branch to not exist")
+	}
+}
+
+func TestDeleteBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	// Create a branch
+	testutil.GitCmd(t, repo, "branch", "to-delete")
+
+	if !git.BranchExists(r, "to-delete") {
+		t.Fatal("branch should exist before delete")
+	}
+
+	if err := git.DeleteBranch(r, "to-delete", false); err != nil {
+		t.Fatalf("DeleteBranch: %v", err)
+	}
+
+	if git.BranchExists(r, "to-delete") {
+		t.Error("branch should not exist after delete")
+	}
+}
+
+func TestIsDirty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	dirty, err := git.IsDirty(r, repo)
+	if err != nil {
+		t.Fatalf("IsDirty: %v", err)
+	}
+	if dirty {
+		t.Error("clean repo should not be dirty")
+	}
+
+	// Make it dirty
+	testutil.CreateFile(t, repo, "new.txt", "dirty")
+
+	dirty, err = git.IsDirty(r, repo)
+	if err != nil {
+		t.Fatalf("IsDirty: %v", err)
+	}
+	if !dirty {
+		t.Error("repo with untracked file should be dirty")
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,0 +1,37 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Runner abstracts git command execution for testability.
+type Runner interface {
+	Run(args ...string) (string, error)
+	RunInDir(dir string, args ...string) (string, error)
+}
+
+// ExecRunner is the production implementation of Runner.
+type ExecRunner struct {
+	// Dir is the working directory for git commands. If empty, uses the current directory.
+	Dir string
+}
+
+func (r *ExecRunner) Run(args ...string) (string, error) {
+	return r.RunInDir(r.Dir, args...)
+}
+
+func (r *ExecRunner) RunInDir(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+
+	out, err := cmd.CombinedOutput()
+	result := strings.TrimSpace(string(out))
+	if err != nil {
+		return result, fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), result, err)
+	}
+	return result, nil
+}

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -1,0 +1,54 @@
+package git
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	refsHeadsPrefix = "refs/heads/"
+	cmdRevParse     = "rev-parse"
+	flagVerify      = "--verify"
+)
+
+// RepoRoot returns the absolute path to the repository root.
+func RepoRoot(r Runner) (string, error) {
+	out, err := r.Run(cmdRevParse, "--show-toplevel")
+	if err != nil {
+		return "", fmt.Errorf("not a git repository: %w", err)
+	}
+	return out, nil
+}
+
+// RepoName returns the name of the repository (basename of the root directory).
+func RepoName(r Runner) (string, error) {
+	root, err := RepoRoot(r)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Base(root), nil
+}
+
+// DefaultBranch detects the default branch (main or master).
+func DefaultBranch(r Runner) (string, error) {
+	// Try symbolic-ref for origin/HEAD first
+	out, err := r.Run("symbolic-ref", "refs/remotes/origin/HEAD")
+	if err == nil {
+		// refs/remotes/origin/main → main
+		parts := strings.Split(out, "/")
+		return parts[len(parts)-1], nil
+	}
+
+	// Fall back: check if main exists
+	if _, err := r.Run(cmdRevParse, flagVerify, refsHeadsPrefix+"main"); err == nil {
+		return "main", nil
+	}
+
+	// Fall back: check if master exists
+	if _, err := r.Run(cmdRevParse, flagVerify, refsHeadsPrefix+"master"); err == nil {
+		return "master", nil
+	}
+
+	return "", fmt.Errorf("could not detect default branch (no main or master found)")
+}

--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -1,0 +1,66 @@
+package git_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+func TestRepoRoot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	root, err := git.RepoRoot(r)
+	if err != nil {
+		t.Fatalf("RepoRoot: %v", err)
+	}
+
+	// Resolve symlinks for macOS /private/var vs /var
+	wantRoot, _ := filepath.EvalSymlinks(repo)
+	gotRoot, _ := filepath.EvalSymlinks(root)
+	if gotRoot != wantRoot {
+		t.Errorf("RepoRoot = %q, want %q", gotRoot, wantRoot)
+	}
+}
+
+func TestRepoName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	name, err := git.RepoName(r)
+	if err != nil {
+		t.Fatalf("RepoName: %v", err)
+	}
+
+	if name != "test-repo" {
+		t.Errorf("RepoName = %q, want %q", name, "test-repo")
+	}
+}
+
+func TestDefaultBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	branch, err := git.DefaultBranch(r)
+	if err != nil {
+		t.Fatalf("DefaultBranch: %v", err)
+	}
+
+	if branch != "main" {
+		t.Errorf("DefaultBranch = %q, want %q", branch, "main")
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,0 +1,88 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	cmdWorktree = "worktree"
+
+	// Porcelain output prefixes
+	porcelainWorktree = "worktree "
+	porcelainHEAD     = "HEAD "
+	porcelainBranch   = "branch "
+)
+
+// WorktreeEntry represents a parsed worktree from `git worktree list --porcelain`.
+type WorktreeEntry struct {
+	Path   string
+	HEAD   string
+	Branch string
+	Bare   bool
+}
+
+// AddWorktree creates a new worktree at the given path with a new branch from source.
+func AddWorktree(r Runner, path, branch, source string) error {
+	_, err := r.Run(cmdWorktree, "add", "-b", branch, path, source)
+	return err
+}
+
+// RemoveWorktree removes the worktree at the given path.
+func RemoveWorktree(r Runner, path string, force bool) error {
+	args := []string{cmdWorktree, "remove", path}
+	if force {
+		args = append(args, "--force")
+	}
+	_, err := r.Run(args...)
+	return err
+}
+
+// ListWorktrees returns all worktrees by parsing `git worktree list --porcelain`.
+func ListWorktrees(r Runner) ([]WorktreeEntry, error) {
+	out, err := r.Run(cmdWorktree, "list", "--porcelain")
+	if err != nil {
+		return nil, err
+	}
+
+	var entries []WorktreeEntry
+	var current WorktreeEntry
+
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, porcelainWorktree):
+			if current.Path != "" {
+				entries = append(entries, current)
+			}
+			current = WorktreeEntry{Path: strings.TrimPrefix(line, porcelainWorktree)}
+		case strings.HasPrefix(line, porcelainHEAD):
+			current.HEAD = strings.TrimPrefix(line, porcelainHEAD)
+		case strings.HasPrefix(line, porcelainBranch):
+			// refs/heads/feat/my-task → feat/my-task
+			ref := strings.TrimPrefix(line, porcelainBranch)
+			current.Branch = strings.TrimPrefix(ref, refsHeadsPrefix)
+		case line == "bare":
+			current.Bare = true
+		}
+	}
+
+	if current.Path != "" {
+		entries = append(entries, current)
+	}
+
+	return entries, nil
+}
+
+// Prune runs `git worktree prune` to clean up stale worktree references.
+func Prune(r Runner, dryRun bool) (string, error) {
+	args := []string{cmdWorktree, "prune"}
+	if dryRun {
+		args = append(args, "--dry-run")
+	}
+	out, err := r.Run(args...)
+	if err != nil {
+		return "", fmt.Errorf("prune: %w", err)
+	}
+	return out, nil
+}

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -1,0 +1,73 @@
+package git_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+func TestAddAndListWorktrees(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	wtPath := filepath.Join(filepath.Dir(repo), "wt-feat-login")
+
+	if err := git.AddWorktree(r, wtPath, "feat/login", "main"); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+
+	// Verify directory exists
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("worktree dir not created: %v", err)
+	}
+
+	entries, err := git.ListWorktrees(r)
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+
+	// Should have at least 2: main repo + new worktree
+	if len(entries) < 2 {
+		t.Fatalf("expected at least 2 worktrees, got %d", len(entries))
+	}
+
+	found := false
+	for _, e := range entries {
+		if e.Branch == "feat/login" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("worktree with branch feat/login not found in list")
+	}
+}
+
+func TestRemoveWorktree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	wtPath := filepath.Join(filepath.Dir(repo), "wt-to-remove")
+	if err := git.AddWorktree(r, wtPath, "feat/remove-me", "main"); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+
+	if err := git.RemoveWorktree(r, wtPath, false); err != nil {
+		t.Fatalf("RemoveWorktree: %v", err)
+	}
+
+	if _, err := os.Stat(wtPath); !os.IsNotExist(err) {
+		t.Error("worktree directory should be removed")
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1,0 +1,59 @@
+package resolver
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// BranchName returns the full branch name for a task with the given prefix.
+func BranchName(prefix, task string) string {
+	return prefix + task
+}
+
+// DirName converts a branch name to a directory-safe name.
+// e.g. "feat/my-task" → "feat-my-task"
+func DirName(branch string) string {
+	return strings.ReplaceAll(branch, "/", "-")
+}
+
+// WorktreePath returns the full path to the worktree directory.
+func WorktreePath(worktreeDir, branch string) string {
+	return filepath.Join(worktreeDir, DirName(branch))
+}
+
+// TaskFromBranch extracts the task name from a branch name by stripping the prefix.
+// Returns the full branch name if the prefix doesn't match.
+func TaskFromBranch(branch, prefix string) string {
+	if task, ok := strings.CutPrefix(branch, prefix); ok {
+		return task
+	}
+	return branch
+}
+
+// WorktreeInfo holds parsed information about a worktree.
+type WorktreeInfo struct {
+	Path   string
+	Branch string
+}
+
+// FindBranchForTask searches worktrees for one matching the given task.
+// It tries: prefix+task exact match, then bare task name match.
+func FindBranchForTask(task string, worktrees []WorktreeInfo, prefix string) (WorktreeInfo, bool) {
+	target := BranchName(prefix, task)
+
+	// Try exact match with prefix
+	for _, wt := range worktrees {
+		if wt.Branch == target {
+			return wt, true
+		}
+	}
+
+	// Try exact match without prefix (user passed full branch name)
+	for _, wt := range worktrees {
+		if wt.Branch == task {
+			return wt, true
+		}
+	}
+
+	return WorktreeInfo{}, false
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1,0 +1,99 @@
+package resolver_test
+
+import (
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/resolver"
+)
+
+func TestBranchName(t *testing.T) {
+	tests := []struct {
+		prefix, task, want string
+	}{
+		{"feat/", "my-task", "feat/my-task"},
+		{"bugfix/", "login-fix", "bugfix/login-fix"},
+		{"", "bare-branch", "bare-branch"},
+	}
+	for _, tt := range tests {
+		got := resolver.BranchName(tt.prefix, tt.task)
+		if got != tt.want {
+			t.Errorf("BranchName(%q, %q) = %q, want %q", tt.prefix, tt.task, got, tt.want)
+		}
+	}
+}
+
+func TestDirName(t *testing.T) {
+	tests := []struct {
+		branch, want string
+	}{
+		{"feat/my-task", "feat-my-task"},
+		{"bugfix/login-fix", "bugfix-login-fix"},
+		{"bare-branch", "bare-branch"},
+	}
+	for _, tt := range tests {
+		got := resolver.DirName(tt.branch)
+		if got != tt.want {
+			t.Errorf("DirName(%q) = %q, want %q", tt.branch, got, tt.want)
+		}
+	}
+}
+
+func TestWorktreePath(t *testing.T) {
+	got := resolver.WorktreePath("/home/user/repo-worktrees", "feat/my-task")
+	want := "/home/user/repo-worktrees/feat-my-task"
+	if got != want {
+		t.Errorf("WorktreePath = %q, want %q", got, want)
+	}
+}
+
+func TestTaskFromBranch(t *testing.T) {
+	tests := []struct {
+		branch, prefix, want string
+	}{
+		{"feat/my-task", "feat/", "my-task"},
+		{"bugfix/login-fix", "bugfix/", "login-fix"},
+		{"feat/my-task", "bugfix/", "feat/my-task"},
+		{"bare-branch", "feat/", "bare-branch"},
+	}
+	for _, tt := range tests {
+		got := resolver.TaskFromBranch(tt.branch, tt.prefix)
+		if got != tt.want {
+			t.Errorf("TaskFromBranch(%q, %q) = %q, want %q", tt.branch, tt.prefix, got, tt.want)
+		}
+	}
+}
+
+func TestFindBranchForTask(t *testing.T) {
+	worktrees := []resolver.WorktreeInfo{
+		{Path: "/wt/feat-login", Branch: "feat/login"},
+		{Path: "/wt/feat-signup", Branch: "feat/signup"},
+		{Path: "/wt/bugfix-crash", Branch: "bugfix/crash"},
+	}
+
+	t.Run("match with prefix", func(t *testing.T) {
+		wt, ok := resolver.FindBranchForTask("login", worktrees, "feat/")
+		if !ok {
+			t.Fatal("expected match")
+		}
+		if wt.Branch != "feat/login" {
+			t.Errorf("got branch %q, want %q", wt.Branch, "feat/login")
+		}
+	})
+
+	t.Run("match with full branch name", func(t *testing.T) {
+		wt, ok := resolver.FindBranchForTask("bugfix/crash", worktrees, "feat/")
+		if !ok {
+			t.Fatal("expected match")
+		}
+		if wt.Branch != "bugfix/crash" {
+			t.Errorf("got branch %q, want %q", wt.Branch, "bugfix/crash")
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		_, ok := resolver.FindBranchForTask("nonexistent", worktrees, "feat/")
+		if ok {
+			t.Fatal("expected no match")
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lugassawan/rimba/cmd"
+)
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/testutil/githelper.go
+++ b/testutil/githelper.go
@@ -1,0 +1,76 @@
+package testutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// NewTestRepo creates a temporary git repository with an initial commit.
+// Returns the path to the repo. The repo is cleaned up when the test finishes.
+func NewTestRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "test-repo")
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cmds := [][]string{
+		{"git", "init", "-b", "main"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+	}
+
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %s: %v", args, out, err)
+		}
+	}
+
+	// Create an initial commit
+	readmePath := filepath.Join(repo, "README.md")
+	if err := os.WriteFile(readmePath, []byte("# Test\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cmds = [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-m", "initial commit"},
+	}
+
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("cmd %v: %s: %v", args, out, err)
+		}
+	}
+
+	return repo
+}
+
+// CreateFile creates a file in the given directory with the given content.
+func CreateFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// GitCmd runs a git command in the given directory.
+func GitCmd(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %s: %v", args, out, err)
+	}
+	return string(out)
+}


### PR DESCRIPTION
## Summary
- Implement a developer-friendly CLI for managing git worktrees with auto-copying dotfiles, branch naming conventions, and status dashboards
- Commands: `init`, `add`, `remove`, `list`, `clean`, `version`, `completion`
- Core packages: `internal/git`, `internal/config`, `internal/resolver`, `internal/fileutil`
- Includes 20 unit/integration tests and goreleaser config

## Test plan
- [x] Run `go test ./...` to verify all 20 tests pass
- [x] Run `go build -o rimba .` and test CLI commands manually
- [x] Verify `rimba init`, `rimba add`, `rimba list`, `rimba remove`, `rimba clean` work against a real git repo