### PR TITLE
[perf] Optimize long-running commands with flag-aware short-circuits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS  = -s -w \
 	-X github.com/lugassawan/rimba/cmd.commit=$(COMMIT) \
 	-X github.com/lugassawan/rimba/cmd.date=$(DATE)
 
-.PHONY: build test test-short test-e2e test-coverage clean lint
+.PHONY: build test test-short test-e2e test-coverage clean lint bench
 
 build:
 	go build -ldflags '$(LDFLAGS)' -o bin/rimba .
@@ -29,3 +29,6 @@ test-coverage:
 
 lint:
 	golangci-lint run ./...
+
+bench:
+	go test -bench=. -benchmem -run=^$$ ./...

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -59,6 +59,11 @@ var addCmd = &cobra.Command{
 		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
 		wtPath := resolver.WorktreePath(wtDir, branch)
 
+		wtEntries, err := git.ListWorktrees(r)
+		if err != nil {
+			return err
+		}
+
 		// Validate
 		if git.BranchExists(r, branch) {
 			return fmt.Errorf("branch %q already exists", branch)
@@ -94,7 +99,7 @@ var addCmd = &cobra.Command{
 		var depsResults []deps.InstallResult
 		if !skipDeps {
 			s.Update("Installing dependencies...")
-			depsResults = installDeps(r, cfg, wtPath)
+			depsResults = installDeps(r, cfg, wtPath, wtEntries)
 		}
 
 		// Post-create hooks

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -88,6 +88,11 @@ var duplicateCmd = &cobra.Command{
 		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
 		wtPath := resolver.WorktreePath(wtDir, newBranch)
 
+		wtEntries, err := git.ListWorktrees(r)
+		if err != nil {
+			return err
+		}
+
 		// Validate
 		if git.BranchExists(r, newBranch) {
 			return fmt.Errorf("branch %q already exists", newBranch)
@@ -123,7 +128,7 @@ var duplicateCmd = &cobra.Command{
 		var depsResults []deps.InstallResult
 		if !skipDeps {
 			s.Update("Installing dependencies...")
-			depsResults = installDepsPreferSource(r, cfg, wtPath, wt.Path)
+			depsResults = installDepsPreferSource(r, cfg, wtPath, wt.Path, wtEntries)
 		}
 
 		// Post-create hooks

--- a/cmd/list_bench_test.go
+++ b/cmd/list_bench_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/resolver"
+)
+
+const benchFilterType = "bugfix"
+
+// benchMockRunner simulates git status calls with minimal overhead.
+type benchMockRunner struct{}
+
+func (m *benchMockRunner) Run(_ ...string) (string, error) { return "", nil }
+func (m *benchMockRunner) RunInDir(_ string, args ...string) (string, error) {
+	// Simulate IsDirty returning clean, AheadBehind returning 0/0
+	if len(args) > 0 && args[0] == "rev-list" {
+		return "0\t0", nil
+	}
+	return "", nil
+}
+
+func makeBenchEntries(n int) []git.WorktreeEntry { //nolint:unparam // n is parameterized for benchmark flexibility
+	prefixes := []string{"feature/", "bugfix/", "hotfix/"}
+	entries := make([]git.WorktreeEntry, n)
+	for i := range n {
+		p := prefixes[i%len(prefixes)]
+		entries[i] = git.WorktreeEntry{
+			Path:   "/tmp/wt-" + string(rune('a'+i)),
+			Branch: p + "task-" + string(rune('a'+i)),
+		}
+	}
+	return entries
+}
+
+func BenchmarkListStatusCollectionSequential(b *testing.B) {
+	r := &benchMockRunner{}
+	entries := makeBenchEntries(10)
+	prefixes := resolver.AllPrefixes()
+
+	b.ResetTimer()
+	for b.Loop() {
+		rows := make([]resolver.WorktreeDetail, 0, len(entries))
+		for _, e := range entries {
+			var status resolver.WorktreeStatus
+			if dirty, err := git.IsDirty(r, e.Path); err == nil && dirty {
+				status.Dirty = true
+			}
+			ahead, behind, _ := git.AheadBehind(r, e.Path)
+			status.Ahead = ahead
+			status.Behind = behind
+			rows = append(rows, resolver.NewWorktreeDetail(e.Branch, prefixes, e.Path, status, false))
+		}
+		_ = rows
+	}
+}
+
+func BenchmarkListStatusCollectionParallel(b *testing.B) {
+	r := &benchMockRunner{}
+	entries := makeBenchEntries(10)
+	prefixes := resolver.AllPrefixes()
+
+	b.ResetTimer()
+	for b.Loop() {
+		rows := make([]resolver.WorktreeDetail, len(entries))
+		var wg sync.WaitGroup
+		sem := make(chan struct{}, 8)
+
+		for i, e := range entries {
+			wg.Add(1)
+			go func(idx int, e git.WorktreeEntry) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+
+				var status resolver.WorktreeStatus
+				if dirty, err := git.IsDirty(r, e.Path); err == nil && dirty {
+					status.Dirty = true
+				}
+				ahead, behind, _ := git.AheadBehind(r, e.Path)
+				status.Ahead = ahead
+				status.Behind = behind
+				rows[idx] = resolver.NewWorktreeDetail(e.Branch, prefixes, e.Path, status, false)
+			}(i, e)
+		}
+		wg.Wait()
+		_ = rows
+	}
+}
+
+func BenchmarkListWithTypeFilter(b *testing.B) {
+	r := &benchMockRunner{}
+	entries := makeBenchEntries(10)
+	prefixes := resolver.AllPrefixes()
+	filterType := benchFilterType
+
+	b.ResetTimer()
+	for b.Loop() {
+		// Early filter
+		var filtered []git.WorktreeEntry
+		for _, e := range entries {
+			_, matchedPrefix := resolver.TaskFromBranch(e.Branch, prefixes)
+			entryType := strings.TrimSuffix(matchedPrefix, "/")
+			if entryType != filterType {
+				continue
+			}
+			filtered = append(filtered, e)
+		}
+
+		// Collect status only for matching
+		rows := make([]resolver.WorktreeDetail, len(filtered))
+		for i, e := range filtered {
+			var status resolver.WorktreeStatus
+			if dirty, err := git.IsDirty(r, e.Path); err == nil && dirty {
+				status.Dirty = true
+			}
+			ahead, behind, _ := git.AheadBehind(r, e.Path)
+			status.Ahead = ahead
+			status.Behind = behind
+			rows[i] = resolver.NewWorktreeDetail(e.Branch, prefixes, e.Path, status, false)
+		}
+		_ = rows
+	}
+}
+
+func BenchmarkListWithoutTypeFilter(b *testing.B) {
+	r := &benchMockRunner{}
+	entries := makeBenchEntries(10)
+	prefixes := resolver.AllPrefixes()
+
+	b.ResetTimer()
+	for b.Loop() {
+		// Collect status for all entries (no early filter)
+		rows := make([]resolver.WorktreeDetail, len(entries))
+		for i, e := range entries {
+			var status resolver.WorktreeStatus
+			if dirty, err := git.IsDirty(r, e.Path); err == nil && dirty {
+				status.Dirty = true
+			}
+			ahead, behind, _ := git.AheadBehind(r, e.Path)
+			status.Ahead = ahead
+			status.Behind = behind
+			rows[i] = resolver.NewWorktreeDetail(e.Branch, prefixes, e.Path, status, false)
+		}
+
+		// Post-filter by type
+		filtered := rows[:0]
+		for _, row := range rows {
+			if row.Type != benchFilterType {
+				continue
+			}
+			filtered = append(filtered, row)
+		}
+		_ = filtered
+	}
+}

--- a/cmd/merge_bench_test.go
+++ b/cmd/merge_bench_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/git"
+)
+
+// mergeBenchMockRunner simulates IsDirty calls.
+type mergeBenchMockRunner struct{}
+
+func (m *mergeBenchMockRunner) Run(_ ...string) (string, error)              { return "", nil }
+func (m *mergeBenchMockRunner) RunInDir(_ string, _ ...string) (string, error) { return "", nil }
+
+func BenchmarkDirtyChecksSequential(b *testing.B) {
+	r := &mergeBenchMockRunner{}
+	srcPath := "/tmp/wt-src"
+	tgtPath := "/tmp/wt-tgt"
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = git.IsDirty(r, srcPath)
+		_, _ = git.IsDirty(r, tgtPath)
+	}
+}
+
+func BenchmarkDirtyChecksParallel(b *testing.B) {
+	r := &mergeBenchMockRunner{}
+	srcPath := "/tmp/wt-src"
+	tgtPath := "/tmp/wt-tgt"
+
+	b.ResetTimer()
+	for b.Loop() {
+		type dirtyResult struct {
+			dirty bool
+			err   error
+		}
+		var srcResult, tgtResult dirtyResult
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			srcResult.dirty, srcResult.err = git.IsDirty(r, srcPath)
+		}()
+		go func() {
+			defer wg.Done()
+			tgtResult.dirty, tgtResult.err = git.IsDirty(r, tgtPath)
+		}()
+		wg.Wait()
+		_ = srcResult
+		_ = tgtResult
+	}
+}

--- a/internal/git/bench_test.go
+++ b/internal/git/bench_test.go
@@ -1,0 +1,150 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+const skipShortBench = "skipping integration benchmark in short mode"
+
+// newBenchRepo creates a temporary git repo for benchmarks.
+func newBenchRepo(b *testing.B) string {
+	b.Helper()
+	dir := b.TempDir()
+	repo := filepath.Join(dir, "bench-repo")
+	if err := os.MkdirAll(repo, 0755); err != nil {
+		b.Fatalf("mkdir: %v", err)
+	}
+
+	cmds := [][]string{
+		{"git", "init", "-b", "main"},
+		{"git", "config", "user.email", "bench@test.com"},
+		{"git", "config", "user.name", "Bench"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			b.Fatalf("cmd %v: %s: %v", args, out, err)
+		}
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# Bench\n"), 0644); err != nil {
+		b.Fatalf("write: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-m", "initial"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			b.Fatalf("cmd %v: %s: %v", args, out, err)
+		}
+	}
+	return repo
+}
+
+// addBenchWorktrees creates n worktrees in the repo.
+func addBenchWorktrees(b *testing.B, repo string, n int) []string {
+	b.Helper()
+	var paths []string
+	for i := 0; i < n; i++ {
+		branch := filepath.Join("feature", "bench-"+string(rune('a'+i)))
+		wtPath := filepath.Join(filepath.Dir(repo), "wt-"+string(rune('a'+i)))
+		cmd := exec.Command("git", "worktree", "add", "-b", branch, wtPath, "main")
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			b.Fatalf("worktree add: %s: %v", out, err)
+		}
+		paths = append(paths, wtPath)
+	}
+	return paths
+}
+
+func BenchmarkListWorktrees5(b *testing.B) {
+	if testing.Short() {
+		b.Skip(skipShortBench)
+	}
+	repo := newBenchRepo(b)
+	addBenchWorktrees(b, repo, 5)
+	r := &ExecRunner{Dir: repo}
+
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := ListWorktrees(r); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkListWorktrees10(b *testing.B) {
+	if testing.Short() {
+		b.Skip(skipShortBench)
+	}
+	repo := newBenchRepo(b)
+	addBenchWorktrees(b, repo, 10)
+	r := &ExecRunner{Dir: repo}
+
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := ListWorktrees(r); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkIsDirty(b *testing.B) {
+	if testing.Short() {
+		b.Skip(skipShortBench)
+	}
+	repo := newBenchRepo(b)
+	wts := addBenchWorktrees(b, repo, 1)
+	r := &ExecRunner{Dir: repo}
+
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := IsDirty(r, wts[0]); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkAheadBehind(b *testing.B) {
+	if testing.Short() {
+		b.Skip(skipShortBench)
+	}
+	repo := newBenchRepo(b)
+	wts := addBenchWorktrees(b, repo, 1)
+	r := &ExecRunner{Dir: repo}
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, _, err := AheadBehind(r, wts[0])
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkIsDirtyParallel(b *testing.B) {
+	if testing.Short() {
+		b.Skip(skipShortBench)
+	}
+	repo := newBenchRepo(b)
+	wts := addBenchWorktrees(b, repo, 4)
+	r := &ExecRunner{Dir: repo}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if _, err := IsDirty(r, wts[i%len(wts)]); err != nil {
+				b.Fatal(err)
+			}
+			i++
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Early `--type` filtering in `list` command skips expensive `IsDirty`/`AheadBehind` git calls on non-matching worktrees
- Parallel status collection in `list` (8 workers), parallel dirty checks in `merge`, and parallel `sync --all` (4 workers)
- Eliminate redundant `ListWorktrees` calls in `installDeps`/`installDepsPreferSource` by accepting pre-fetched entries
- Add benchmark tests for `list`, `merge`, and core git operations, plus `make bench` target

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test-short` — all unit tests pass
- [x] `make test-e2e` — all e2e tests pass
- [x] `make bench` — all benchmarks run successfully
- [ ] Manual smoke test: create 5+ worktrees, run `rimba list`, `rimba list --type=feature`, `rimba sync --all`