### PR TITLE
[fix] Detect squash-merged branches in clean --merged

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -175,6 +175,16 @@ func findMergedCandidates(r git.Runner, mergeRef, mainBranch string) ([]cleanCan
 	for _, e := range git.FilterEntries(entries, mainBranch) {
 		if mergedSet[e.Branch] {
 			candidates = append(candidates, cleanCandidate{path: e.Path, branch: e.Branch})
+			continue
+		}
+
+		// Fallback: squash-merge detection
+		squashed, err := git.IsSquashMerged(r, mergeRef, e.Branch)
+		if err != nil {
+			continue
+		}
+		if squashed {
+			candidates = append(candidates, cleanCandidate{path: e.Path, branch: e.Branch})
 		}
 	}
 	return candidates, nil

--- a/cmd/mock_runner_test.go
+++ b/cmd/mock_runner_test.go
@@ -41,6 +41,13 @@ const (
 	pathWorktreesFeatureLogin = "/worktrees/feature-login"
 	cmdRevList                = "rev-list"
 
+	// Squash merge detection constants
+	cmdCommitTree = "commit-tree"
+	cmdCherry     = "cherry"
+	cmdMergeBase  = "merge-base"
+	branchSquash  = "feature/squash"
+	pathWtSquash  = "/wt/feature-squash"
+
 	// Shared git command and value constants
 	cmdList               = "list"
 	cmdDiff               = "diff"

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -11,6 +11,10 @@ const (
 	refsHeadsPrefix = "refs/heads/"
 	cmdRevParse     = "rev-parse"
 	flagVerify      = "--verify"
+	cmdCommitTree   = "commit-tree"
+	cmdCherry       = "cherry"
+	treeSuffix      = "^{tree}"
+	cherryMerged    = "- "
 )
 
 // RepoRoot returns the absolute path to the repository root.


### PR DESCRIPTION
## Summary
- Add `IsSquashMerged` function using the `commit-tree` + `cherry` technique to detect branches whose content was squash-merged into main
- Update `findMergedCandidates` in `clean --merged` to fall back to squash-merge detection when `git branch --merged` doesn't find a match
- Errors from squash detection are gracefully skipped (best-effort fallback)

## Test Plan
- [x] Unit tests for `IsSquashMerged` (7 tests: merged, not merged, empty cherry, 4 error paths)
- [x] Integration tests using real git repos (squash-merged and unmerged scenarios)
- [x] Unit tests for `findMergedCandidates` (squash detection, error skipping, mixed merge types)
- [x] E2E tests (detection, force removal, keeps unmerged, both regular + squash)
- [x] `make lint` — 0 issues
- [x] `go test ./...` — all pass
- [x] Manual verification: `go run . clean --merged --dry-run` detects `feature/lint-enforcement`