### PR TITLE
[feat] Auto-add .rimba.toml to .gitignore during init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/fileutil"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/spf13/cobra"
 )
@@ -53,11 +54,20 @@ var initCmd = &cobra.Command{
 			return fmt.Errorf("failed to create worktree directory: %w", err)
 		}
 
+		added, err := fileutil.EnsureGitignore(repoRoot, configFileName)
+		if err != nil {
+			return fmt.Errorf("failed to update .gitignore: %w", err)
+		}
+
 		fmt.Fprintf(cmd.OutOrStdout(), "Initialized rimba in %s\n", repoRoot)
 		fmt.Fprintf(cmd.OutOrStdout(), "  Config:       %s\n", configPath)
 		fmt.Fprintf(cmd.OutOrStdout(), "  Worktree dir: %s\n", wtDir)
 		fmt.Fprintf(cmd.OutOrStdout(), "  Source:       %s\n", defaultBranch)
-		fmt.Fprintf(cmd.OutOrStdout(), "\nTip: add .rimba.toml to .gitignore\n")
+		if added {
+			fmt.Fprintf(cmd.OutOrStdout(), "  Gitignore:   %s added to .gitignore\n", configFileName)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "  Gitignore:   %s (already in .gitignore)\n", configFileName)
+		}
 
 		return nil
 	},

--- a/internal/fileutil/gitignore_test.go
+++ b/internal/fileutil/gitignore_test.go
@@ -1,0 +1,131 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testEntry      = ".rimba.toml"
+	gitignoreFile  = ".gitignore"
+	errUnexpected  = "unexpected error: %v"
+	otherEntry     = "node_modules"
+	otherEntryLine = otherEntry + "\n"
+)
+
+func TestEnsureGitignoreNoFile(t *testing.T) {
+	dir := t.TempDir()
+
+	added, err := EnsureGitignore(dir, testEntry)
+	if err != nil {
+		t.Fatalf(errUnexpected, err)
+	}
+	if !added {
+		t.Fatal("expected added=true when .gitignore does not exist")
+	}
+
+	got := readFile(t, filepath.Join(dir, gitignoreFile))
+	if got != testEntry+"\n" {
+		t.Errorf("expected %q, got %q", testEntry+"\n", got)
+	}
+}
+
+func TestEnsureGitignoreExistsWithoutEntry(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, gitignoreFile), otherEntryLine)
+
+	added, err := EnsureGitignore(dir, testEntry)
+	if err != nil {
+		t.Fatalf(errUnexpected, err)
+	}
+	if !added {
+		t.Fatal("expected added=true")
+	}
+
+	got := readFile(t, filepath.Join(dir, gitignoreFile))
+	if got != otherEntryLine+testEntry+"\n" {
+		t.Errorf("unexpected content: %q", got)
+	}
+}
+
+func TestEnsureGitignoreAlreadyPresent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, gitignoreFile), otherEntryLine+testEntry+"\n")
+
+	added, err := EnsureGitignore(dir, testEntry)
+	if err != nil {
+		t.Fatalf(errUnexpected, err)
+	}
+	if added {
+		t.Fatal("expected added=false when entry already present")
+	}
+
+	got := readFile(t, filepath.Join(dir, gitignoreFile))
+	if got != otherEntryLine+testEntry+"\n" {
+		t.Errorf("content should be unchanged, got %q", got)
+	}
+}
+
+func TestEnsureGitignoreNoTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, gitignoreFile), otherEntry)
+
+	added, err := EnsureGitignore(dir, testEntry)
+	if err != nil {
+		t.Fatalf(errUnexpected, err)
+	}
+	if !added {
+		t.Fatal("expected added=true")
+	}
+
+	got := readFile(t, filepath.Join(dir, gitignoreFile))
+	if !strings.HasSuffix(got, "\n"+testEntry+"\n") {
+		t.Errorf("expected entry on its own line, got %q", got)
+	}
+}
+
+func TestEnsureGitignoreWhitespaceMatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, gitignoreFile), "  "+testEntry+"  \n")
+
+	added, err := EnsureGitignore(dir, testEntry)
+	if err != nil {
+		t.Fatalf(errUnexpected, err)
+	}
+	if added {
+		t.Fatal("expected added=false when entry present with surrounding whitespace")
+	}
+}
+
+func TestEnsureGitignoreIdempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	for range 3 {
+		if _, err := EnsureGitignore(dir, testEntry); err != nil {
+			t.Fatalf(errUnexpected, err)
+		}
+	}
+
+	got := readFile(t, filepath.Join(dir, gitignoreFile))
+	if strings.Count(got, testEntry) != 1 {
+		t.Errorf("expected exactly one occurrence, got %q", got)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -17,6 +17,7 @@ const (
 	defaultPrefix = "feature/"
 	bugfixPrefix  = "bugfix/"
 	configFile    = ".rimba.toml"
+	gitignoreFile = ".gitignore"
 
 	// Output messages asserted in tests.
 	msgCreatedWorktree = "Created worktree"


### PR DESCRIPTION
## Summary
- `rimba init` now automatically adds `.rimba.toml` to `.gitignore`, replacing the manual tip message
- Added `EnsureGitignore` helper in `internal/fileutil` with idempotent append logic
- Displays whether the entry was added or already present in the init output

## Test plan
- [x] Unit tests for `EnsureGitignore`: no file, append, already present, no trailing newline, whitespace match, idempotency
- [x] E2E tests: `TestInitCreatesConfigAndDir` asserts `.gitignore` exists, `TestInitAddsToGitignore` verifies append to existing file, `TestInitGitignoreIdempotent` verifies no duplicates
- [x] Full test suite passes (`make test`)