### PR TITLE
[fix] Ad-hoc codesign macOS binaries in rimba update

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -58,6 +58,10 @@ var updateCmd = &cobra.Command{
 		}
 		defer updater.CleanupTempDir(newBinary)
 
+		if err := updater.PrepareBinary(newBinary); err != nil {
+			return fmt.Errorf("preparing binary: %w", err)
+		}
+
 		currentBinary, err := os.Executable()
 		if err != nil {
 			return fmt.Errorf("locating current binary: %w", err)

--- a/internal/updater/prepare_darwin.go
+++ b/internal/updater/prepare_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package updater
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// PrepareBinary removes the macOS quarantine attribute and ad-hoc code-signs
+// the binary so it can execute on Apple Silicon without being killed.
+func PrepareBinary(path string) error {
+	// Best-effort: remove quarantine attribute (may not exist).
+	_ = exec.Command("xattr", "-d", "com.apple.quarantine", path).Run() //nolint:gosec // path from controlled temp dir
+
+	// Ad-hoc sign — fatal on failure.
+	if err := exec.Command("codesign", "--sign", "-", "--force", path).Run(); err != nil { //nolint:gosec // path from controlled temp dir
+		return fmt.Errorf("code-signing binary: %w", err)
+	}
+
+	return nil
+}

--- a/internal/updater/prepare_darwin_test.go
+++ b/internal/updater/prepare_darwin_test.go
@@ -1,0 +1,83 @@
+//go:build darwin
+
+package updater
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildHelperBinary compiles a minimal Go binary for testing.
+func buildHelperBinary(t *testing.T, dir string) string {
+	t.Helper()
+
+	src := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(src, []byte("package main\nfunc main() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	bin := filepath.Join(dir, "helper")
+	cmd := exec.Command("go", "build", "-o", bin, src)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("building helper binary: %v\n%s", err, out)
+	}
+
+	return bin
+}
+
+func TestPrepareBinarySignsExecutable(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildHelperBinary(t, dir)
+
+	// Strip existing signature so we start unsigned.
+	if err := exec.Command("codesign", "--remove-signature", bin).Run(); err != nil {
+		t.Fatalf("removing signature: %v", err)
+	}
+
+	if err := PrepareBinary(bin); err != nil {
+		t.Fatalf("PrepareBinary: %v", err)
+	}
+
+	// Verify the binary is now validly signed.
+	if err := exec.Command("codesign", "--verify", bin).Run(); err != nil {
+		t.Errorf("codesign --verify failed after PrepareBinary: %v", err)
+	}
+}
+
+func TestPrepareBinaryWithQuarantineAttribute(t *testing.T) {
+	dir := t.TempDir()
+	bin := buildHelperBinary(t, dir)
+
+	// Set the quarantine attribute.
+	if err := exec.Command("xattr", "-w", "com.apple.quarantine", "0081;00000000;test;", bin).Run(); err != nil {
+		t.Fatalf("setting quarantine xattr: %v", err)
+	}
+
+	if err := PrepareBinary(bin); err != nil {
+		t.Fatalf("PrepareBinary: %v", err)
+	}
+
+	// Verify quarantine attribute is removed.
+	out, err := exec.Command("xattr", "-l", bin).CombinedOutput()
+	if err != nil {
+		// xattr -l returns error when no attributes exist — that's fine.
+		return
+	}
+	if strings.Contains(string(out), "com.apple.quarantine") {
+		t.Error("quarantine attribute still present after PrepareBinary")
+	}
+}
+
+func TestPrepareBinaryInvalidPath(t *testing.T) {
+	err := PrepareBinary("/nonexistent/path/binary")
+	if err == nil {
+		t.Fatal("expected error for nonexistent path")
+	}
+	if !strings.Contains(err.Error(), "code-signing binary") {
+		t.Errorf("error = %q, want to contain 'code-signing binary'", err.Error())
+	}
+}

--- a/internal/updater/prepare_other.go
+++ b/internal/updater/prepare_other.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+
+package updater
+
+// PrepareBinary is a no-op on non-darwin platforms.
+func PrepareBinary(_ string) error {
+	return nil
+}

--- a/internal/updater/prepare_other_test.go
+++ b/internal/updater/prepare_other_test.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package updater
+
+import "testing"
+
+func TestPrepareBinaryNoOp(t *testing.T) {
+	// On non-darwin platforms, PrepareBinary should always return nil.
+	if err := PrepareBinary("/any/path"); err != nil {
+		t.Errorf("PrepareBinary() = %v, want nil", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `rimba update` fails on Apple Silicon with `signal: killed` because cross-compiled darwin binaries from CI lack a code signature
- Add platform-specific `PrepareBinary` that removes quarantine xattr and ad-hoc codesigns the downloaded binary before replacement
- No-op stub on non-darwin platforms via build tags

## Test plan
- [x] `go build ./...` compiles on all platforms
- [x] `go test ./internal/updater/...` — darwin tests verify signing, quarantine removal, and error handling
- [x] `make test-coverage` — 90.9% overall, `PrepareBinary` at 100%
- [x] `make lint` — 0 issues
- [ ] Manual: run `rimba update` on Apple Silicon Mac to confirm no more SIGKILL