### PR TITLE
[fix] Remove sudo from update and install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@ set -eu
 
 REPO="lugassawan/rimba"
 BINARY="rimba"
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 
 main() {
     os=$(detect_os)
@@ -31,12 +31,14 @@ main() {
     tar -xzf "${tmpdir}/${archive}" -C "$tmpdir"
 
     echo "Installing to ${INSTALL_DIR}..."
-    if [ -w "$INSTALL_DIR" ]; then
-        install -m 755 "${tmpdir}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
-    else
-        echo "Elevated permissions required. Running with sudo..."
-        sudo install -m 755 "${tmpdir}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
-    fi
+    mkdir -p "$INSTALL_DIR"
+    install -m 755 "${tmpdir}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+
+    # Auto PATH setup
+    ensure_path
+
+    # Migration: detect old binary at /usr/local/bin
+    check_old_binary
 
     echo "Verifying installation..."
     if command -v "$BINARY" >/dev/null 2>&1; then
@@ -80,6 +82,50 @@ get_latest_version() {
     fi
 
     echo "$version"
+}
+
+ensure_path() {
+    case ":${PATH}:" in
+        *":${INSTALL_DIR}:"*) return ;; # already in PATH
+    esac
+
+    shell_name=$(basename "${SHELL:-}")
+    case "$shell_name" in
+        zsh)  rc_file="$HOME/.zshrc" ;;
+        bash) rc_file="$HOME/.bashrc" ;;
+        fish)
+            fish -c "fish_add_path $INSTALL_DIR" 2>/dev/null || true
+            echo "Added ${INSTALL_DIR} to PATH via fish_add_path."
+            return
+            ;;
+        *)
+            echo "Note: Add ${INSTALL_DIR} to your PATH manually."
+            return
+            ;;
+    esac
+
+    export_line="export PATH=\"${INSTALL_DIR}:\$PATH\""
+    guard="# Added by rimba"
+
+    # Check if already present (idempotent)
+    if [ -f "$rc_file" ] && grep -qF "$INSTALL_DIR" "$rc_file" 2>/dev/null; then
+        return
+    fi
+
+    printf '\n%s\n%s\n' "$guard" "$export_line" >> "$rc_file"
+    echo "Added ${INSTALL_DIR} to PATH in ${rc_file}. Restart your shell or run: source ${rc_file}"
+}
+
+check_old_binary() {
+    old_path="/usr/local/bin/${BINARY}"
+    resolved_install="$(cd "$INSTALL_DIR" && pwd)/${BINARY}"
+
+    if [ -f "$old_path" ] && [ "$old_path" != "$resolved_install" ]; then
+        echo ""
+        echo "Note: an older copy of ${BINARY} exists at ${old_path}"
+        echo "To avoid conflicts, remove it:"
+        echo "  sudo rm ${old_path}"
+    fi
 }
 
 main


### PR DESCRIPTION
## Summary
- **Fix macOS codesign invalidation**: `Replace()` now uses atomic temp-file-then-rename (new inode) instead of in-place overwrite that invalidated the cached code signature causing "killed: 9"
- **Remove sudo requirement**: On permission errors, `rimba update` installs to `~/.local/bin` with auto PATH setup instead of escalating to `sudo`
- **Update install script**: `scripts/install.sh` defaults to `~/.local/bin`, removes all `sudo` usage, adds auto PATH config for zsh/bash/fish, and detects old `/usr/local/bin` binary with migration guidance

## Test plan
- [x] `go build ./...` — compiles
- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass
- [x] `make test-coverage` — 91.4% (above 90% threshold)
- [x] `go run . update` — shows development build warning