### PR TITLE
[ci] Remove custom release name template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,9 +29,6 @@ archives:
 checksum:
   name_template: checksums.txt
 
-release:
-  name_template: "Release v{{ .Version }}"
-
 changelog:
   sort: asc
   abbrev: -1


### PR DESCRIPTION
## Summary
- Remove the `release.name_template` override from `.goreleaser.yaml`, falling back to GoReleaser's default release naming

## Test plan
- [x] Verify CI checks pass
- [ ] Confirm next release uses GoReleaser's default title format