### PR TITLE
[feat] Add status command with worktree dashboard (#35)

### DIFF
--- a/cmd/colors.go
+++ b/cmd/colors.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/termcolor"
@@ -25,6 +26,20 @@ func typeColor(t string) termcolor.Color {
 		return termcolor.Gray
 	default:
 		return ""
+	}
+}
+
+// ageColor returns a color based on the age of a commit time.
+// Green for <3 days, Yellow for 3-14 days, Red for >14 days.
+func ageColor(commitTime time.Time) termcolor.Color {
+	age := time.Since(commitTime)
+	switch {
+	case age < 3*24*time.Hour:
+		return termcolor.Green
+	case age < 14*24*time.Hour:
+		return termcolor.Yellow
+	default:
+		return termcolor.Red
 	}
 }
 

--- a/cmd/colors_test.go
+++ b/cmd/colors_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/termcolor"
@@ -27,6 +28,31 @@ func TestTypeColor(t *testing.T) {
 			got := typeColor(tt.input)
 			if got != tt.want {
 				t.Errorf("typeColor(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgeColor(t *testing.T) {
+	tests := []struct {
+		name string
+		age  time.Duration
+		want termcolor.Color
+	}{
+		{"recent", 1 * time.Hour, termcolor.Green},
+		{"two days", 2 * 24 * time.Hour, termcolor.Green},
+		{"three days", 3 * 24 * time.Hour, termcolor.Yellow},
+		{"one week", 7 * 24 * time.Hour, termcolor.Yellow},
+		{"two weeks", 14 * 24 * time.Hour, termcolor.Red},
+		{"one month", 30 * 24 * time.Hour, termcolor.Red},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			commitTime := time.Now().Add(-tt.age)
+			got := ageColor(commitTime)
+			if got != tt.want {
+				t.Errorf("ageColor(-%v) = %q, want %q", tt.age, got, tt.want)
 			}
 		})
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,177 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/operations"
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/internal/spinner"
+	"github.com/lugassawan/rimba/internal/termcolor"
+	"github.com/spf13/cobra"
+)
+
+const (
+	flagStaleDays    = "stale-days"
+	defaultStaleDays = 14
+)
+
+func init() {
+	statusCmd.Flags().Int(flagStaleDays, defaultStaleDays, "Number of days after which a worktree is considered stale")
+	rootCmd.AddCommand(statusCmd)
+}
+
+var statusCmd = &cobra.Command{
+	Use:         "status",
+	Short:       "Show worktree dashboard with summary stats and age info",
+	Long:        "Displays a summary of all worktrees including total count, dirty, stale, and behind counts, plus per-worktree age information.",
+	Annotations: map[string]string{"skipConfig": "true"},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		r := newRunner()
+
+		mainBranch, err := resolveMainBranch(r)
+		if err != nil {
+			return err
+		}
+
+		entries, err := git.ListWorktrees(r)
+		if err != nil {
+			return err
+		}
+
+		// Filter out bare entries and main worktree
+		var candidates []git.WorktreeEntry
+		for _, e := range entries {
+			if e.Bare || e.Branch == mainBranch {
+				continue
+			}
+			candidates = append(candidates, e)
+		}
+
+		if len(candidates) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No worktrees found.")
+			return nil
+		}
+
+		staleDays, _ := cmd.Flags().GetInt(flagStaleDays)
+
+		s := spinner.New(spinnerOpts(cmd))
+		defer s.Stop()
+		s.Start("Collecting worktree status...")
+
+		type statusEntry struct {
+			entry      git.WorktreeEntry
+			status     resolver.WorktreeStatus
+			commitTime time.Time
+			hasTime    bool
+		}
+
+		results := make([]statusEntry, len(candidates))
+		var wg sync.WaitGroup
+		sem := make(chan struct{}, 8)
+
+		for i, c := range candidates {
+			s.Update(fmt.Sprintf("Collecting status... (%d/%d)", i+1, len(candidates)))
+			wg.Add(1)
+			go func(idx int, e git.WorktreeEntry) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+
+				st := operations.CollectWorktreeStatus(r, e.Path)
+				var ct time.Time
+				var hasTime bool
+				if t, err := git.LastCommitTime(r, e.Branch); err == nil {
+					ct = t
+					hasTime = true
+				}
+				results[idx] = statusEntry{entry: e, status: st, commitTime: ct, hasTime: hasTime}
+			}(i, c)
+		}
+		wg.Wait()
+		s.Stop()
+
+		// Compute summary
+		var totalCount, dirtyCount, staleCount, behindCount int
+		totalCount = len(results)
+		staleThreshold := time.Now().Add(-time.Duration(staleDays) * 24 * time.Hour)
+
+		for _, r := range results {
+			if r.status.Dirty {
+				dirtyCount++
+			}
+			if r.status.Behind > 0 {
+				behindCount++
+			}
+			if r.hasTime && r.commitTime.Before(staleThreshold) {
+				staleCount++
+			}
+		}
+
+		noColor, _ := cmd.Flags().GetBool(flagNoColor)
+		p := termcolor.NewPainter(noColor)
+		out := cmd.OutOrStdout()
+		prefixes := resolver.AllPrefixes()
+
+		// Print header
+		fmt.Fprintf(out, "Worktrees: %s  Dirty: %s  Stale: %s  Behind: %s\n\n",
+			p.Paint(strconv.Itoa(totalCount), termcolor.Bold),
+			colorCount(p, dirtyCount, termcolor.Yellow),
+			colorCount(p, staleCount, termcolor.Red),
+			colorCount(p, behindCount, termcolor.Red),
+		)
+
+		// Print table
+		tbl := termcolor.NewTable(2)
+		tbl.AddRow(
+			p.Paint("TASK", termcolor.Bold),
+			p.Paint("TYPE", termcolor.Bold),
+			p.Paint("BRANCH", termcolor.Bold),
+			p.Paint("STATUS", termcolor.Bold),
+			p.Paint("AGE", termcolor.Bold),
+		)
+
+		for _, r := range results {
+			task, matchedPrefix := resolver.TaskFromBranch(r.entry.Branch, prefixes)
+			typeName := strings.TrimSuffix(matchedPrefix, "/")
+
+			taskCell := "  " + task
+			typeCell := typeName
+			if c := typeColor(typeName); c != "" {
+				typeCell = p.Paint(typeCell, c)
+			}
+
+			statusCell := colorStatus(p, r.status)
+
+			var ageCell string
+			if r.hasTime {
+				ageStr := resolver.FormatAge(r.commitTime)
+				if r.commitTime.Before(staleThreshold) {
+					ageCell = p.Paint(ageStr, termcolor.Red) + " " + p.Paint("⚠ stale", termcolor.Red)
+				} else {
+					ageCell = p.Paint(ageStr, ageColor(r.commitTime))
+				}
+			} else {
+				ageCell = p.Paint("unknown", termcolor.Gray)
+			}
+
+			tbl.AddRow(taskCell, typeCell, r.entry.Branch, statusCell, ageCell)
+		}
+
+		tbl.Render(out)
+		return nil
+	},
+}
+
+// colorCount formats a count with color if non-zero.
+func colorCount(p *termcolor.Painter, count int, color termcolor.Color) string {
+	s := strconv.Itoa(count)
+	if count > 0 {
+		return p.Paint(s, color, termcolor.Bold)
+	}
+	return s
+}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestStatusNoWorktrees(t *testing.T) {
+	restore := overrideNewRunner(&mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case args[0] == cmdRevParse && args[1] == cmdShowToplevel:
+				return repoPath, nil
+			case args[0] == cmdSymbolicRef:
+				return refsRemotesOriginMain, nil
+			case args[0] == cmdWorktreeTest && args[1] == cmdList:
+				return wtRepo + headMainBlock, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	})
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	if err := statusCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("statusCmd.RunE: %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "No worktrees found") {
+		t.Errorf("expected 'No worktrees found', got: %q", buf.String())
+	}
+}
+
+func TestStatusWithWorktrees(t *testing.T) {
+	restore := overrideNewRunner(&mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case args[0] == cmdRevParse && args[1] == cmdShowToplevel:
+				return repoPath, nil
+			case args[0] == cmdSymbolicRef:
+				return refsRemotesOriginMain, nil
+			case args[0] == cmdWorktreeTest && args[1] == cmdList:
+				return wtRepo + headMainBlock + "\n" +
+					wtFeatureLogin + "\n" + headDEF456 + "\n" + branchRefFeatureLogin + "\n", nil
+			case args[0] == "log":
+				return "1700000000", nil
+			}
+			return "", nil
+		},
+		runInDir: func(dir string, args ...string) (string, error) {
+			if args[0] == cmdStatus {
+				return "", nil
+			}
+			if args[0] == cmdRevList {
+				return aheadBehindZero, nil
+			}
+			return "", nil
+		},
+	})
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	if err := statusCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("statusCmd.RunE: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Worktrees:") {
+		t.Errorf("expected 'Worktrees:' header, got: %q", output)
+	}
+	if !strings.Contains(output, taskLogin) {
+		t.Errorf("expected task 'login', got: %q", output)
+	}
+}
+
+func TestColorCount(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool(flagNoColor, true, "")
+	p := hintPainter(cmd)
+	// Zero count should not be colored
+	s := colorCount(p, 0, "")
+	if s != "0" {
+		t.Errorf("colorCount(0) = %q, want %q", s, "0")
+	}
+}

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -1,7 +1,9 @@
 package git_test
 
 import (
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/testutil"
@@ -51,6 +53,81 @@ func TestDeleteBranch(t *testing.T) {
 
 	if git.BranchExists(r, branchToDelete) {
 		t.Error("branch should not exist after delete")
+	}
+}
+
+func TestLastCommitTime(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	ct, err := git.LastCommitTime(r, "main")
+	if err != nil {
+		t.Fatalf("LastCommitTime: %v", err)
+	}
+
+	// Should be within the last minute (just created)
+	if time.Since(ct) > time.Minute {
+		t.Errorf("commit time %v is too old", ct)
+	}
+}
+
+func TestLastCommitTimeError(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	_, err := git.LastCommitTime(r, "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent branch")
+	}
+}
+
+func TestLocalBranches(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	branches, err := git.LocalBranches(r)
+	if err != nil {
+		t.Fatalf("LocalBranches: %v", err)
+	}
+
+	if len(branches) == 0 {
+		t.Fatal("expected at least one branch")
+	}
+
+	if !slices.Contains(branches, "main") {
+		t.Errorf("expected 'main' in branches, got %v", branches)
+	}
+}
+
+func TestLocalBranchesMultiple(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	testutil.GitCmd(t, repo, "branch", "feature/test-branch")
+
+	branches, err := git.LocalBranches(r)
+	if err != nil {
+		t.Fatalf("LocalBranches: %v", err)
+	}
+
+	if len(branches) < 2 {
+		t.Fatalf("expected at least 2 branches, got %d: %v", len(branches), branches)
 	}
 }
 

--- a/internal/resolver/age.go
+++ b/internal/resolver/age.go
@@ -1,0 +1,34 @@
+package resolver
+
+import (
+	"strconv"
+	"time"
+)
+
+// FormatAge returns a human-readable age string relative to now.
+func FormatAge(t time.Time) string {
+	return FormatAgeSince(t, time.Now())
+}
+
+// FormatAgeSince returns a human-readable age string relative to the given now time.
+// Returns "just now" for <1 minute, "Xh ago" for <24h, "Xd ago" for <14d, "Xw ago" otherwise.
+func FormatAgeSince(t, now time.Time) string {
+	d := max(now.Sub(t), 0)
+
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return formatUnit(int(d.Minutes()), "m")
+	case d < 24*time.Hour:
+		return formatUnit(int(d.Hours()), "h")
+	case d < 14*24*time.Hour:
+		return formatUnit(int(d.Hours()/24), "d")
+	default:
+		return formatUnit(int(d.Hours()/(24*7)), "w")
+	}
+}
+
+func formatUnit(n int, unit string) string {
+	return strconv.Itoa(n) + unit + " ago"
+}

--- a/internal/resolver/age_test.go
+++ b/internal/resolver/age_test.go
@@ -1,0 +1,38 @@
+package resolver_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lugassawan/rimba/internal/resolver"
+)
+
+func TestFormatAgeSince(t *testing.T) {
+	now := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		t    time.Time
+		want string
+	}{
+		{"just now", now.Add(-30 * time.Second), "just now"},
+		{"minutes ago", now.Add(-5 * time.Minute), "5m ago"},
+		{"one minute ago", now.Add(-1 * time.Minute), "1m ago"},
+		{"hours ago", now.Add(-5 * time.Hour), "5h ago"},
+		{"one hour ago", now.Add(-1 * time.Hour), "1h ago"},
+		{"days ago", now.Add(-3 * 24 * time.Hour), "3d ago"},
+		{"one day ago", now.Add(-1 * 24 * time.Hour), "1d ago"},
+		{"weeks ago", now.Add(-21 * 24 * time.Hour), "3w ago"},
+		{"two weeks ago", now.Add(-14 * 24 * time.Hour), "2w ago"},
+		{"future is just now", now.Add(5 * time.Minute), "just now"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolver.FormatAgeSince(tt.t, now)
+			if got != tt.want {
+				t.Errorf("FormatAgeSince(%v, %v) = %q, want %q", tt.t, now, got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/e2e/status_test.go
+++ b/tests/e2e/status_test.go
@@ -1,0 +1,66 @@
+package e2e_test
+
+import (
+	"testing"
+)
+
+func TestStatusBasic(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "status-task")
+
+	r := rimbaSuccess(t, repo, "status")
+	assertContains(t, r.Stdout, "Worktrees:")
+	assertContains(t, r.Stdout, "status-task")
+}
+
+func TestStatusWorksWithoutInit(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupRepo(t) // plain git repo, no rimba init
+	r := rimbaSuccess(t, repo, "status")
+	assertContains(t, r.Stdout, "No worktrees found")
+}
+
+func TestStatusShowsAge(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "age-task")
+
+	r := rimbaSuccess(t, repo, "status")
+	assertContains(t, r.Stdout, "AGE")
+	// Recently created worktree should show "just now" since it was just created
+	assertContains(t, r.Stdout, "just now")
+}
+
+func TestStatusStaleMarker(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "stale-check")
+
+	// Use --stale-days 0 so everything is considered stale
+	r := rimbaSuccess(t, repo, "status", "--stale-days", "0")
+	assertContains(t, r.Stdout, "stale")
+}
+
+func TestStatusNoWorktrees(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+
+	r := rimbaSuccess(t, repo, "status")
+	assertContains(t, r.Stdout, "No worktrees found")
+}


### PR DESCRIPTION
## Summary
- Add `rimba status` command showing a dashboard with summary stats (total, dirty, stale, behind worktrees) and per-worktree table with age column and `⚠ stale` markers
- Add shared functions: `git.LastCommitTime`, `git.LocalBranches`, `resolver.FormatAge`/`FormatAgeSince`, `ageColor` — reused by upcoming #36 and #37
- `--stale-days N` flag (default 14) to customize the staleness threshold
- Works without `.rimba.toml` (skipConfig annotation)

## Test Plan
- [x] Unit tests for `LastCommitTime`, `LocalBranches`, `FormatAgeSince` (table-driven), `ageColor`, `colorCount`
- [x] Unit tests for `statusCmd` (no worktrees, with worktrees)
- [x] E2E tests: `TestStatusBasic`, `TestStatusWorksWithoutInit`, `TestStatusShowsAge`, `TestStatusStaleMarker`, `TestStatusNoWorktrees`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./... -count=1` — all pass

Closes #35