### PR TITLE
[feat] Add spinner/loading indicators for CLI commands

### DIFF
--- a/cmd/banner.go
+++ b/cmd/banner.go
@@ -8,7 +8,7 @@ import (
 )
 
 func printBanner(cmd *cobra.Command) {
-	noColor, _ := cmd.Flags().GetBool("no-color")
+	noColor, _ := cmd.Flags().GetBool(flagNoColor)
 	p := termcolor.NewPainter(noColor)
 
 	lines := []string{

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lugassawan/rimba/internal/deps"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -146,8 +147,13 @@ var depsInstallCmd = &cobra.Command{
 			return nil
 		}
 
+		s := spinner.New(spinnerOpts(cmd))
+		defer s.Stop()
+
+		s.Start("Installing dependencies...")
 		mgr := &deps.Manager{Runner: r}
 		results := mgr.Install(wt.Path, modules)
+		s.Stop()
 
 		out := cmd.OutOrStdout()
 		fmt.Fprintf(out, "Dependencies for %q:\n", task)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -7,11 +7,19 @@ import (
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/internal/spinner"
+	"github.com/spf13/cobra"
 )
 
 // newRunner creates a git.Runner for command execution.
 func newRunner() git.Runner {
 	return &git.ExecRunner{}
+}
+
+// spinnerOpts returns spinner options derived from the cobra command flags.
+func spinnerOpts(cmd *cobra.Command) spinner.Options {
+	noColor, _ := cmd.Flags().GetBool(flagNoColor)
+	return spinner.Options{Writer: cmd.ErrOrStderr(), NoColor: noColor}
 }
 
 // resolveMainBranch tries to get the main branch from config, falling back to DefaultBranch.

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
@@ -59,7 +60,11 @@ var renameCmd = &cobra.Command{
 		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
 		newPath := resolver.WorktreePath(wtDir, newBranch)
 
+		s := spinner.New(spinnerOpts(cmd))
+		defer s.Stop()
+
 		force, _ := cmd.Flags().GetBool("force")
+		s.Start("Renaming worktree...")
 		if err := git.MoveWorktree(r, wt.Path, newPath, force); err != nil {
 			return err
 		}
@@ -68,6 +73,7 @@ var renameCmd = &cobra.Command{
 			return fmt.Errorf("worktree moved but failed to rename branch %q: %w\nTo complete manually: git branch -m %s %s", wt.Branch, err, wt.Branch, newBranch)
 		}
 
+		s.Stop()
 		fmt.Fprintf(cmd.OutOrStdout(), "Renamed worktree: %s -> %s\n", task, newTask)
 		return nil
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const errWorktreeNotFound = "worktree not found for task %q"
+const (
+	errWorktreeNotFound = "worktree not found for task %q"
+	flagNoColor         = "no-color"
+	flagSkipDeps        = "skip-deps"
+	flagSkipHooks       = "skip-hooks"
+)
 
 var rootCmd = &cobra.Command{
 	Use:          "rimba",
@@ -46,7 +51,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.PersistentFlags().Bool("no-color", false, "disable colored output")
+	rootCmd.PersistentFlags().Bool(flagNoColor, false, "disable colored output")
 
 	originalHelp := rootCmd.HelpFunc()
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {

--- a/cmd/update_hint.go
+++ b/cmd/update_hint.go
@@ -63,7 +63,7 @@ func collectHint(ch <-chan *updater.CheckResult) *updater.CheckResult {
 
 // printUpdateHint prints a yellow-colored update notification.
 func printUpdateHint(cmd *cobra.Command, result *updater.CheckResult) {
-	noColor, _ := cmd.Flags().GetBool("no-color")
+	noColor, _ := cmd.Flags().GetBool(flagNoColor)
 	p := termcolor.NewPainter(noColor)
 
 	msg := fmt.Sprintf(

--- a/internal/spinner/spinner.go
+++ b/internal/spinner/spinner.go
@@ -1,0 +1,147 @@
+package spinner
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+var frames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// Options configures spinner behavior.
+type Options struct {
+	Writer  io.Writer
+	NoColor bool
+}
+
+// Spinner provides visual feedback during slow operations.
+type Spinner struct {
+	w        io.Writer
+	animated bool
+
+	mu      sync.Mutex
+	running bool
+	msg     string
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+}
+
+// New creates a Spinner. If the writer is not a TTY or NoColor is set,
+// the spinner falls back to plain line-based output.
+func New(opts Options) *Spinner {
+	w := opts.Writer
+	if w == nil {
+		w = os.Stderr
+	}
+	return &Spinner{
+		w:        w,
+		animated: !opts.NoColor && isTTY(w),
+	}
+}
+
+// Start begins the spinner with the given message.
+func (s *Spinner) Start(message string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.running {
+		s.msg = message
+		return
+	}
+
+	s.msg = message
+	s.running = true
+
+	if !s.animated {
+		fmt.Fprintln(s.w, message)
+		return
+	}
+
+	s.stopCh = make(chan struct{})
+	s.doneCh = make(chan struct{})
+	go s.animate()
+}
+
+// Update changes the spinner message while running.
+func (s *Spinner) Update(message string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.running {
+		return
+	}
+
+	s.msg = message
+
+	if !s.animated {
+		fmt.Fprintln(s.w, message)
+	}
+}
+
+// Stop clears the spinner line and stops the animation.
+// Safe to call multiple times and with defer.
+func (s *Spinner) Stop() {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = false
+
+	if !s.animated {
+		s.mu.Unlock()
+		return
+	}
+
+	close(s.stopCh)
+	s.mu.Unlock()
+
+	<-s.doneCh
+}
+
+func (s *Spinner) animate() {
+	defer close(s.doneCh)
+
+	ticker := time.NewTicker(80 * time.Millisecond)
+	defer ticker.Stop()
+
+	i := 0
+	for {
+		s.mu.Lock()
+		msg := s.msg
+		s.mu.Unlock()
+
+		fmt.Fprintf(s.w, "\r%s %s", frames[i%len(frames)], msg)
+
+		select {
+		case <-s.stopCh:
+			// Clear the spinner line
+			s.clearLine()
+			return
+		case <-ticker.C:
+			i++
+		}
+	}
+}
+
+func (s *Spinner) clearLine() {
+	fmt.Fprintf(s.w, "\r\033[K")
+}
+
+// isTTY reports whether w is a terminal.
+func isTTY(w io.Writer) bool {
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}

--- a/internal/spinner/spinner_test.go
+++ b/internal/spinner/spinner_test.go
@@ -1,0 +1,161 @@
+package spinner
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	msgLoading = "Loading..."
+	msgStep1   = "Step 1"
+	msgStep2   = "Step 2"
+	msgCycle1  = "Cycle 1"
+	msgCycle2  = "Cycle 2"
+)
+
+func requireContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Errorf("expected output to contain %q, got %q", want, got)
+	}
+}
+
+func TestNonAnimatedStartStop(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(Options{Writer: &buf})
+
+	s.Start(msgLoading)
+	s.Stop()
+
+	requireContains(t, buf.String(), msgLoading)
+}
+
+func TestNonAnimatedUpdate(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(Options{Writer: &buf})
+
+	s.Start(msgStep1)
+	s.Update(msgStep2)
+	s.Stop()
+
+	got := buf.String()
+	requireContains(t, got, msgStep1)
+	requireContains(t, got, msgStep2)
+}
+
+func TestStopIdempotent(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(Options{Writer: &buf})
+
+	s.Start(msgLoading)
+	s.Stop()
+	s.Stop() // should not panic
+	s.Stop() // should not panic
+}
+
+func TestStopWithoutStart(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(Options{Writer: &buf})
+
+	s.Stop() // should not panic
+}
+
+func TestUpdateWithoutStart(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(Options{Writer: &buf})
+
+	s.Update("nope") // should not panic
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output, got %q", buf.String())
+	}
+}
+
+func TestNoColorForcesNonAnimated(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(Options{Writer: &buf, NoColor: true})
+
+	// Even if writer were a TTY, NoColor forces non-animated
+	if s.animated {
+		t.Error("expected animated=false when NoColor=true")
+	}
+}
+
+func TestBufferIsNonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(Options{Writer: &buf})
+
+	if s.animated {
+		t.Error("expected animated=false for bytes.Buffer (non-TTY)")
+	}
+}
+
+func TestStartWhileRunningUpdatesMessage(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(Options{Writer: &buf})
+
+	s.Start("First")
+	s.Start("Second") // should act like Update
+	s.Stop()
+
+	// In non-animated mode, only "First" gets printed (Start while running just updates msg)
+	requireContains(t, buf.String(), "First")
+}
+
+func TestMultipleStartStopCycles(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(Options{Writer: &buf})
+
+	s.Start(msgCycle1)
+	s.Stop()
+	s.Start(msgCycle2)
+	s.Stop()
+
+	got := buf.String()
+	requireContains(t, got, msgCycle1)
+	requireContains(t, got, msgCycle2)
+}
+
+func TestNilWriterDefaultsToStderr(t *testing.T) {
+	s := New(Options{})
+	if s.w == nil {
+		t.Error("expected writer to default to os.Stderr")
+	}
+}
+
+func TestNonAnimatedOutputHasNewlines(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(Options{Writer: &buf})
+
+	s.Start("Line 1")
+	s.Update("Line 2")
+	s.Stop()
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 lines, got %d: %q", len(lines), buf.String())
+	}
+}
+
+func TestConcurrentStopSafe(t *testing.T) {
+	var buf bytes.Buffer
+	s := New(Options{Writer: &buf})
+
+	s.Start("Concurrent")
+
+	done := make(chan struct{})
+	go func() {
+		s.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("concurrent Stop timed out")
+	}
+
+	s.Stop() // idempotent
+}


### PR DESCRIPTION
## Summary
- Add `internal/spinner/` package with TTY-aware animated spinner (Braille frames) and plain-text fallback for pipes/NO_COLOR
- Integrate spinners into all commands with slow git/IO operations: add, sync, merge, duplicate, clean, list, remove, rename, update, deps install
- Refactor `deps_helpers.go` to separate work (install) from output (print), enabling spinner wrapping around slow operations
- Extract flag name constants (`flagNoColor`, `flagSkipDeps`, `flagSkipHooks`) to eliminate hardcoded string literals

## Test plan
- [x] `go build ./...` compiles
- [x] `make lint` passes with 0 issues
- [x] `go test ./internal/spinner/...` — 12 unit tests pass
- [x] `go test ./...` — all existing unit + e2e tests pass
- [x] Manual: `rimba add test-task` shows spinner, `rimba list` shows progress counter
- [x] Manual: `rimba list | cat` — no animation (pipe detection)
- [x] Manual: `NO_COLOR=1 rimba add test-task` — plain text fallback