### PR TITLE
[feat] Improve update command with sudo fallback and update hint

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -62,7 +62,13 @@ var updateCmd = &cobra.Command{
 		}
 
 		if err := updater.Replace(currentBinary, newBinary); err != nil {
-			return fmt.Errorf("replacing binary: %w", err)
+			if !updater.IsPermissionError(err) {
+				return fmt.Errorf("replacing binary: %w", err)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Elevated permissions required. Retrying with sudo...")
+			if err := updater.ReplaceElevated(currentBinary, newBinary); err != nil {
+				return fmt.Errorf("replacing binary with sudo: %w", err)
+			}
 		}
 
 		// Verify the new binary works

--- a/cmd/update_hint.go
+++ b/cmd/update_hint.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lugassawan/rimba/internal/termcolor"
+	"github.com/lugassawan/rimba/internal/updater"
+	"github.com/spf13/cobra"
+)
+
+// newUpdater is a package-level function variable for creating an Updater.
+// Tests can override this to inject a mock server.
+var newUpdater func(string) *updater.Updater = updater.New
+
+// checkUpdateHint runs a background version check with a timeout.
+// Returns nil if the version is dev, the check fails, times out, or is up to date.
+func checkUpdateHint(version string, timeout time.Duration) <-chan *updater.CheckResult {
+	ch := make(chan *updater.CheckResult, 1)
+
+	if updater.IsDevVersion(version) {
+		close(ch)
+		return ch
+	}
+
+	go func() {
+		u := newUpdater(version)
+		result, err := u.Check()
+		if err != nil || result.UpToDate {
+			close(ch)
+			return
+		}
+		ch <- result
+	}()
+
+	// Return a channel that resolves with the result or nil after timeout
+	out := make(chan *updater.CheckResult, 1)
+	go func() {
+		select {
+		case r, ok := <-ch:
+			if ok {
+				out <- r
+			} else {
+				close(out)
+			}
+		case <-time.After(timeout):
+			close(out)
+		}
+	}()
+
+	return out
+}
+
+// collectHint reads the result from the hint channel. Returns nil if the
+// channel was closed (no update available, timed out, or error).
+func collectHint(ch <-chan *updater.CheckResult) *updater.CheckResult {
+	r, ok := <-ch
+	if !ok {
+		return nil
+	}
+	return r
+}
+
+// printUpdateHint prints a yellow-colored update notification.
+func printUpdateHint(cmd *cobra.Command, result *updater.CheckResult) {
+	noColor, _ := cmd.Flags().GetBool("no-color")
+	p := termcolor.NewPainter(noColor)
+
+	msg := fmt.Sprintf(
+		"Update available: %s → %s — run \"rimba update\" to upgrade",
+		result.CurrentVersion, result.LatestVersion,
+	)
+	fmt.Fprintln(cmd.OutOrStdout(), p.Paint(msg, termcolor.Yellow))
+}

--- a/cmd/update_hint_test.go
+++ b/cmd/update_hint_test.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/lugassawan/rimba/internal/updater"
+)
+
+const (
+	hdrContentType  = "Content-Type"
+	mimeJSON        = "application/json"
+	testVersionHint = "v1.0.0"
+)
+
+// overrideNewUpdater temporarily replaces newUpdater to point at the test server.
+func overrideNewUpdater(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	orig := newUpdater
+	newUpdater = func(version string) *updater.Updater {
+		return &updater.Updater{
+			CurrentVersion: version,
+			GOOS:           "linux",
+			GOARCH:         "amd64",
+			Client:         srv.Client(),
+			APIEndpoint:    srv.URL,
+		}
+	}
+	t.Cleanup(func() { newUpdater = orig })
+}
+
+func TestCheckUpdateHintNewVersionAvailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(hdrContentType, mimeJSON)
+		_, _ = w.Write([]byte(`{
+			"tag_name":"v2.0.0",
+			"assets":[
+				{"name":"rimba_2.0.0_linux_amd64.tar.gz","browser_download_url":"https://example.com/download"}
+			]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+	overrideNewUpdater(t, srv)
+
+	ch := checkUpdateHint(testVersionHint, 2*time.Second)
+	result := collectHint(ch)
+	if result == nil {
+		t.Fatal("expected non-nil result for available update")
+	}
+	if result.LatestVersion != "v2.0.0" {
+		t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, "v2.0.0")
+	}
+}
+
+func TestCheckUpdateHintUpToDate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(hdrContentType, mimeJSON)
+		_, _ = w.Write([]byte(`{"tag_name":"v1.0.0","assets":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	overrideNewUpdater(t, srv)
+
+	ch := checkUpdateHint(testVersionHint, 2*time.Second)
+	result := collectHint(ch)
+	if result != nil {
+		t.Errorf("expected nil result for up-to-date version, got %+v", result)
+	}
+}
+
+func TestCheckUpdateHintDevVersion(t *testing.T) {
+	// Should not make any HTTP calls for dev versions
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("unexpected HTTP request for dev version")
+	}))
+	t.Cleanup(srv.Close)
+	overrideNewUpdater(t, srv)
+
+	ch := checkUpdateHint("dev", 2*time.Second)
+	result := collectHint(ch)
+	if result != nil {
+		t.Errorf("expected nil result for dev version, got %+v", result)
+	}
+}
+
+func TestCheckUpdateHintTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.Header().Set(hdrContentType, mimeJSON)
+		_, _ = w.Write([]byte(`{
+			"tag_name":"v2.0.0",
+			"assets":[
+				{"name":"rimba_2.0.0_linux_amd64.tar.gz","browser_download_url":"https://example.com/download"}
+			]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+	overrideNewUpdater(t, srv)
+
+	ch := checkUpdateHint(testVersionHint, 50*time.Millisecond)
+	result := collectHint(ch)
+	if result != nil {
+		t.Errorf("expected nil result on timeout, got %+v", result)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix duplicate error display by adding `SilenceErrors: true` to root command
- Add sudo fallback (`IsPermissionError` + `ReplaceElevated`) when binary replacement fails with permission denied
- Add update hint in help banner that checks for new versions in the background with a 2s timeout

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] `make lint` reports 0 issues
- [x] Manual: `go run . help` — verify banner shows, no update hint for dev build
- [x] Manual: `rimba update` on a permission-restricted path — verify sudo fallback prompt
- [x] Manual: trigger any error — verify error prints only once