### PR TITLE
[feat] Add open command for worktree navigation and command execution

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(openCmd)
+}
+
+var openCmd = &cobra.Command{
+	Use:   "open <task> [command args...]",
+	Short: "Open a worktree or run a command inside it",
+	Long: `Prints the worktree path for the given task, or executes a command inside it.
+
+Examples:
+  rimba open my-task              # Print worktree path
+  cd $(rimba open my-task)        # Navigate to worktree
+  rimba open my-task code .       # Open in VS Code
+  rimba open my-task claude       # Launch claude in worktree`,
+	Args: cobra.MinimumNArgs(1),
+	FParseErrWhitelist: cobra.FParseErrWhitelist{
+		UnknownFlags: true,
+	},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return completeWorktreeTasks(cmd, toComplete), cobra.ShellCompDirectiveNoFileComp
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		task := args[0]
+		r := newRunner()
+
+		wt, err := findWorktree(r, task)
+		if err != nil {
+			return err
+		}
+
+		if len(args) == 1 {
+			fmt.Fprint(cmd.OutOrStdout(), wt.Path)
+			return nil
+		}
+
+		sub := exec.Command(args[1], args[2:]...) //nolint:gosec // Intentional: user specifies the command to run
+		sub.Dir = wt.Path
+		sub.Stdin = os.Stdin
+		sub.Stdout = os.Stdout
+		sub.Stderr = os.Stderr
+
+		if err := sub.Run(); err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				os.Exit(exitErr.ExitCode())
+			}
+			return fmt.Errorf("failed to run %q: %w", args[1], err)
+		}
+
+		return nil
+	},
+}

--- a/tests/e2e/open_test.go
+++ b/tests/e2e/open_test.go
@@ -1,0 +1,98 @@
+package e2e_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenPrintsPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "open-path")
+
+	r := rimbaSuccess(t, repo, "open", "open-path")
+
+	cfg := loadConfig(t, repo)
+	expectedDir := filepath.Join(repo, cfg.WorktreeDir)
+	if !strings.Contains(r.Stdout, expectedDir) {
+		t.Errorf("expected stdout to contain worktree dir %q, got: %s", expectedDir, r.Stdout)
+	}
+}
+
+func TestOpenRunsCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "open-cmd")
+
+	r := rimbaSuccess(t, repo, "open", "open-cmd", "pwd")
+
+	// Resolve symlinks — macOS /tmp → /private/tmp
+	actual := strings.TrimSpace(r.Stdout)
+	actualResolved, err := filepath.EvalSymlinks(actual)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", actual, err)
+	}
+
+	cfg := loadConfig(t, repo)
+	expectedDir := filepath.Join(repo, cfg.WorktreeDir)
+	expectedResolved, err := filepath.EvalSymlinks(expectedDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", expectedDir, err)
+	}
+
+	if !strings.Contains(actualResolved, expectedResolved) {
+		t.Errorf("expected pwd output to contain %q, got: %s", expectedResolved, actualResolved)
+	}
+}
+
+func TestOpenCommandExitCode(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "open-exit")
+
+	r := rimba(t, repo, "open", "open-exit", "false")
+	if r.ExitCode == 0 {
+		t.Error("expected non-zero exit code from 'false' command")
+	}
+}
+
+func TestOpenFailsNonexistentTask(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	r := rimbaFail(t, repo, "open", "ghost-task")
+	assertContains(t, r.Stderr, "not found")
+}
+
+func TestOpenFailsNoArgs(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaFail(t, repo, "open")
+}
+
+func TestOpenFailsCommandNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "open-notfound")
+
+	r := rimbaFail(t, repo, "open", "open-notfound", "nonexistent-cmd-xyz")
+	assertContains(t, r.Stderr, "nonexistent-cmd-xyz")
+}


### PR DESCRIPTION
## Summary
- Add `rimba open <task>` command that prints the worktree path for shell integration (`cd $(rimba open my-task)`)
- Add exec mode: `rimba open <task> <command> [args...]` runs a command inside the worktree with full TTY support (e.g., `rimba open my-task code .`, `rimba open my-task claude`)
- Add e2e tests covering path output, command execution, exit code propagation, and error cases

## Test plan
- [x] `make lint` — passes with 0 issues
- [x] `make test-coverage` — all tests pass
- [x] 6 new e2e tests: path output, command execution, exit code propagation, nonexistent task, no args, command not found