### PR TITLE
[chore] Add make fmt target and use it in pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -14,7 +14,7 @@ set -e
 STAGED_GO_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.go')
 
 if [ -n "$STAGED_GO_FILES" ]; then
-    echo "$STAGED_GO_FILES" | xargs gofmt -l -w
+    make fmt
     echo "$STAGED_GO_FILES" | xargs git add
 fi
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS  = -s -w \
 	-X github.com/lugassawan/rimba/cmd.commit=$(COMMIT) \
 	-X github.com/lugassawan/rimba/cmd.date=$(DATE)
 
-.PHONY: build test test-short test-e2e test-coverage clean lint bench hooks
+.PHONY: build test test-short test-e2e test-coverage clean fmt lint bench hooks
 
 build:
 	go build -ldflags '$(LDFLAGS)' -o bin/rimba .
@@ -19,6 +19,9 @@ test-short:
 
 clean:
 	rm -rf bin/ custom-gcl
+
+fmt:
+	go fmt ./...
 
 test-e2e:
 	go test ./tests/e2e/ -v -count=1 -timeout 120s


### PR DESCRIPTION
## Summary
- Add `make fmt` target (`go fmt ./...`) to Makefile for standalone formatting
- Update pre-commit hook to call `make fmt` instead of inline `gofmt` logic
- Staged Go files are still re-added after formatting to capture changes

## Test plan
- [x] `make fmt` runs successfully
- [x] All tests pass (`go test ./... -short`)
- [x] Pre-commit hook triggers formatting via `make fmt` on commit