### PR TITLE
[feat] Extend copy_files to support directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 🌿 **Core Workflow**
 
 - **Automatic branch naming** — configurable prefix (e.g. `feat/`, `fix/`) applied to task names
-- **Dotfile copying** — auto-copies `.env`, `.envrc`, `.tool-versions` into new worktrees
+- **File & directory copying** — auto-copies `.env`, `.envrc`, `.tool-versions`, `.vscode/` and other files or directories into new worktrees
 - **Duplicate worktrees** — copy an existing worktree with auto-suffixed or custom name
 - **Local merge** — merge worktree branches into main or other worktrees with auto-cleanup
 - **Sync worktrees** — rebase or merge onto the latest main branch, with bulk sync support
@@ -342,7 +342,7 @@ rimba version
 ```toml
 worktree_dir = '../myrepo-worktrees'
 default_source = 'main'
-copy_files = ['.env', '.env.local', '.envrc', '.tool-versions']
+copy_files = ['.env', '.env.local', '.envrc', '.tool-versions', '.vscode']
 
 # Post-create hooks (run in new worktree directory)
 post_create = ['./gradlew build']
@@ -368,7 +368,7 @@ work_dir = 'api'
 |-------|-------------|---------|
 | `worktree_dir` | Directory for worktrees (relative to repo root) | `../<repo-name>-worktrees` |
 | `default_source` | Branch to create worktrees from | Default branch (e.g. `main`) |
-| `copy_files` | Files to copy from repo root into new worktrees | `.env`, `.env.local`, `.envrc`, `.tool-versions` |
+| `copy_files` | Files or directories to copy from repo root into new worktrees | `.env`, `.env.local`, `.envrc`, `.tool-versions` |
 | `post_create` | Shell commands to run in new worktrees after creation | (none) |
 | `deps.auto_detect` | Auto-detect dependency modules from lockfiles | `true` |
 | `deps.modules[].dir` | Dependency directory to clone (e.g. `node_modules`) | — |

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -69,9 +69,9 @@ var addCmd = &cobra.Command{
 			return err
 		}
 
-		// Copy dotfiles
-		s.Update("Copying dotfiles...")
-		copied, err := fileutil.CopyDotfiles(repoRoot, wtPath, cfg.CopyFiles)
+		// Copy files
+		s.Update("Copying files...")
+		copied, err := fileutil.CopyEntries(repoRoot, wtPath, cfg.CopyFiles)
 		if err != nil {
 			return fmt.Errorf("worktree created but failed to copy files: %w\nTo retry, manually copy files to: %s\nTo remove the worktree: rimba remove %s", err, wtPath, task)
 		}

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -98,9 +98,9 @@ var duplicateCmd = &cobra.Command{
 			return err
 		}
 
-		// Copy dotfiles
-		s.Update("Copying dotfiles...")
-		copied, err := fileutil.CopyDotfiles(repoRoot, wtPath, cfg.CopyFiles)
+		// Copy files
+		s.Update("Copying files...")
+		copied, err := fileutil.CopyEntries(repoRoot, wtPath, cfg.CopyFiles)
 		if err != nil {
 			return fmt.Errorf("worktree created but failed to copy files: %w\nTo retry, manually copy files to: %s\nTo remove the worktree: rimba remove %s", err, wtPath, newTask)
 		}

--- a/internal/fileutil/copy_test.go
+++ b/internal/fileutil/copy_test.go
@@ -11,11 +11,20 @@ import (
 )
 
 const (
-	testSecret = "SECRET=123"
-	dotEnvrc   = ".envrc"
+	testSecret      = "SECRET=123"
+	dotEnvrc        = ".envrc"
+	dotVscode       = ".vscode"
+	dotConfig       = ".config"
+	dotEmpty        = ".empty"
+	dotSecret       = ".secret"
+	settingsJSON    = "settings.json"
+	appTOML         = "app.toml"
+	msgCopyErr      = "CopyEntries: %v"
+	msgCopiedWant   = "copied = %v, want %v"
+	msgExpect1Entry = "expected 1 entry copied, got %d"
 )
 
-func TestCopyDotfiles(t *testing.T) {
+func TestCopyEntries(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()
 
@@ -25,14 +34,14 @@ func TestCopyDotfiles(t *testing.T) {
 	// .env.local does NOT exist — should be silently skipped
 
 	files := []string{".env", ".env.local", dotEnvrc, ".tool-versions"}
-	copied, err := fileutil.CopyDotfiles(src, dst, files)
+	copied, err := fileutil.CopyEntries(src, dst, files)
 	if err != nil {
-		t.Fatalf("CopyDotfiles: %v", err)
+		t.Fatalf(msgCopyErr, err)
 	}
 
 	want := []string{".env", dotEnvrc}
 	if !reflect.DeepEqual(copied, want) {
-		t.Errorf("copied = %v, want %v", copied, want)
+		t.Errorf(msgCopiedWant, copied, want)
 	}
 
 	// Verify content
@@ -50,15 +59,15 @@ func TestCopyDotfiles(t *testing.T) {
 	}
 }
 
-func TestCopyDotfilesPreservesPermissions(t *testing.T) {
+func TestCopyEntriesPreservesPermissions(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()
 
 	_ = os.WriteFile(filepath.Join(src, dotEnvrc), []byte("use nix"), 0755)
 
-	copied, err := fileutil.CopyDotfiles(src, dst, []string{dotEnvrc})
+	copied, err := fileutil.CopyEntries(src, dst, []string{dotEnvrc})
 	if err != nil {
-		t.Fatalf("CopyDotfiles: %v", err)
+		t.Fatalf(msgCopyErr, err)
 	}
 	if len(copied) != 1 {
 		t.Fatalf("expected 1 copied file, got %d", len(copied))
@@ -73,20 +82,20 @@ func TestCopyDotfilesPreservesPermissions(t *testing.T) {
 	}
 }
 
-func TestCopyDotfilesEmptyList(t *testing.T) {
+func TestCopyEntriesEmptyList(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()
 
-	copied, err := fileutil.CopyDotfiles(src, dst, []string{})
+	copied, err := fileutil.CopyEntries(src, dst, []string{})
 	if err != nil {
-		t.Fatalf("CopyDotfiles with empty list: %v", err)
+		t.Fatalf("CopyEntries with empty list: %v", err)
 	}
 	if len(copied) != 0 {
 		t.Errorf("expected empty copied list, got %v", copied)
 	}
 }
 
-func TestCopyDotfilesDstError(t *testing.T) {
+func TestCopyEntriesDstError(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()
 
@@ -97,11 +106,230 @@ func TestCopyDotfilesDstError(t *testing.T) {
 	// which is not an os.IsNotExist error and triggers the wrapped error return.
 	_ = os.Mkdir(filepath.Join(dst, ".env"), 0755)
 
-	_, err := fileutil.CopyDotfiles(src, dst, []string{".env"})
+	_, err := fileutil.CopyEntries(src, dst, []string{".env"})
 	if err == nil {
 		t.Fatal("expected error when dst path is a directory")
 	}
 	if !strings.Contains(err.Error(), "copy .env:") {
 		t.Errorf("error = %q, want it to contain %q", err, "copy .env:")
+	}
+}
+
+func TestCopyEntriesCopiesDirectory(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create .vscode/ with two files
+	vscodeDir := filepath.Join(src, dotVscode)
+	_ = os.Mkdir(vscodeDir, 0755)
+	_ = os.WriteFile(filepath.Join(vscodeDir, settingsJSON), []byte(`{"go.formatTool":"goimports"}`), 0644)
+	_ = os.WriteFile(filepath.Join(vscodeDir, "extensions.json"), []byte(`{"recommendations":[]}`), 0644)
+
+	copied, err := fileutil.CopyEntries(src, dst, []string{dotVscode})
+	if err != nil {
+		t.Fatalf(msgCopyErr, err)
+	}
+
+	want := []string{dotVscode}
+	if !reflect.DeepEqual(copied, want) {
+		t.Errorf(msgCopiedWant, copied, want)
+	}
+
+	// Verify both files exist in destination
+	data, err := os.ReadFile(filepath.Join(dst, dotVscode, settingsJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "goimports") {
+		t.Errorf("settings.json content = %q, expected goimports", data)
+	}
+
+	if _, err := os.Stat(filepath.Join(dst, dotVscode, "extensions.json")); os.IsNotExist(err) {
+		t.Error("extensions.json should exist in dst/.vscode")
+	}
+}
+
+func TestCopyEntriesCopiesNestedDirectory(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create .config/sub/deep/ structure
+	deepDir := filepath.Join(src, dotConfig, "sub", "deep")
+	_ = os.MkdirAll(deepDir, 0755)
+	_ = os.WriteFile(filepath.Join(src, dotConfig, "top.toml"), []byte("top"), 0644)
+	_ = os.WriteFile(filepath.Join(deepDir, "nested.toml"), []byte("nested"), 0644)
+
+	copied, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	if err != nil {
+		t.Fatalf(msgCopyErr, err)
+	}
+	if len(copied) != 1 {
+		t.Fatalf(msgExpect1Entry, len(copied))
+	}
+
+	// Verify nested file
+	data, err := os.ReadFile(filepath.Join(dst, dotConfig, "sub", "deep", "nested.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "nested" {
+		t.Errorf("nested.toml content = %q, want %q", data, "nested")
+	}
+
+	// Verify top-level file in dir
+	data, err = os.ReadFile(filepath.Join(dst, dotConfig, "top.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "top" {
+		t.Errorf("top.toml content = %q, want %q", data, "top")
+	}
+}
+
+func TestCopyEntriesMixedFilesAndDirs(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create a file
+	_ = os.WriteFile(filepath.Join(src, ".env"), []byte(testSecret), 0644)
+
+	// Create a directory with a file
+	configDir := filepath.Join(src, dotConfig)
+	_ = os.Mkdir(configDir, 0755)
+	_ = os.WriteFile(filepath.Join(configDir, appTOML), []byte("app"), 0644)
+
+	// .missing does NOT exist — should be skipped
+	copied, err := fileutil.CopyEntries(src, dst, []string{".env", dotConfig, ".missing"})
+	if err != nil {
+		t.Fatalf(msgCopyErr, err)
+	}
+
+	want := []string{".env", dotConfig}
+	if !reflect.DeepEqual(copied, want) {
+		t.Errorf(msgCopiedWant, copied, want)
+	}
+
+	// Verify file
+	if _, err := os.Stat(filepath.Join(dst, ".env")); os.IsNotExist(err) {
+		t.Error(".env should exist in dst")
+	}
+	// Verify dir content
+	if _, err := os.Stat(filepath.Join(dst, dotConfig, appTOML)); os.IsNotExist(err) {
+		t.Error(".config/app.toml should exist in dst")
+	}
+	// Verify missing was skipped
+	if _, err := os.Stat(filepath.Join(dst, ".missing")); !os.IsNotExist(err) {
+		t.Error(".missing should not exist in dst")
+	}
+}
+
+func TestCopyEntriesEmptyDirectory(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create an empty directory
+	_ = os.Mkdir(filepath.Join(src, dotEmpty), 0755)
+
+	copied, err := fileutil.CopyEntries(src, dst, []string{dotEmpty})
+	if err != nil {
+		t.Fatalf(msgCopyErr, err)
+	}
+	if len(copied) != 1 {
+		t.Fatalf(msgExpect1Entry, len(copied))
+	}
+
+	// Verify directory was created
+	info, err := os.Stat(filepath.Join(dst, dotEmpty))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.IsDir() {
+		t.Error(".empty should be a directory in dst")
+	}
+}
+
+func TestCopyEntriesDirPreservesPermissions(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create directory with specific permissions
+	srcDir := filepath.Join(src, dotSecret)
+	_ = os.Mkdir(srcDir, 0700)
+	_ = os.WriteFile(filepath.Join(srcDir, "key.pem"), []byte("key"), 0600)
+
+	copied, err := fileutil.CopyEntries(src, dst, []string{dotSecret})
+	if err != nil {
+		t.Fatalf(msgCopyErr, err)
+	}
+	if len(copied) != 1 {
+		t.Fatalf(msgExpect1Entry, len(copied))
+	}
+
+	// Verify directory permissions
+	dirInfo, err := os.Stat(filepath.Join(dst, dotSecret))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dirInfo.Mode().Perm() != 0700 {
+		t.Errorf("dir mode = %o, want %o", dirInfo.Mode().Perm(), 0700)
+	}
+
+	// Verify file permissions
+	fileInfo, err := os.Stat(filepath.Join(dst, dotSecret, "key.pem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fileInfo.Mode().Perm() != 0600 {
+		t.Errorf("file mode = %o, want %o", fileInfo.Mode().Perm(), 0600)
+	}
+}
+
+func TestCopyEntriesSkipsSymlinksInDir(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create a directory with a regular file and a symlink
+	srcDir := filepath.Join(src, dotConfig)
+	_ = os.Mkdir(srcDir, 0755)
+	_ = os.WriteFile(filepath.Join(srcDir, "real.toml"), []byte("real"), 0644)
+	_ = os.Symlink("/dev/null", filepath.Join(srcDir, "link.toml"))
+
+	copied, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	if err != nil {
+		t.Fatalf(msgCopyErr, err)
+	}
+	if len(copied) != 1 {
+		t.Fatalf(msgExpect1Entry, len(copied))
+	}
+
+	// Real file should exist
+	if _, err := os.Stat(filepath.Join(dst, dotConfig, "real.toml")); os.IsNotExist(err) {
+		t.Error("real.toml should exist in dst")
+	}
+	// Symlink should NOT exist
+	if _, err := os.Lstat(filepath.Join(dst, dotConfig, "link.toml")); !os.IsNotExist(err) {
+		t.Error("link.toml (symlink) should not exist in dst")
+	}
+}
+
+func TestCopyEntriesDirCopyError(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create a source directory with a file
+	srcDir := filepath.Join(src, dotConfig)
+	_ = os.Mkdir(srcDir, 0755)
+	_ = os.WriteFile(filepath.Join(srcDir, appTOML), []byte("app"), 0644)
+
+	// Create a regular file at the destination path where a directory is expected.
+	// This causes MkdirAll for the nested file to fail.
+	_ = os.WriteFile(filepath.Join(dst, dotConfig), []byte("conflict"), 0644)
+
+	_, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	if err == nil {
+		t.Fatal("expected error when dst path conflicts")
+	}
+	if !strings.Contains(err.Error(), "copy "+dotConfig+":") {
+		t.Errorf("error = %q, want it to contain %q", err, "copy "+dotConfig+":")
 	}
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -58,6 +58,14 @@ const (
 	contentMainChg  = "main change"
 	commitUpdateMsg = "update main"
 
+	// Shared directory/file names.
+	dotVscode    = ".vscode"
+	dotConfig    = ".config"
+	settingsJSON = "settings.json"
+
+	// Shared error format strings.
+	msgSaveConfig = "save config: %v"
+
 	// Shared flags.
 	flagMergedE2E  = "--merged"
 	flagForceE2E   = "--force"


### PR DESCRIPTION
## Summary
- Extend `copy_files` config to auto-detect and copy directories (e.g. `.vscode/`, `.config/`) in addition to individual files
- Rename `CopyDotfiles` → `CopyEntries` with recursive `copyDir` that preserves permissions and skips symlinks
- Update `add` and `duplicate` commands to use the new function

## Test plan
- [x] Unit tests: 11 tests covering basic dir, nested dir, mixed files+dirs, empty dir, permission preservation, symlink skipping, and error handling
- [x] E2E tests: 4 new tests (`TestAddCopiesDirectory`, `TestAddCopiesNestedDirectory`, `TestAddSkipsMissingDirectory`, `TestDuplicateCopiesDirectory`)
- [x] Updated `TestAddPartialFailCopyHint` to use permission-denied trigger (directories now succeed)
- [x] Full suite: `go test ./...` passes
- [x] Lint: `golangci-lint` reports 0 issues