### PR TITLE
[feat] Auto-delete branch on rimba remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ rimba add my-feature
 # List all worktrees with status (colored output)
 rimba list
 
-# Remove a worktree when done
-rimba remove my-feature --branch
+# Remove a worktree and its branch when done
+rimba remove my-feature
 ```
 
 ## Commands
@@ -159,17 +159,17 @@ rimba open my-task claude       # Launch claude in worktree
 
 ### `rimba remove <task>`
 
-Remove the worktree for the given task. Optionally delete the local branch.
+Remove the worktree for the given task and delete the local branch.
 
 ```sh
 rimba remove my-feature
-rimba remove my-feature --branch     # Also delete the local branch
+rimba remove my-feature -k           # Keep the branch after removal
 rimba remove my-feature -f           # Force removal even if dirty
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--branch` | Also delete the local branch |
+| `-k`, `--keep-branch` | Keep the local branch after removing the worktree |
 | `-f`, `--force` | Force removal even if the worktree is dirty |
 
 ### `rimba rename <task> <new-task>`

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -15,12 +15,11 @@ import (
 const (
 	flagDryRun = "dry-run"
 	flagMerged = "merged"
-	flagForce  = "force"
 
-	hintMerged        = "Remove worktrees whose branches are already merged into main"
-	hintDryRunPrune   = "Preview what would be pruned without making changes"
-	hintDryRunMerged  = "Preview what would be removed without making changes"
-	hintForce         = "Skip confirmation prompt"
+	hintMerged       = "Remove worktrees whose branches are already merged into main"
+	hintDryRunPrune  = "Preview what would be pruned without making changes"
+	hintDryRunMerged = "Preview what would be removed without making changes"
+	hintForce        = "Skip confirmation prompt"
 )
 
 type mergedCandidate struct {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -4,20 +4,28 @@ import (
 	"fmt"
 
 	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/hint"
 	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
+const (
+	flagKeepBranch = "keep-branch"
+
+	hintKeepBranch = "Keep the local branch after removing the worktree"
+	hintForceRm    = "Force removal even if the worktree has uncommitted changes"
+)
+
 func init() {
-	removeCmd.Flags().Bool("branch", false, "Also delete the local branch")
-	removeCmd.Flags().BoolP("force", "f", false, "Force removal even if worktree is dirty")
+	removeCmd.Flags().BoolP(flagKeepBranch, "k", false, "Keep the local branch after removing the worktree")
+	removeCmd.Flags().BoolP(flagForce, "f", false, "Force removal even if worktree is dirty")
 	rootCmd.AddCommand(removeCmd)
 }
 
 var removeCmd = &cobra.Command{
 	Use:   "remove <task>",
-	Short: "Remove a worktree",
-	Long:  "Removes the worktree for the given task. Use --branch to also delete the local branch.",
+	Short: "Remove a worktree and delete its branch",
+	Long:  "Removes the worktree for the given task and deletes the local branch. Use --keep-branch to preserve the branch.",
 	Args:  cobra.ExactArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
@@ -34,10 +42,15 @@ var removeCmd = &cobra.Command{
 			return err
 		}
 
+		hint.New(cmd, hintPainter(cmd)).
+			Add(flagKeepBranch, hintKeepBranch).
+			Add(flagForce, hintForceRm).
+			Show()
+
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
 
-		force, _ := cmd.Flags().GetBool("force")
+		force, _ := cmd.Flags().GetBool(flagForce)
 		s.Start("Removing worktree...")
 		if err := git.RemoveWorktree(r, wt.Path, force); err != nil {
 			return err
@@ -46,15 +59,13 @@ var removeCmd = &cobra.Command{
 		s.Stop()
 		fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree: %s\n", wt.Path)
 
-		deleteBranch, _ := cmd.Flags().GetBool("branch")
-		if deleteBranch {
+		keepBranch, _ := cmd.Flags().GetBool(flagKeepBranch)
+		if !keepBranch {
 			s.Start("Deleting branch...")
-			if err := git.DeleteBranch(r, wt.Branch, force); err != nil {
+			if err := git.DeleteBranch(r, wt.Branch, true); err != nil {
 				s.Stop()
-				if force {
-					return fmt.Errorf("worktree removed but failed to delete branch %q: %w\nTo force delete: git branch -D %s", wt.Branch, err, wt.Branch)
-				}
-				return fmt.Errorf("worktree removed but failed to delete branch %q: %w\nTo delete manually: git branch -d %s (or -D to force)", wt.Branch, err, wt.Branch)
+				fmt.Fprintf(cmd.OutOrStdout(), "Worktree removed but failed to delete branch: %v\nTo delete manually: git branch -D %s\n", err, wt.Branch)
+				return nil
 			}
 			s.Stop()
 			fmt.Fprintf(cmd.OutOrStdout(), "Deleted branch: %s\n", wt.Branch)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	errWorktreeNotFound = "worktree not found for task %q"
+	flagForce           = "force"
 	flagNoColor         = "no-color"
 	flagSkipDeps        = "skip-deps"
 	flagSkipHooks       = "skip-hooks"

--- a/tests/e2e/add_test.go
+++ b/tests/e2e/add_test.go
@@ -28,7 +28,7 @@ func TestAddCreatesWorktree(t *testing.T) {
 	assertFileExists(t, wtPath)
 
 	// Verify branch exists
-	testutil.GitCmd(t, repo, "branch", "--list", branch)
+	testutil.GitCmd(t, repo, "branch", flagBranchList, branch)
 }
 
 func TestAddCustomPrefix(t *testing.T) {

--- a/tests/e2e/clean_test.go
+++ b/tests/e2e/clean_test.go
@@ -130,7 +130,7 @@ func TestCleanMergedForce(t *testing.T) {
 	assertFileNotExists(t, wtPath)
 
 	// Branch should be gone
-	out := testutil.GitCmd(t, repo, "branch", "--list")
+	out := testutil.GitCmd(t, repo, "branch", flagBranchList)
 	if strings.Contains(out, defaultPrefix+"clean-force") {
 		t.Error("expected branch to be deleted")
 	}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -26,13 +26,13 @@ const (
 	msgDeletedBranch   = "Deleted branch"
 
 	// Flags reused across tests.
+	flagBranchList   = "--list"
 	flagInto         = "--into"
 	flagSkipDepsE2E  = "--skip-deps"
 	flagSkipHooksE2E = "--skip-hooks"
 
 	// Task names reused across tests.
 	taskRm         = "rm-task"
-	taskRmBranch   = "rm-branch"
 	taskKeepBranch = "keep-branch"
 	taskFix123     = "fix-123"
 	taskForce      = "force-task"

--- a/tests/e2e/merge_test.go
+++ b/tests/e2e/merge_test.go
@@ -71,7 +71,7 @@ func TestMergeIntoMain(t *testing.T) {
 	assertFileNotExists(t, wtPath)
 
 	// Verify branch is deleted
-	out := testutil.GitCmd(t, repo, "branch", "--list")
+	out := testutil.GitCmd(t, repo, "branch", flagBranchList)
 	if strings.Contains(out, defaultPrefix+taskMergeMain) {
 		t.Error("expected branch to be deleted")
 	}
@@ -93,7 +93,7 @@ func TestMergeIntoMainKeep(t *testing.T) {
 	assertFileExists(t, wtPath)
 
 	// Verify branch still exists
-	out := testutil.GitCmd(t, repo, "branch", "--list")
+	out := testutil.GitCmd(t, repo, "branch", flagBranchList)
 	if !strings.Contains(out, defaultPrefix+taskMergeKeep) {
 		t.Error("expected branch to still exist")
 	}

--- a/tests/e2e/rename_test.go
+++ b/tests/e2e/rename_test.go
@@ -41,7 +41,7 @@ func TestRenameRenamesWorktree(t *testing.T) {
 
 	// Old directory and branch should be gone
 	assertFileNotExists(t, oldPath)
-	branches := testutil.GitCmd(t, repo, "branch", "--list")
+	branches := testutil.GitCmd(t, repo, "branch", flagBranchList)
 	if strings.Contains(branches, oldBranch) {
 		t.Errorf("expected old branch %q to be gone", oldBranch)
 	}
@@ -65,7 +65,7 @@ func TestRenamePreservesPrefix(t *testing.T) {
 	assertContains(t, r.Stdout, "Renamed worktree")
 
 	// Verify the branch preserved the bugfix/ prefix
-	branches := testutil.GitCmd(t, repo, "branch", "--list")
+	branches := testutil.GitCmd(t, repo, "branch", flagBranchList)
 	if !strings.Contains(branches, "bugfix/new-bug") {
 		t.Errorf("expected branch bugfix/new-bug to exist, got branches:\n%s", branches)
 	}

--- a/tests/e2e/workflow_test.go
+++ b/tests/e2e/workflow_test.go
@@ -42,8 +42,8 @@ func TestWorkflowFullLifecycle(t *testing.T) {
 	assertContains(t, r.Stdout, task1)
 	assertContains(t, r.Stdout, task2)
 
-	// Step 5: remove task-1 with --branch
-	r = rimbaSuccess(t, repo, "remove", "--branch", task1)
+	// Step 5: remove task-1 (branch auto-deleted by default)
+	r = rimbaSuccess(t, repo, "remove", task1)
 	assertContains(t, r.Stdout, "Removed worktree")
 	assertContains(t, r.Stdout, "Deleted branch")
 	assertFileNotExists(t, wtPath1)
@@ -53,8 +53,8 @@ func TestWorkflowFullLifecycle(t *testing.T) {
 	assertNotContains(t, r.Stdout, defaultPrefix+task1)
 	assertContains(t, r.Stdout, task2)
 
-	// Step 7: remove task-2 with --branch (using full branch name)
-	r = rimbaSuccess(t, repo, "remove", "--branch", bugfixPrefix+task2)
+	// Step 7: remove task-2 (using full branch name, branch auto-deleted)
+	r = rimbaSuccess(t, repo, "remove", bugfixPrefix+task2)
 	assertContains(t, r.Stdout, "Removed worktree")
 	assertContains(t, r.Stdout, "Deleted branch")
 	assertFileNotExists(t, wtPath2)


### PR DESCRIPTION
## Summary
- `rimba remove` now deletes the local branch by default (using `git branch -D`), matching the behavior of `merge` and `clean --merged`
- Replaced `--branch` flag (opt-in delete) with `--keep-branch` / `-k` (opt-out)
- Branch deletion failures are handled gracefully (warning + success exit) instead of returning an error
- Moved shared `flagForce` constant to `root.go` for reuse across commands

## Test plan
- [x] `TestRemoveRemovesWorktree` — verifies branch is auto-deleted
- [x] `TestRemoveKeepBranchFlag` — verifies `--keep-branch` preserves the branch
- [x] `TestRemoveForceFlag` — verifies `-f` works and branch is still auto-deleted
- [x] `TestRemoveDeletesUnmergedBranch` — verifies `-D` handles unmerged branches
- [x] `TestRemoveFailsNonexistent` / `TestRemoveFailsNoArgs` — error cases unchanged
- [x] `TestWorkflowFullLifecycle` — updated to use new default behavior
- [x] Full test suite passes (`go test ./...`)
- [x] Lint clean (`make lint`)