### PR TITLE
[chore] Expand golangci-lint config with additional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,17 +6,30 @@ linters:
     - bodyclose
     - copyloopvar
     - dupl
+    - dupword
     - errname
     - errorlint
     - fatcontext
+    - forcetypeassert
     - goconst
     - gocritic
     - gocyclo
     - gosec
+    - intrange
+    - misspell
+    - modernize
+    - nakedret
     - nilerr
+    - nilnil
+    - perfsprint
     - prealloc
+    - predeclared
+    - recvcheck
+    - thelper
     - unconvert
     - unparam
+    - usestdlibvars
+    - wastedassign
     - whitespace
   settings:
     gocyclo:

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -83,7 +83,7 @@ func TestFindMergedCandidatesRemoteRef(t *testing.T) {
 }
 
 func TestFindMergedCandidatesNone(t *testing.T) {
-	r := mergedWorktreeRunner("", wtRepo + headMainBlock)
+	r := mergedWorktreeRunner("", wtRepo+headMainBlock)
 	candidates, err := findMergedCandidates(r, branchMain, branchMain)
 	if err != nil {
 		t.Fatalf(fatalFindMerged, err)
@@ -398,6 +398,7 @@ func TestCleanPruneError(t *testing.T) {
 }
 
 func cleanMergedTestRunner(t *testing.T, mergedOut, worktreeOut string) *mockRunner {
+	t.Helper()
 	dir := t.TempDir()
 	cfg := &config.Config{DefaultSource: branchMain}
 	_ = config.Save(filepath.Join(dir, config.FileName), cfg)
@@ -519,4 +520,3 @@ func TestCleanMergedResolveError(t *testing.T) {
 		t.Fatal("expected error from resolveMainBranch failure")
 	}
 }
-

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -67,7 +67,7 @@ var hookUninstallCmd = &cobra.Command{
 
 		err = hook.Uninstall(hooksDir)
 		if errors.Is(err, hook.ErrNotInstalled) {
-			return fmt.Errorf("rimba post-merge hook is not installed")
+			return errors.New("rimba post-merge hook is not installed")
 		}
 		if err != nil {
 			return err

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,7 +41,7 @@ var initCmd = &cobra.Command{
 
 		configPath := filepath.Join(repoRoot, config.FileName)
 		if _, err := os.Stat(configPath); err == nil {
-			return fmt.Errorf(".rimba.toml already exists (use a text editor to modify it)")
+			return errors.New(".rimba.toml already exists (use a text editor to modify it)")
 		}
 
 		cfg := config.DefaultConfig(repoName, defaultBranch)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -93,7 +93,7 @@ func TestInitRepoRootError(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			if len(args) >= 2 && args[1] == cmdShowToplevel {
-				return "", fmt.Errorf("not a git repository")
+				return "", errors.New("not a git repository")
 			}
 			return "", nil
 		},

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -444,14 +445,7 @@ func TestMergeWithNoFF(t *testing.T) {
 	}
 
 	// Verify --no-ff was passed to merge
-	foundNoFF := false
-	for _, arg := range mergeArgs {
-		if arg == "--no-ff" {
-			foundNoFF = true
-			break
-		}
-	}
-	if !foundNoFF {
+	if !slices.Contains(mergeArgs, "--no-ff") {
 		t.Errorf("merge args = %v, want --no-ff to be present", mergeArgs)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -111,6 +111,7 @@ func TestPersistentPreRunESuccess(t *testing.T) {
 	loaded := config.FromContext(cmd.Context())
 	if loaded == nil {
 		t.Fatal("expected config in context after successful PreRunE")
+		return
 	}
 	if loaded.DefaultSource != "main" {
 		t.Errorf("DefaultSource = %q, want %q", loaded.DefaultSource, "main")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -65,7 +66,7 @@ var syncCmd = &cobra.Command{
 		includeInherited, _ := cmd.Flags().GetBool(flagIncludeInherited)
 
 		if !all && len(args) == 0 {
-			return fmt.Errorf("provide a task name or use --all to sync all worktrees")
+			return errors.New("provide a task name or use --all to sync all worktrees")
 		}
 
 		hint.New(cmd, hintPainter(cmd)).

--- a/cmd/update_hint_test.go
+++ b/cmd/update_hint_test.go
@@ -51,6 +51,7 @@ func TestCheckUpdateHintNewVersionAvailable(t *testing.T) {
 	result := collectHint(ch)
 	if result == nil {
 		t.Fatal("expected non-nil result for available update")
+		return
 	}
 	if result.LatestVersion != testVersionNew {
 		t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, testVersionNew)
@@ -142,6 +143,7 @@ func TestCollectHintValue(t *testing.T) {
 	result := collectHint(ch)
 	if result == nil {
 		t.Fatal("expected non-nil result")
+		return
 	}
 	if result.LatestVersion != testVersionOther {
 		t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, testVersionOther)

--- a/internal/git/bench_test.go
+++ b/internal/git/bench_test.go
@@ -50,8 +50,8 @@ func newBenchRepo(b *testing.B) string {
 // addBenchWorktrees creates n worktrees in the repo.
 func addBenchWorktrees(b *testing.B, repo string, n int) []string {
 	b.Helper()
-	var paths []string
-	for i := 0; i < n; i++ {
+	paths := make([]string, 0, n)
+	for i := range n {
 		branch := filepath.Join("feature", "bench-"+string(rune('a'+i)))
 		wtPath := filepath.Join(filepath.Dir(repo), "wt-"+string(rune('a'+i)))
 		cmd := exec.Command("git", "worktree", "add", "-b", branch, wtPath, "main")

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -70,5 +71,5 @@ func DefaultBranch(r Runner) (string, error) {
 		return "master", nil
 	}
 
-	return "", fmt.Errorf("could not detect default branch (no main or master found)")
+	return "", errors.New("could not detect default branch (no main or master found)")
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -76,7 +76,7 @@ func IsDevVersion(v string) bool {
 func (u *Updater) Check() (*CheckResult, error) {
 	url := u.APIEndpoint + repoPath
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -125,7 +125,7 @@ func (u *Updater) Check() (*CheckResult, error) {
 // Download fetches a tar.gz archive from the given URL and extracts the binary
 // to a temporary directory. Returns the path to the extracted binary.
 func (u *Updater) Download(url string) (string, error) {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return "", fmt.Errorf("creating download request: %w", err)
 	}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -25,12 +26,12 @@ const (
 	errWantFmt       = "error = %q, want %q"
 
 	// Shared format and value constants
-	contentFmt   = "content = %q, want %q"
-	fatalReplace = "Replace: %v"
-	valNewBinary = "new binary"
+	contentFmt    = "content = %q, want %q"
+	fatalReplace  = "Replace: %v"
+	valNewBinary  = "new binary"
 	valNewContent = "new content"
-	testRcZshrc  = ".zshrc"
-	testShellZsh = "/bin/zsh"
+	testRcZshrc   = ".zshrc"
+	testShellZsh  = "/bin/zsh"
 )
 
 // newTestUpdater creates an Updater wired to the given test server.
@@ -231,7 +232,7 @@ func TestIsPermissionError(t *testing.T) {
 	}{
 		{"wrapped permission error", fmt.Errorf("opening destination: %w", os.ErrPermission), true},
 		{"direct permission error", os.ErrPermission, true},
-		{"other error", fmt.Errorf("something else"), false},
+		{"other error", errors.New("something else"), false},
 		{"nil error", nil, false},
 	}
 
@@ -480,7 +481,7 @@ func TestWriteBinaryCopyError(t *testing.T) {
 	tmpDir := t.TempDir()
 	dst := filepath.Join(tmpDir, "binary")
 
-	r := &errorReader{err: fmt.Errorf("read error")}
+	r := &errorReader{err: errors.New("read error")}
 	_, err := writeBinary(dst, r)
 	if err == nil {
 		t.Fatal("expected error from io.Copy failure")


### PR DESCRIPTION
## Summary
- Add 13 new linters to `.golangci.yml`: `dupword`, `forcetypeassert`, `intrange`, `misspell`, `modernize`, `nakedret`, `nilnil`, `perfsprint`, `predeclared`, `recvcheck`, `thelper`, `usestdlibvars`, `wastedassign`
- Fix all lint issues caught by the new linters across 14 files
- Key fixes: `fmt.Errorf` → `errors.New` (no format verbs), `strings.Index` → `strings.Cut`, loop → `slices.Contains`, `"GET"` → `http.MethodGet`, missing `t.Helper()`, slice preallocation, integer range loops

## Test plan
- [x] `golangci-lint run ./...` passes with 0 issues
- [x] `go test ./...` passes all tests