### PR TITLE
[feat] Add duplicate and merge commands for worktree management

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Git worktree manager CLI — branch naming conventions, dotfile copying, and wor
 - **Automatic branch naming** — configurable prefix (e.g. `feat/`, `fix/`) applied to task names
 - **Dotfile copying** — auto-copies files like `.env`, `.envrc`, `.tool-versions` into new worktrees
 - **Status dashboard** — colored tabular view of all worktrees with dirty state, ahead/behind counts, current worktree indicator, and filtering
+- **Duplicate worktrees** — create a copy of an existing worktree with auto-suffixed or custom name
+- **Local merge** — merge worktree branches into main or other worktrees with auto-cleanup
 - **Stale cleanup** — prune stale worktree references with dry-run support
 - **Shell completions** — built-in completion for bash, zsh, fish, and PowerShell
 - **Cross-platform** — builds for Linux, macOS, and Windows (amd64/arm64)
@@ -124,6 +126,40 @@ rimba rename old-task new-task -f  # Force rename even if locked
 | Flag | Description |
 |------|-------------|
 | `-f`, `--force` | Force rename even if the worktree is locked |
+
+### `rimba duplicate <task>`
+
+Create a new worktree from an existing worktree, inheriting its branch prefix. Auto-generates a `-1`, `-2`, etc. suffix unless `--as` is provided.
+
+```sh
+rimba duplicate auth              # Creates feature/auth-1 from feature/auth
+rimba duplicate auth --as auth-v2 # Creates feature/auth-v2 from feature/auth
+```
+
+| Flag | Description |
+|------|-------------|
+| `--as` | Custom name for the duplicate worktree (instead of auto-suffix) |
+
+### `rimba merge <source-task>`
+
+Merge a worktree's branch into main or another worktree. When merging into main, the source worktree and branch are auto-deleted unless `--keep` is set. When merging between worktrees, the source is kept unless `--delete` is set.
+
+```sh
+rimba merge auth                           # Merge into main, delete source
+rimba merge auth --keep                    # Merge into main, keep source
+rimba merge auth --into dashboard          # Merge into worktree, keep source
+rimba merge auth --into dashboard --delete # Merge into worktree, delete source
+rimba merge auth --no-ff                   # Force merge commit
+```
+
+| Flag | Description |
+|------|-------------|
+| `--into` | Target worktree task to merge into (default: main/repo root) |
+| `--no-ff` | Force a merge commit (no fast-forward) |
+| `--keep` | Keep source worktree after merging into main |
+| `--delete` | Delete source worktree after merging into another worktree |
+
+> **Note:** `--keep` and `--delete` are mutually exclusive. Merging to main deletes the source by default; merging to another worktree keeps it by default.
 
 ### `rimba clean`
 

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/fileutil"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	duplicateCmd.Flags().String("as", "", "Custom name for the duplicate worktree")
+	rootCmd.AddCommand(duplicateCmd)
+}
+
+var duplicateCmd = &cobra.Command{
+	Use:   "duplicate <task>",
+	Short: "Create a new worktree from an existing worktree",
+	Long:  "Creates a new worktree branched from an existing worktree's branch, inheriting its prefix. Auto-suffixes with -1, -2, etc. unless --as is provided.",
+	Args:  cobra.ExactArgs(1),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return completeWorktreeTasks(cmd, toComplete), cobra.ShellCompDirectiveNoFileComp
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		task := args[0]
+		cfg := config.FromContext(cmd.Context())
+		if cfg == nil {
+			return fmt.Errorf(errNoConfig)
+		}
+
+		r := &git.ExecRunner{}
+
+		repoRoot, err := git.RepoRoot(r)
+		if err != nil {
+			return err
+		}
+
+		// Find the source worktree
+		entries, err := git.ListWorktrees(r)
+		if err != nil {
+			return err
+		}
+
+		var worktrees []resolver.WorktreeInfo
+		for _, e := range entries {
+			worktrees = append(worktrees, resolver.WorktreeInfo{
+				Path:   e.Path,
+				Branch: e.Branch,
+			})
+		}
+
+		prefixes := resolver.AllPrefixes()
+		wt, found := resolver.FindBranchForTask(task, worktrees, prefixes)
+		if !found {
+			return fmt.Errorf(errWorktreeNotFound, task)
+		}
+
+		if wt.Branch == cfg.DefaultSource {
+			return fmt.Errorf("cannot duplicate the default branch %q; use 'rimba add' instead", cfg.DefaultSource)
+		}
+
+		// Extract prefix from source branch
+		_, matchedPrefix := resolver.TaskFromBranch(wt.Branch, prefixes)
+		if matchedPrefix == "" {
+			matchedPrefix, _ = resolver.PrefixString(resolver.DefaultPrefixType)
+		}
+
+		// Determine new task name
+		asFlag, _ := cmd.Flags().GetString("as")
+		var newTask string
+		if asFlag != "" {
+			newTask = asFlag
+		} else {
+			// Auto-suffix: try task-1, task-2, etc.
+			for i := 1; ; i++ {
+				candidate := fmt.Sprintf("%s-%d", task, i)
+				candidateBranch := resolver.BranchName(matchedPrefix, candidate)
+				if !git.BranchExists(r, candidateBranch) {
+					newTask = candidate
+					break
+				}
+			}
+		}
+
+		newBranch := resolver.BranchName(matchedPrefix, newTask)
+		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
+		wtPath := resolver.WorktreePath(wtDir, newBranch)
+
+		// Validate
+		if git.BranchExists(r, newBranch) {
+			return fmt.Errorf("branch %q already exists", newBranch)
+		}
+		if _, err := os.Stat(wtPath); err == nil {
+			return fmt.Errorf("worktree path already exists: %s", wtPath)
+		}
+
+		// Create worktree from source branch
+		if err := git.AddWorktree(r, wtPath, newBranch, wt.Branch); err != nil {
+			return err
+		}
+
+		// Copy dotfiles
+		copied, err := fileutil.CopyDotfiles(repoRoot, wtPath, cfg.CopyFiles)
+		if err != nil {
+			return fmt.Errorf("worktree created but failed to copy files: %w\nTo retry, manually copy files to: %s\nTo remove the worktree: rimba remove %s", err, wtPath, newTask)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Duplicated worktree %q as %q\n", task, newTask)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Branch: %s\n", newBranch)
+		fmt.Fprintf(cmd.OutOrStdout(), "  Path:   %s\n", wtPath)
+		if len(copied) > 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "  Copied: %v\n", copied)
+		}
+
+		return nil
+	},
+}

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	mergeCmd.Flags().String("into", "", "Target worktree task to merge into (default: main/repo root)")
+	mergeCmd.Flags().Bool("no-ff", false, "Force a merge commit (no fast-forward)")
+	mergeCmd.Flags().Bool("keep", false, "Keep source worktree after merging into main")
+	mergeCmd.Flags().Bool("delete", false, "Delete source worktree after merging into another worktree")
+	mergeCmd.MarkFlagsMutuallyExclusive("keep", "delete")
+
+	_ = mergeCmd.RegisterFlagCompletionFunc("into", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return completeWorktreeTasks(cmd, toComplete), cobra.ShellCompDirectiveNoFileComp
+	})
+
+	rootCmd.AddCommand(mergeCmd)
+}
+
+var mergeCmd = &cobra.Command{
+	Use:   "merge <source-task>",
+	Short: "Merge a worktree branch into main or another worktree",
+	Long:  "Merges the source worktree's branch into main (default) or another worktree. Auto-deletes the source when merging to main unless --keep is set. Keeps the source when merging between worktrees unless --delete is set.",
+	Args:  cobra.ExactArgs(1),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return completeWorktreeTasks(cmd, toComplete), cobra.ShellCompDirectiveNoFileComp
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sourceTask := args[0]
+		cfg := config.FromContext(cmd.Context())
+		if cfg == nil {
+			return fmt.Errorf(errNoConfig)
+		}
+
+		r := &git.ExecRunner{}
+
+		repoRoot, err := git.RepoRoot(r)
+		if err != nil {
+			return err
+		}
+
+		// List worktrees
+		entries, err := git.ListWorktrees(r)
+		if err != nil {
+			return err
+		}
+
+		var worktrees []resolver.WorktreeInfo
+		for _, e := range entries {
+			worktrees = append(worktrees, resolver.WorktreeInfo{
+				Path:   e.Path,
+				Branch: e.Branch,
+			})
+		}
+
+		prefixes := resolver.AllPrefixes()
+
+		// Resolve source
+		source, found := resolver.FindBranchForTask(sourceTask, worktrees, prefixes)
+		if !found {
+			return fmt.Errorf(errWorktreeNotFound, sourceTask)
+		}
+
+		// Resolve target
+		intoTask, _ := cmd.Flags().GetString("into")
+		var targetDir, targetLabel string
+		mergingToMain := intoTask == ""
+
+		if mergingToMain {
+			targetDir = repoRoot
+			targetLabel = cfg.DefaultSource
+		} else {
+			target, found := resolver.FindBranchForTask(intoTask, worktrees, prefixes)
+			if !found {
+				return fmt.Errorf(errWorktreeNotFound, intoTask)
+			}
+			targetDir = target.Path
+			targetLabel = target.Branch
+		}
+
+		// Pre-flight: check source is clean
+		dirty, err := git.IsDirty(r, source.Path)
+		if err != nil {
+			return err
+		}
+		if dirty {
+			return fmt.Errorf("source worktree %q has uncommitted changes\nCommit or stash changes before merging: cd %s", sourceTask, source.Path)
+		}
+
+		// Pre-flight: check target is clean
+		dirty, err = git.IsDirty(r, targetDir)
+		if err != nil {
+			return err
+		}
+		if dirty {
+			if mergingToMain {
+				return fmt.Errorf("target %q has uncommitted changes\nCommit or stash changes before merging: cd %s", targetLabel, targetDir)
+			}
+			return fmt.Errorf("target worktree %q has uncommitted changes\nCommit or stash changes before merging: cd %s", intoTask, targetDir)
+		}
+
+		// Execute merge
+		noFF, _ := cmd.Flags().GetBool("no-ff")
+		if err := git.Merge(r, targetDir, source.Branch, noFF); err != nil {
+			return fmt.Errorf("merge failed: %w\nTo resolve conflicts: cd %s", err, targetDir)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Merged %s into %s\n", source.Branch, targetLabel)
+
+		// Auto-cleanup
+		keep, _ := cmd.Flags().GetBool("keep")
+		del, _ := cmd.Flags().GetBool("delete")
+
+		shouldDelete := false
+		if mergingToMain {
+			shouldDelete = !keep
+		} else {
+			shouldDelete = del
+		}
+
+		if shouldDelete {
+			if err := git.RemoveWorktree(r, source.Path, false); err != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "Merged successfully but failed to remove worktree: %v\nTo remove manually: rimba remove %s\n", err, sourceTask)
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree: %s\n", source.Path)
+
+			if err := git.DeleteBranch(r, source.Branch, true); err != nil {
+				fmt.Fprintf(cmd.OutOrStdout(), "Worktree removed but failed to delete branch: %v\nTo delete manually: git branch -D %s\n", err, source.Branch)
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted branch: %s\n", source.Branch)
+		}
+
+		return nil
+	},
+}

--- a/internal/git/merge.go
+++ b/internal/git/merge.go
@@ -1,0 +1,12 @@
+package git
+
+// Merge runs `git merge [--no-ff] <branch>` inside the given directory.
+func Merge(r Runner, dir, branch string, noFF bool) error {
+	args := []string{"merge"}
+	if noFF {
+		args = append(args, "--no-ff")
+	}
+	args = append(args, branch)
+	_, err := r.RunInDir(dir, args...)
+	return err
+}

--- a/internal/git/merge_test.go
+++ b/internal/git/merge_test.go
@@ -1,0 +1,79 @@
+package git_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+func TestMergeBasic(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	// Create a branch with a commit
+	wtPath := filepath.Join(filepath.Dir(repo), "wt-merge-basic")
+	if err := git.AddWorktree(r, wtPath, "feat/merge-basic", "main"); err != nil {
+		t.Fatalf(fatalAddWorktree, err)
+	}
+
+	testutil.CreateFile(t, wtPath, "new.txt", "merge content")
+	testutil.GitCmd(t, wtPath, "add", ".")
+	testutil.GitCmd(t, wtPath, "commit", "-m", "add new.txt")
+
+	// Merge into main repo
+	if err := git.Merge(r, repo, "feat/merge-basic", false); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+
+	// Verify new.txt exists in main repo
+	testutil.GitCmd(t, repo, "log", "--oneline", "-1")
+}
+
+func TestMergeNoFF(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	// Create a branch with a commit
+	wtPath := filepath.Join(filepath.Dir(repo), "wt-merge-noff")
+	if err := git.AddWorktree(r, wtPath, "feat/merge-noff", "main"); err != nil {
+		t.Fatalf(fatalAddWorktree, err)
+	}
+
+	testutil.CreateFile(t, wtPath, "noff.txt", "no-ff content")
+	testutil.GitCmd(t, wtPath, "add", ".")
+	testutil.GitCmd(t, wtPath, "commit", "-m", "add noff.txt")
+
+	if err := git.Merge(r, repo, "feat/merge-noff", true); err != nil {
+		t.Fatalf("Merge --no-ff: %v", err)
+	}
+
+	// Verify merge commit was created (--no-ff forces a merge commit)
+	log := testutil.GitCmd(t, repo, "log", "--oneline", "-1")
+	if len(log) == 0 {
+		t.Error("expected merge commit in log")
+	}
+}
+
+func TestMergeError(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	// Merge a nonexistent branch should fail
+	if err := git.Merge(r, repo, "nonexistent-branch", false); err == nil {
+		t.Error("expected error merging nonexistent branch")
+	}
+}

--- a/tests/e2e/duplicate_test.go
+++ b/tests/e2e/duplicate_test.go
@@ -1,0 +1,165 @@
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+func TestDuplicateAutoSuffix(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+
+	// Create source worktree with a file
+	rimbaSuccess(t, repo, "add", taskDupA)
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	srcBranch := resolver.BranchName(defaultPrefix, taskDupA)
+	srcPath := resolver.WorktreePath(wtDir, srcBranch)
+	testutil.CreateFile(t, srcPath, "source.txt", "from "+taskDupA)
+	testutil.GitCmd(t, srcPath, "add", ".")
+	testutil.GitCmd(t, srcPath, "commit", "-m", "add source.txt")
+
+	// Duplicate
+	r := rimbaSuccess(t, repo, "duplicate", taskDupA)
+	assertContains(t, r.Stdout, taskDupA+"-1")
+	assertContains(t, r.Stdout, "Duplicated worktree")
+
+	// Verify new worktree exists with source content
+	dupBranch := resolver.BranchName(defaultPrefix, taskDupA+"-1")
+	dupPath := resolver.WorktreePath(wtDir, dupBranch)
+	assertFileExists(t, dupPath)
+	assertFileExists(t, filepath.Join(dupPath, "source.txt"))
+}
+
+func TestDuplicateAutoSuffixIncrement(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", taskDupB)
+
+	// First duplicate
+	r1 := rimbaSuccess(t, repo, "duplicate", taskDupB)
+	assertContains(t, r1.Stdout, taskDupB+"-1")
+
+	// Second duplicate
+	r2 := rimbaSuccess(t, repo, "duplicate", taskDupB)
+	assertContains(t, r2.Stdout, taskDupB+"-2")
+
+	// Verify both exist
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	assertFileExists(t, resolver.WorktreePath(wtDir, resolver.BranchName(defaultPrefix, taskDupB+"-1")))
+	assertFileExists(t, resolver.WorktreePath(wtDir, resolver.BranchName(defaultPrefix, taskDupB+"-2")))
+}
+
+func TestDuplicateWithAs(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+
+	// Create source with a file
+	rimbaSuccess(t, repo, "add", "orig")
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	srcBranch := resolver.BranchName(defaultPrefix, "orig")
+	srcPath := resolver.WorktreePath(wtDir, srcBranch)
+	testutil.CreateFile(t, srcPath, "data.txt", "original data")
+	testutil.GitCmd(t, srcPath, "add", ".")
+	testutil.GitCmd(t, srcPath, "commit", "-m", "add data.txt")
+
+	r := rimbaSuccess(t, repo, "duplicate", "orig", "--as", taskMyCopy)
+	assertContains(t, r.Stdout, taskMyCopy)
+
+	// Verify new worktree has source content
+	dupBranch := resolver.BranchName(defaultPrefix, taskMyCopy)
+	dupPath := resolver.WorktreePath(wtDir, dupBranch)
+	assertFileExists(t, dupPath)
+	assertFileExists(t, filepath.Join(dupPath, "data.txt"))
+}
+
+func TestDuplicateInheritsPrefix(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+
+	// Create a bugfix worktree
+	rimbaSuccess(t, repo, "add", "--bugfix", "fix-auth")
+
+	r := rimbaSuccess(t, repo, "duplicate", "fix-auth")
+	assertContains(t, r.Stdout, bugfixPrefix+"fix-auth-1")
+}
+
+func TestDuplicateCopiesDotfiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupRepo(t)
+
+	// Create .env before init
+	testutil.CreateFile(t, repo, ".env", secretContent)
+
+	rimbaSuccess(t, repo, "init")
+	rimbaSuccess(t, repo, "add", "dot-src")
+
+	r := rimbaSuccess(t, repo, "duplicate", "dot-src")
+	assertContains(t, r.Stdout, "Copied")
+
+	// Verify .env was copied
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	dupBranch := resolver.BranchName(defaultPrefix, "dot-src-1")
+	dupPath := resolver.WorktreePath(wtDir, dupBranch)
+	copiedEnv := filepath.Join(dupPath, ".env")
+	assertFileExists(t, copiedEnv)
+
+	data, err := os.ReadFile(copiedEnv)
+	if err != nil {
+		t.Fatalf("failed to read copied .env: %v", err)
+	}
+	if string(data) != secretContent {
+		t.Errorf("expected .env content %q, got %q", secretContent, string(data))
+	}
+}
+
+func TestDuplicateSourceNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	r := rimbaFail(t, repo, "duplicate", "nonexistent")
+	assertContains(t, r.Stderr, "not found")
+}
+
+func TestDuplicateNoArgs(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaFail(t, repo, "duplicate")
+}
+
+func TestDuplicateMain(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	r := rimbaFail(t, repo, "duplicate", "main")
+	assertContains(t, r.Stderr, "cannot duplicate the default branch")
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -21,6 +21,11 @@ const (
 
 	// Output messages asserted in tests.
 	msgCreatedWorktree = "Created worktree"
+	msgRemovedWorktree = "Removed worktree"
+	msgDeletedBranch   = "Deleted branch"
+
+	// Flags reused across tests.
+	flagInto = "--into"
 
 	// Task names reused across tests.
 	taskRm         = "rm-task"
@@ -34,6 +39,18 @@ const (
 	task2          = "task-2"
 	taskRmPartial  = "rm-partial-task"
 	taskDirtyOne   = "dirty-one"
+
+	// Duplicate test constants.
+	taskDupA      = "task-a"
+	taskDupB      = "task-b"
+	taskMyCopy    = "my-copy"
+	secretContent = "SECRET=test"
+
+	// Merge test constants.
+	taskMergeMain   = "merge-main"
+	taskMergeKeep   = "merge-keep"
+	taskMergeSrc    = "merge-src"
+	taskMergeDelSrc = "merge-del-src"
 )
 
 var (

--- a/tests/e2e/merge_test.go
+++ b/tests/e2e/merge_test.go
@@ -1,0 +1,219 @@
+package e2e_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+// setupCleanInitializedRepo creates a repo with rimba init and commits
+// the init artifacts so the repo root is clean for merge operations.
+func setupCleanInitializedRepo(t *testing.T) string {
+	t.Helper()
+	repo := setupInitializedRepo(t)
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "rimba init")
+	return repo
+}
+
+// mergeSetup creates a worktree with a committed file, ready for merging.
+// Returns the worktree path and the file name that was committed.
+func mergeSetup(t *testing.T, repo, task string, flags ...string) string {
+	t.Helper()
+	args := append([]string{"add"}, flags...)
+	args = append(args, task)
+	rimbaSuccess(t, repo, args...)
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+
+	prefix := defaultPrefix
+	for _, f := range flags {
+		if f == "--bugfix" {
+			prefix = bugfixPrefix
+		}
+	}
+	branch := resolver.BranchName(prefix, task)
+	wtPath := resolver.WorktreePath(wtDir, branch)
+
+	fileName := task + ".txt"
+	testutil.CreateFile(t, wtPath, fileName, "content from "+task)
+	testutil.GitCmd(t, wtPath, "add", ".")
+	testutil.GitCmd(t, wtPath, "commit", "-m", "add "+fileName)
+
+	return wtPath
+}
+
+func TestMergeIntoMain(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupCleanInitializedRepo(t)
+	mergeSetup(t, repo, taskMergeMain)
+
+	r := rimbaSuccess(t, repo, "merge", taskMergeMain)
+	assertContains(t, r.Stdout, "Merged")
+	assertContains(t, r.Stdout, msgRemovedWorktree)
+	assertContains(t, r.Stdout, msgDeletedBranch)
+
+	// Verify file appears in repo root
+	assertFileExists(t, filepath.Join(repo, taskMergeMain+".txt"))
+
+	// Verify worktree is gone
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.BranchName(defaultPrefix, taskMergeMain)
+	wtPath := resolver.WorktreePath(wtDir, branch)
+	assertFileNotExists(t, wtPath)
+
+	// Verify branch is deleted
+	out := testutil.GitCmd(t, repo, "branch", "--list")
+	if strings.Contains(out, defaultPrefix+taskMergeMain) {
+		t.Error("expected branch to be deleted")
+	}
+}
+
+func TestMergeIntoMainKeep(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupCleanInitializedRepo(t)
+	wtPath := mergeSetup(t, repo, taskMergeKeep)
+
+	r := rimbaSuccess(t, repo, "merge", taskMergeKeep, "--keep")
+	assertContains(t, r.Stdout, "Merged")
+	assertNotContains(t, r.Stdout, msgRemovedWorktree)
+
+	// Verify worktree still exists
+	assertFileExists(t, wtPath)
+
+	// Verify branch still exists
+	out := testutil.GitCmd(t, repo, "branch", "--list")
+	if !strings.Contains(out, defaultPrefix+taskMergeKeep) {
+		t.Error("expected branch to still exist")
+	}
+}
+
+func TestMergeIntoWorktree(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	mergeSetup(t, repo, taskMergeSrc)
+	targetPath := mergeSetup(t, repo, "merge-tgt")
+
+	r := rimbaSuccess(t, repo, "merge", taskMergeSrc, flagInto, "merge-tgt")
+	assertContains(t, r.Stdout, "Merged")
+	// Source should still exist by default when merging into worktree
+	assertNotContains(t, r.Stdout, msgRemovedWorktree)
+
+	// Verify file appears in target worktree
+	assertFileExists(t, filepath.Join(targetPath, taskMergeSrc+".txt"))
+
+	// Verify source still exists
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	srcBranch := resolver.BranchName(defaultPrefix, taskMergeSrc)
+	srcPath := resolver.WorktreePath(wtDir, srcBranch)
+	assertFileExists(t, srcPath)
+}
+
+func TestMergeIntoWorktreeDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	mergeSetup(t, repo, taskMergeDelSrc)
+	mergeSetup(t, repo, "merge-del-tgt")
+
+	r := rimbaSuccess(t, repo, "merge", taskMergeDelSrc, flagInto, "merge-del-tgt", "--delete")
+	assertContains(t, r.Stdout, "Merged")
+	assertContains(t, r.Stdout, msgRemovedWorktree)
+	assertContains(t, r.Stdout, msgDeletedBranch)
+
+	// Verify source is gone
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	srcBranch := resolver.BranchName(defaultPrefix, taskMergeDelSrc)
+	srcPath := resolver.WorktreePath(wtDir, srcBranch)
+	assertFileNotExists(t, srcPath)
+}
+
+func TestMergeSourceDirty(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	wtPath := mergeSetup(t, repo, "merge-dirty-src")
+
+	// Make source dirty
+	testutil.CreateFile(t, wtPath, "uncommitted.txt", "dirty")
+
+	r := rimbaFail(t, repo, "merge", "merge-dirty-src")
+	assertContains(t, r.Stderr, "uncommitted changes")
+	assertContains(t, r.Stderr, "Commit or stash")
+}
+
+func TestMergeTargetDirty(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	mergeSetup(t, repo, "merge-tgt-dirty-src")
+	targetPath := mergeSetup(t, repo, "merge-tgt-dirty")
+
+	// Make target dirty
+	testutil.CreateFile(t, targetPath, "uncommitted.txt", "dirty")
+
+	r := rimbaFail(t, repo, "merge", "merge-tgt-dirty-src", flagInto, "merge-tgt-dirty")
+	assertContains(t, r.Stderr, "uncommitted changes")
+	assertContains(t, r.Stderr, "Commit or stash")
+}
+
+func TestMergeNoFF(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupCleanInitializedRepo(t)
+	mergeSetup(t, repo, "merge-noff")
+
+	rimbaSuccess(t, repo, "merge", "merge-noff", "--no-ff", "--keep")
+
+	// Verify merge commit exists (--no-ff always creates one)
+	log := testutil.GitCmd(t, repo, "log", "--oneline", "-1")
+	if !strings.Contains(log, "Merge branch") {
+		t.Errorf("expected merge commit, got: %s", log)
+	}
+}
+
+func TestMergeSourceNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	r := rimbaFail(t, repo, "merge", "ghost-task")
+	assertContains(t, r.Stderr, "not found")
+}
+
+func TestMergeTargetNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	mergeSetup(t, repo, "merge-no-tgt-src")
+
+	r := rimbaFail(t, repo, "merge", "merge-no-tgt-src", flagInto, "ghost-target")
+	assertContains(t, r.Stderr, "not found")
+}

--- a/tests/e2e/remove_test.go
+++ b/tests/e2e/remove_test.go
@@ -19,7 +19,7 @@ func TestRemoveRemovesWorktree(t *testing.T) {
 	rimbaSuccess(t, repo, "add", taskRm)
 
 	r := rimbaSuccess(t, repo, "remove", taskRm)
-	assertContains(t, r.Stdout, "Removed worktree")
+	assertContains(t, r.Stdout, msgRemovedWorktree)
 
 	// Verify the worktree directory is gone
 	cfg := loadConfig(t, repo)
@@ -38,8 +38,8 @@ func TestRemoveWithBranchFlag(t *testing.T) {
 	rimbaSuccess(t, repo, "add", taskRmBranch)
 
 	r := rimbaSuccess(t, repo, "remove", "--branch", taskRmBranch)
-	assertContains(t, r.Stdout, "Removed worktree")
-	assertContains(t, r.Stdout, "Deleted branch")
+	assertContains(t, r.Stdout, msgRemovedWorktree)
+	assertContains(t, r.Stdout, msgDeletedBranch)
 
 	// Verify branch is deleted
 	out := testutil.GitCmd(t, repo, "branch", "--list")


### PR DESCRIPTION
## Summary
- **`rimba duplicate <task>`** — create a new worktree from an existing worktree, inheriting its branch prefix with auto-suffix (`-1`, `-2`, ...) or custom name via `--as`
- **`rimba merge <source-task>`** — merge a worktree branch into main or another worktree (`--into`), with dirty checks, `--no-ff` support, and auto-cleanup (configurable via `--keep`/`--delete`)
- Rejects `rimba duplicate main` with a clear error directing users to `rimba add`

## Test plan
- [x] `go build .` compiles
- [x] `go test ./internal/git/...` — 3 new unit tests for `Merge` helper (basic, no-ff, error)
- [x] `go test ./tests/e2e/ -run TestDuplicate` — 8 e2e tests (auto-suffix, increment, --as, prefix inheritance, dotfiles, not-found, no-args, duplicate-main)
- [x] `go test ./tests/e2e/ -run TestMerge` — 9 e2e tests (into-main, keep, into-worktree, delete, source-dirty, target-dirty, no-ff, source-not-found, target-not-found)
- [x] `go test ./...` — full suite passes