### PR TITLE
[docs] Restructure README into docs/ with grouped command reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to rimba
+
+Thanks for your interest in contributing! This guide covers the development workflow.
+
+## Development Setup
+
+```sh
+git clone https://github.com/lugassawan/rimba.git
+cd rimba
+make hooks  # Activate git hooks
+make build  # Build the binary
+```
+
+## Git Hooks
+
+Running `make hooks` configures Git to use the hooks in `.githooks/`:
+
+- **pre-commit** — prevents direct commits to main/master, formats staged Go files with `make fmt`, and runs `make lint`
+- **commit-msg** — enforces the `[type] Description` commit message format
+
+## Commit Convention
+
+All commit messages must follow the format `[type] Description`, where type is one of:
+
+| Type | Purpose |
+|------|---------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `refactor` | Code restructuring (no behavior change) |
+| `test` | Adding or updating tests |
+| `ci` | CI/CD changes |
+| `docs` | Documentation |
+| `perf` | Performance improvement |
+| `chore` | Maintenance tasks |
+| `polish` | Minor improvements and cleanups |
+| `breaking` | Breaking changes |
+
+This convention is enforced locally by git hooks and in CI by PR title validation.
+
+## Useful Make Targets
+
+| Target | Description |
+|--------|-------------|
+| `make build` | Build the binary to `./bin/rimba` |
+| `make test` | Run all tests (verbose) |
+| `make test-short` | Run tests in short mode (skip slow tests) |
+| `make test-e2e` | Run end-to-end tests |
+| `make test-coverage` | Run tests with coverage report |
+| `make clean` | Remove build artifacts |
+| `make fmt` | Format all Go source files |
+| `make lint` | Run linters via golangci-lint |
+| `make bench` | Run benchmarks |
+| `make hooks` | Activate git hooks from `.githooks/` |
+
+## License
+
+All contributions are licensed under the [MIT](LICENSE) license.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@
 - [Quick Start](#quick-start)
 - [Commands](#commands)
 - [Configuration](#configuration)
-- [Environment Variables](#environment-variables)
-- [Development](#development)
+- [Contributing](CONTRIBUTING.md)
 - [License](#license)
 
 ## Features
@@ -90,263 +89,34 @@ rimba remove my-feature
 
 ## Commands
 
-### `rimba init`
-
-Initialize rimba in the current repository. Detects the repo root, creates `.rimba.toml`, and sets up the worktree directory.
-
-```sh
-rimba init
-```
-
-### `rimba add <task>`
-
-Create a new worktree with a branch named `<prefix><task>` and copy dotfiles from the repo root.
-
-```sh
-rimba add my-feature
-rimba add my-feature --bugfix        # Use bugfix/ prefix instead of feature/
-rimba add my-feature -s develop      # Branch from a different source
-```
-
-| Flag | Description |
-|------|-------------|
-| `--bugfix` | Use `bugfix/` branch prefix |
-| `--hotfix` | Use `hotfix/` branch prefix |
-| `--docs` | Use `docs/` branch prefix |
-| `--test` | Use `test/` branch prefix |
-| `--chore` | Use `chore/` branch prefix |
-| `-s`, `--source` | Source branch to create worktree from (default from config) |
-| `--skip-deps` | Skip dependency detection and installation |
-| `--skip-hooks` | Skip post-create hooks |
-
-### `rimba list`
-
-List all worktrees with their task name, type, branch, path, and status. The current worktree is marked with `*`. Output is colored by default.
-
-```sh
-rimba list
-rimba list --type bugfix        # Show only bugfix worktrees
-rimba list --dirty              # Show only dirty worktrees
-rimba list --behind             # Show only worktrees behind upstream
-rimba list --no-color           # Disable colored output
-```
-
-Example output:
-
-```
-TASK            TYPE     BRANCH              PATH              STATUS
-* auth-flow     feature  feature/auth-flow   feature-auth-flow [dirty]
-  fix-login     bugfix   bugfix/fix-login    bugfix-fix-login  ↑2 ↓1
-  ui-cleanup    chore    chore/ui-cleanup    chore-ui-cleanup  ✓
-```
-
-| Flag | Description |
-|------|-------------|
-| `--type` | Filter by prefix type (e.g. `feature`, `bugfix`, `hotfix`, `docs`, `test`, `chore`) |
-| `--dirty` | Show only worktrees with uncommitted changes |
-| `--behind` | Show only worktrees behind their upstream branch |
-| `--no-color` | Disable colored output (also respects `NO_COLOR` env var) |
-
-### `rimba open <task> [command args...]`
-
-Open a worktree or run a command inside it. When called with just a task name, prints the worktree path. When given additional arguments, executes that command inside the worktree directory. Supports configurable shortcuts via the `[open]` config section.
-
-```sh
-rimba open my-task              # Print worktree path
-cd $(rimba open my-task)        # Navigate to worktree
-rimba open my-task --ide        # Run the 'ide' shortcut
-rimba open my-task --agent      # Run the 'agent' shortcut
-rimba open my-task -w test      # Run a named shortcut
-rimba open my-task npm start    # Run an inline command
-```
-
-| Flag | Description |
-|------|-------------|
-| `--ide` | Run the `ide` shortcut from `[open]` config |
-| `--agent` | Run the `agent` shortcut from `[open]` config |
-| `-w`, `--with` | Run any named shortcut from `[open]` config |
-
-> **Note:** `--ide`, `--agent`, and `--with` are mutually exclusive with each other and with inline command arguments. Shortcuts are configured in the `[open]` section of `.rimba.toml` (see [Configuration](#configuration)).
-
-### `rimba remove <task>`
-
-Remove the worktree for the given task and delete the local branch.
-
-```sh
-rimba remove my-feature
-rimba remove my-feature -k           # Keep the branch after removal
-rimba remove my-feature -f           # Force removal even if dirty
-```
-
-| Flag | Description |
-|------|-------------|
-| `-k`, `--keep-branch` | Keep the local branch after removing the worktree |
-| `-f`, `--force` | Force removal even if the worktree is dirty |
-
-### `rimba rename <task> <new-task>`
-
-Rename a worktree's task, branch, and directory.
-
-```sh
-rimba rename old-task new-task
-rimba rename old-task new-task -f  # Force rename even if locked
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f`, `--force` | Force rename even if the worktree is locked |
-
-### `rimba duplicate <task>`
-
-Create a new worktree from an existing worktree, inheriting its branch prefix. Auto-generates a `-1`, `-2`, etc. suffix unless `--as` is provided.
-
-```sh
-rimba duplicate auth              # Creates feature/auth-1 from feature/auth
-rimba duplicate auth --as auth-v2 # Creates feature/auth-v2 from feature/auth
-```
-
-| Flag | Description |
-|------|-------------|
-| `--as` | Custom name for the duplicate worktree (instead of auto-suffix) |
-| `--skip-deps` | Skip dependency detection and installation |
-| `--skip-hooks` | Skip post-create hooks |
-
-### `rimba merge <source-task>`
-
-Merge a worktree's branch into main or another worktree. When merging into main, the source worktree and branch are auto-deleted unless `--keep` is set. When merging between worktrees, the source is kept unless `--delete` is set.
-
-```sh
-rimba merge auth                           # Merge into main, delete source
-rimba merge auth --keep                    # Merge into main, keep source
-rimba merge auth --into dashboard          # Merge into worktree, keep source
-rimba merge auth --into dashboard --delete # Merge into worktree, delete source
-rimba merge auth --no-ff                   # Force merge commit
-```
-
-| Flag | Description |
-|------|-------------|
-| `--into` | Target worktree task to merge into (default: main/repo root) |
-| `--no-ff` | Force a merge commit (no fast-forward) |
-| `--keep` | Keep source worktree after merging into main |
-| `--delete` | Delete source worktree after merging into another worktree |
-
-> **Note:** `--keep` and `--delete` are mutually exclusive. Merging to main deletes the source by default; merging to another worktree keeps it by default.
-
-### `rimba sync <task>`
-
-Sync worktree(s) with the main branch by rebasing (default) or merging. Fetches the latest changes from origin first.
-
-```sh
-rimba sync my-feature                # Rebase a single worktree onto main
-rimba sync my-feature --merge        # Use merge instead of rebase
-rimba sync --all                     # Sync all eligible worktrees
-rimba sync --all --include-inherited # Include duplicate worktrees
-```
-
-| Flag | Description |
-|------|-------------|
-| `--all` | Sync all eligible worktrees (skips dirty and inherited by default) |
-| `--merge` | Use merge instead of rebase |
-| `--include-inherited` | Include inherited/duplicate worktrees when using `--all` |
-
-> **Note:** Dirty worktrees are skipped with a warning. On conflict, the rebase is automatically aborted and a recovery hint is printed.
-
-### `rimba hook install`
-
-Install a `post-merge` Git hook that automatically runs `rimba clean --merged --force` after `git pull`. The hook only fires on the default branch (e.g. `main`), so pulling on feature branches is unaffected.
-
-```sh
-rimba hook install           # Install the post-merge hook
-```
-
-### `rimba hook uninstall`
-
-Remove the rimba post-merge hook. Preserves any other content in the hook file.
-
-```sh
-rimba hook uninstall         # Remove the rimba hook
-```
-
-### `rimba hook status`
-
-Show whether the rimba post-merge hook is currently installed.
-
-```sh
-rimba hook status            # Check installation status
-```
-
-> **Note:** `rimba hook` works with or without `rimba init`. The hook coexists with existing user-defined hooks in the same `post-merge` file.
-
-### `rimba deps status`
-
-Show detected dependency modules and lockfile hashes for all worktrees.
-
-```sh
-rimba deps status
-```
-
-Example output:
-
-```
-refs/heads/main (/path/to/repo)
-  node_modules [a1b2c3d4e5f6]
-  vendor [7g8h9i0j1k2l]
-refs/heads/feature/auth (/path/to/worktrees/feature-auth)
-  node_modules [a1b2c3d4e5f6]
-  vendor [7g8h9i0j1k2l]
-```
-
-### `rimba deps install <task>`
-
-Detect and install dependencies for a specific worktree. Clones from an existing worktree with a matching lockfile hash, or falls back to the configured install command.
-
-```sh
-rimba deps install my-feature
-```
-
-### `rimba clean`
-
-Prune stale worktree references, or detect and remove worktrees whose branches have been merged into main.
-
-```sh
-rimba clean                          # Prune stale worktree references
-rimba clean --dry-run                # Preview what would be pruned
-rimba clean --merged                 # Detect and remove merged worktrees (with confirmation)
-rimba clean --merged --force         # Remove merged worktrees without confirmation
-rimba clean --merged --dry-run       # Show merged worktrees without removing
-```
-
-| Flag | Description |
-|------|-------------|
-| `--dry-run` | Show what would be pruned/removed without making changes |
-| `--merged` | Detect and remove worktrees whose branches are merged into main |
-| `--force` | Skip confirmation prompt when used with `--merged` |
-
-> **Note:** `--merged` works with or without `rimba init`. Without a config file, it falls back to auto-detecting the default branch.
-
-### `rimba update`
-
-Check for the latest release on GitHub and update the binary in place.
-
-```sh
-rimba update             # Check and update to latest
-rimba update --force     # Also works on dev builds
-```
-
-| Flag | Description |
-|------|-------------|
-| `--force` | Update even if running a development build |
-
-> **Note:** If the binary cannot be replaced due to file permissions, rimba automatically retries with `sudo`.
-
-### `rimba version`
-
-Print version, commit, and build date.
-
-```sh
-rimba version
-# rimba v0.1.0 (commit: abc1234, built: 2026-01-01T00:00:00Z)
-```
+| Command | Description |
+|---------|-------------|
+| `rimba init` | Initialize rimba in the current repository |
+| `rimba add <task>` | Create a new worktree with auto-prefixed branch |
+| `rimba remove <task>` | Remove a worktree and delete its branch |
+| `rimba rename <old> <new>` | Rename a worktree's task, branch, and directory |
+| `rimba duplicate <task>` | Create a copy of an existing worktree |
+| `rimba archive <task>` | Archive a worktree (remove directory, keep branch) |
+| `rimba restore <task>` | Restore an archived worktree from its preserved branch |
+| `rimba list` | List all worktrees with status dashboard |
+| `rimba status` | Show worktree dashboard with summary stats and age info |
+| `rimba log` | Show last commit from each worktree, sorted by recency |
+| `rimba open <task>` | Open a worktree or run a command inside it |
+| `rimba merge <task>` | Merge a worktree branch into main or another worktree |
+| `rimba sync <task>` | Rebase or merge a worktree onto the latest main |
+| `rimba merge-plan` | Recommend optimal merge order to minimize conflicts |
+| `rimba conflict-check` | Detect file overlaps between worktree branches |
+| `rimba exec <command>` | Run a shell command across worktrees |
+| `rimba hook install` | Install post-merge and pre-commit hooks |
+| `rimba hook uninstall` | Remove the rimba hooks |
+| `rimba hook status` | Show whether the rimba hooks are installed |
+| `rimba deps status` | Show detected dependency modules for all worktrees |
+| `rimba deps install <task>` | Detect and install dependencies for a worktree |
+| `rimba clean` | Prune stale references or remove merged/stale worktrees |
+| `rimba update` | Check for updates and replace the binary in place |
+| `rimba version` | Print version, commit, and build date |
+
+> See [docs/commands.md](docs/commands.md) for the full reference with all flags, examples, and notes.
 
 ## Configuration
 
@@ -356,100 +126,14 @@ rimba version
 worktree_dir = '../myrepo-worktrees'
 default_source = 'main'
 copy_files = ['.env', '.env.local', '.envrc', '.tool-versions', '.vscode']
-
-# Post-create hooks (run in new worktree directory)
 post_create = ['./gradlew build']
 
-# Open shortcuts (used by `rimba open --ide`, `--agent`, `-w`)
 [open]
 ide = 'code .'
 agent = 'claude'
-test = 'npm test'
-
-# Dependency management (optional — auto-detect is on by default)
-[deps]
-auto_detect = true
-
-# Manual module overrides (supplements or overrides auto-detected modules)
-[[deps.modules]]
-dir = 'node_modules'
-lockfile = 'package-lock.json'
-install = 'npm ci'
-
-[[deps.modules]]
-dir = 'api/vendor'
-lockfile = 'api/go.sum'
-install = 'go mod vendor'
-work_dir = 'api'
 ```
 
-| Field | Description | Default |
-|-------|-------------|---------|
-| `worktree_dir` | Directory for worktrees (relative to repo root) | `../<repo-name>-worktrees` |
-| `default_source` | Branch to create worktrees from | Default branch (e.g. `main`) |
-| `copy_files` | Files or directories to copy from repo root into new worktrees | `.env`, `.env.local`, `.envrc`, `.tool-versions` |
-| `post_create` | Shell commands to run in new worktrees after creation | (none) |
-| `open.<name>` | Named shortcut command for `rimba open --with <name>` | (none) |
-| `deps.auto_detect` | Auto-detect dependency modules from lockfiles | `true` |
-| `deps.modules[].dir` | Dependency directory to clone (e.g. `node_modules`) | — |
-| `deps.modules[].lockfile` | Lockfile used to match worktrees (e.g. `pnpm-lock.yaml`) | — |
-| `deps.modules[].install` | Install command to run if no matching worktree is found | — |
-| `deps.modules[].work_dir` | Subdirectory to run the install command in | (repo root) |
-
-**Auto-detected ecosystems** (when `auto_detect` is enabled):
-
-| Lockfile | Dep directory | Install command | Behavior |
-|----------|---------------|-----------------|----------|
-| `pnpm-lock.yaml` | `node_modules` | `pnpm install --frozen-lockfile` | Recursive clone + install fallback |
-| `yarn.lock` | `node_modules` | `yarn install` | Recursive clone + `.yarn/cache` |
-| `package-lock.json` | `node_modules` | `npm ci` | Recursive clone + install fallback |
-| `go.sum` | `vendor` | `go mod vendor` | Clone only (skip if no match) |
-
-> **Note:** Dependencies are shared using copy-on-write clones (`cp -c` on macOS, `cp --reflink=auto` on Linux) for near-instant copies on supported filesystems (APFS, Btrfs). Falls back to regular copy on other systems.
-
-## Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `RIMBA_QUIET` | Suppress pre-execution hints (set to any value, e.g. `RIMBA_QUIET=1`) |
-| `NO_COLOR` | Disable colored output globally (per [no-color.org](https://no-color.org)) |
-
-## Development
-
-### Setup
-
-```sh
-git clone https://github.com/lugassawan/rimba.git
-cd rimba
-make hooks  # Activate git hooks
-make build  # Build the binary
-```
-
-### Git Hooks
-
-Running `make hooks` configures Git to use the hooks in `.githooks/`:
-
-- **pre-commit** — formats staged Go files with `gofmt` and runs `make lint`
-- **commit-msg** — enforces the `[type] Description` commit message format
-
-### Commit Convention
-
-All commit messages must follow the format `[type] Description`, where type is one of:
-
-| Type | Purpose |
-|------|---------|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `refactor` | Code restructuring (no behavior change) |
-| `test` | Adding or updating tests |
-| `ci` | CI/CD changes |
-| `docs` | Documentation |
-| `perf` | Performance improvement |
-| `chore` | Maintenance tasks |
-| `polish` | Minor improvements and cleanups |
-| `breaking` | Breaking changes |
-
-This convention is enforced locally by git hooks and in CI by PR title validation.
+> See [docs/configuration.md](docs/configuration.md) for the full field reference, dependency management, and environment variables.
 
 ## License
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,469 @@
+# Command Reference
+
+> Back to [README](../README.md) | See also: [Configuration](configuration.md)
+
+---
+
+## Global Flags
+
+These flags are available on every command via the root `rimba` command:
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output in JSON format (supported by `list`, `status`, `deps status`, `conflict-check`, `exec`) |
+| `--no-color` | Disable colored output (also respects `NO_COLOR` env var) |
+
+---
+
+## Setup
+
+### rimba init
+
+Initialize rimba in the current repository. Detects the repo root, creates `.rimba.toml`, and sets up the worktree directory.
+
+```sh
+rimba init
+```
+
+---
+
+## Worktree Lifecycle
+
+### rimba add
+
+Create a new worktree with a branch named `<prefix><task>` and copy dotfiles from the repo root.
+
+```sh
+rimba add my-feature
+rimba add my-feature --bugfix        # Use bugfix/ prefix instead of feature/
+rimba add my-feature -s develop      # Branch from a different source
+```
+
+| Flag | Description |
+|------|-------------|
+| `--bugfix` | Use `bugfix/` branch prefix |
+| `--hotfix` | Use `hotfix/` branch prefix |
+| `--docs` | Use `docs/` branch prefix |
+| `--test` | Use `test/` branch prefix |
+| `--chore` | Use `chore/` branch prefix |
+| `-s`, `--source` | Source branch to create worktree from (default from config) |
+| `--skip-deps` | Skip dependency detection and installation |
+| `--skip-hooks` | Skip post-create hooks |
+
+### rimba remove
+
+Remove the worktree for the given task and delete the local branch.
+
+```sh
+rimba remove my-feature
+rimba remove my-feature -k           # Keep the branch after removal
+rimba remove my-feature -f           # Force removal even if dirty
+```
+
+| Flag | Description |
+|------|-------------|
+| `-k`, `--keep-branch` | Keep the local branch after removing the worktree |
+| `-f`, `--force` | Force removal even if the worktree is dirty |
+
+### rimba rename
+
+Rename a worktree's task, branch, and directory.
+
+```sh
+rimba rename old-task new-task
+rimba rename old-task new-task -f  # Force rename even if locked
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Force rename even if the worktree is locked |
+
+### rimba duplicate
+
+Create a new worktree from an existing worktree, inheriting its branch prefix. Auto-generates a `-1`, `-2`, etc. suffix unless `--as` is provided.
+
+```sh
+rimba duplicate auth              # Creates feature/auth-1 from feature/auth
+rimba duplicate auth --as auth-v2 # Creates feature/auth-v2 from feature/auth
+```
+
+| Flag | Description |
+|------|-------------|
+| `--as` | Custom name for the duplicate worktree (instead of auto-suffix) |
+| `--skip-deps` | Skip dependency detection and installation |
+| `--skip-hooks` | Skip post-create hooks |
+
+### rimba archive
+
+Archive a worktree by removing its directory but preserving the local branch for later restoration with `rimba restore`.
+
+```sh
+rimba archive my-feature
+rimba archive my-feature -f      # Force archival even if dirty
+```
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Force archival even if the worktree has uncommitted changes |
+
+> **Note:** The branch is preserved locally. Use [`rimba restore`](#rimba-restore) to recreate the worktree from the archived branch.
+
+### rimba restore
+
+Restore an archived worktree by recreating it from a branch that was previously archived with `rimba archive`.
+
+```sh
+rimba restore my-feature
+```
+
+| Flag | Description |
+|------|-------------|
+| `--skip-deps` | Skip dependency detection and installation |
+| `--skip-hooks` | Skip post-create hooks |
+
+> **Note:** Restoring copies dotfiles, installs dependencies, and runs post-create hooks — just like `rimba add`. Use [`rimba archive`](#rimba-archive) to archive a worktree.
+
+---
+
+## Inspection
+
+### rimba list
+
+List all worktrees with their task name, type, branch, path, and status. The current worktree is marked with `*`.
+
+```sh
+rimba list
+rimba list --type bugfix        # Show only bugfix worktrees
+rimba list --dirty              # Show only dirty worktrees
+rimba list --behind             # Show only worktrees behind upstream
+rimba list --archived           # Show archived branches (not in any active worktree)
+rimba list --json               # Output as JSON
+```
+
+Example output:
+
+```
+TASK            TYPE     BRANCH              PATH              STATUS
+* auth-flow     feature  feature/auth-flow   feature-auth-flow [dirty]
+  fix-login     bugfix   bugfix/fix-login    bugfix-fix-login  ↑2 ↓1
+  ui-cleanup    chore    chore/ui-cleanup    chore-ui-cleanup  ✓
+```
+
+| Flag | Description |
+|------|-------------|
+| `--type` | Filter by prefix type (e.g. `feature`, `bugfix`, `hotfix`, `docs`, `test`, `chore`) |
+| `--dirty` | Show only worktrees with uncommitted changes |
+| `--behind` | Show only worktrees behind their upstream branch |
+| `--archived` | Show archived branches not in any active worktree (mutually exclusive with other filters) |
+
+### rimba status
+
+Show a worktree dashboard with summary stats (total, dirty, stale, behind) and per-worktree age information.
+
+```sh
+rimba status
+rimba status --stale-days 7     # Consider worktrees stale after 7 days
+rimba status --json             # Output as JSON
+```
+
+Example output:
+
+```
+Worktrees: 4  Dirty: 1  Stale: 1  Behind: 0
+
+TASK          TYPE     BRANCH              STATUS    AGE
+  auth-flow   feature  feature/auth-flow   [dirty]   2d
+  fix-login   bugfix   bugfix/fix-login    ✓         5h
+  ui-cleanup  chore    chore/ui-cleanup    ✓         21d ⚠ stale
+  payments    feature  feature/payments    ✓         3d
+```
+
+| Flag | Description |
+|------|-------------|
+| `--stale-days` | Number of days after which a worktree is considered stale (default: 14) |
+
+### rimba log
+
+Show the most recent commit from each worktree, sorted from newest to oldest.
+
+```sh
+rimba log
+rimba log --limit 5             # Show only the 5 most recent entries
+rimba log --since 7d            # Show entries from the last 7 days
+```
+
+Example output:
+
+```
+Recent commits across 3 worktree(s):
+
+TASK          TYPE     AGE    COMMIT
+  auth-flow   feature  5h     Add OAuth2 callback handler
+  payments    feature  3d     Implement Stripe webhook endpoint
+  ui-cleanup  chore    21d    Remove deprecated CSS classes
+```
+
+| Flag | Description |
+|------|-------------|
+| `--limit` | Maximum number of entries to show (default: 0 = all) |
+| `--since` | Show entries since duration (e.g. `7d`, `2w`, `3h`) |
+
+### rimba open
+
+Open a worktree or run a command inside it. When called with just a task name, prints the worktree path. When given additional arguments, executes that command inside the worktree directory. Supports configurable shortcuts via the `[open]` config section.
+
+```sh
+rimba open my-task              # Print worktree path
+cd $(rimba open my-task)        # Navigate to worktree
+rimba open my-task --ide        # Run the 'ide' shortcut
+rimba open my-task --agent      # Run the 'agent' shortcut
+rimba open my-task -w test      # Run a named shortcut
+rimba open my-task npm start    # Run an inline command
+```
+
+| Flag | Description |
+|------|-------------|
+| `--ide` | Run the `ide` shortcut from `[open]` config |
+| `--agent` | Run the `agent` shortcut from `[open]` config |
+| `-w`, `--with` | Run any named shortcut from `[open]` config |
+
+> **Note:** `--ide`, `--agent`, and `--with` are mutually exclusive with each other and with inline command arguments. Shortcuts are configured in the `[open]` section of `.rimba.toml` (see [Configuration](configuration.md)).
+
+---
+
+## Merging & Syncing
+
+### rimba merge
+
+Merge a worktree's branch into main or another worktree. When merging into main, the source worktree and branch are auto-deleted unless `--keep` is set. When merging between worktrees, the source is kept unless `--delete` is set.
+
+```sh
+rimba merge auth                           # Merge into main, delete source
+rimba merge auth --keep                    # Merge into main, keep source
+rimba merge auth --into dashboard          # Merge into worktree, keep source
+rimba merge auth --into dashboard --delete # Merge into worktree, delete source
+rimba merge auth --no-ff                   # Force merge commit
+```
+
+| Flag | Description |
+|------|-------------|
+| `--into` | Target worktree task to merge into (default: main/repo root) |
+| `--no-ff` | Force a merge commit (no fast-forward) |
+| `--keep` | Keep source worktree after merging into main |
+| `--delete` | Delete source worktree after merging into another worktree |
+
+> **Note:** `--keep` and `--delete` are mutually exclusive. Merging to main deletes the source by default; merging to another worktree keeps it by default.
+
+### rimba sync
+
+Sync worktree(s) with the main branch by rebasing (default) or merging. Fetches the latest changes from origin first.
+
+```sh
+rimba sync my-feature                # Rebase a single worktree onto main
+rimba sync my-feature --merge        # Use merge instead of rebase
+rimba sync --all                     # Sync all eligible worktrees
+rimba sync --all --include-inherited # Include duplicate worktrees
+```
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Sync all eligible worktrees (skips dirty and inherited by default) |
+| `--merge` | Use merge instead of rebase |
+| `--include-inherited` | Include inherited/duplicate worktrees when using `--all` |
+
+> **Note:** Dirty worktrees are skipped with a warning. On conflict, the rebase is automatically aborted and a recovery hint is printed.
+
+### rimba merge-plan
+
+Analyze file overlaps between worktree branches and recommend an optimal merge order that minimizes conflicts.
+
+```sh
+rimba merge-plan
+```
+
+Example output:
+
+```
+ORDER  BRANCH       CONFLICTS
+1      fix-login    0
+2      auth-flow    1
+3      ui-cleanup   2
+
+Merge in this order to minimize conflicts.
+```
+
+### rimba conflict-check
+
+Scan all active worktrees and report files modified in multiple branches, indicating potential merge conflicts. Optionally simulate merges with `git merge-tree`.
+
+```sh
+rimba conflict-check
+rimba conflict-check --dry-merge    # Simulate merges with git merge-tree
+```
+
+Example output:
+
+```
+FILE              BRANCHES              SEVERITY
+src/auth.go       auth-flow, fix-login  high
+src/config.go     auth-flow, payments   medium
+
+2 file overlap(s) found across 3 branches.
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-merge` | Simulate merges with `git merge-tree` (requires git 2.38+) |
+
+---
+
+## Bulk Operations
+
+### rimba exec
+
+Run a shell command in parallel across matching worktrees. Requires `--all` or `--type` to select targets.
+
+```sh
+rimba exec "npm test" --all                 # Run in all worktrees
+rimba exec "git status" --type bugfix       # Run in bugfix worktrees only
+rimba exec "npm test" --all --dirty         # Run only in dirty worktrees
+rimba exec "npm test" --all --fail-fast     # Stop after first failure
+rimba exec "npm test" --all --concurrency 4 # Limit to 4 parallel runs
+```
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Run in all eligible worktrees |
+| `--type` | Filter by prefix type (e.g. `feature`, `bugfix`, `hotfix`, `docs`, `test`, `chore`) |
+| `--dirty` | Run only in worktrees with uncommitted changes |
+| `--fail-fast` | Stop execution after the first failure |
+| `--concurrency` | Max parallel executions (default: 0 = unlimited) |
+
+> **Note:** Either `--all` or `--type` is required to select worktrees.
+
+---
+
+## Hooks
+
+### rimba hook
+
+Manage Git hooks for worktree workflow automation. Installs two hooks: a `post-merge` hook for automatic cleanup and a `pre-commit` hook that prevents direct commits to main/master.
+
+#### rimba hook install
+
+Install the rimba Git hooks: a `post-merge` hook that automatically runs `rimba clean --merged --force` after `git pull` (only on the default branch), and a `pre-commit` hook that prevents direct commits to main/master.
+
+```sh
+rimba hook install           # Install both hooks
+```
+
+#### rimba hook uninstall
+
+Remove the rimba post-merge and pre-commit hooks. Preserves any other content in the hook files.
+
+```sh
+rimba hook uninstall         # Remove both rimba hooks
+```
+
+#### rimba hook status
+
+Show whether the rimba post-merge and pre-commit hooks are currently installed.
+
+```sh
+rimba hook status            # Check installation status
+```
+
+> **Note:** `rimba hook` works with or without `rimba init`. The hooks coexist with existing user-defined hooks in the same hook files.
+
+---
+
+## Dependencies
+
+### rimba deps
+
+Manage worktree dependencies — detect lockfiles, clone dependency directories, and install packages.
+
+#### rimba deps status
+
+Show detected dependency modules and lockfile hashes for all worktrees.
+
+```sh
+rimba deps status
+```
+
+Example output:
+
+```
+refs/heads/main (/path/to/repo)
+  node_modules [a1b2c3d4e5f6]
+  vendor [7g8h9i0j1k2l]
+refs/heads/feature/auth (/path/to/worktrees/feature-auth)
+  node_modules [a1b2c3d4e5f6]
+  vendor [7g8h9i0j1k2l]
+```
+
+#### rimba deps install
+
+Detect and install dependencies for a specific worktree. Clones from an existing worktree with a matching lockfile hash, or falls back to the configured install command.
+
+```sh
+rimba deps install my-feature
+```
+
+---
+
+## Maintenance
+
+### rimba clean
+
+Prune stale worktree references, or detect and remove worktrees whose branches have been merged into main or are stale.
+
+```sh
+rimba clean                              # Prune stale worktree references
+rimba clean --dry-run                    # Preview what would be pruned
+rimba clean --merged                     # Detect and remove merged worktrees (with confirmation)
+rimba clean --merged --force             # Remove merged worktrees without confirmation
+rimba clean --merged --dry-run           # Show merged worktrees without removing
+rimba clean --stale                      # Detect and remove stale worktrees (with confirmation)
+rimba clean --stale --stale-days 7       # Use a 7-day threshold instead of 14
+rimba clean --stale --force              # Remove stale worktrees without confirmation
+rimba clean --stale --dry-run            # Show stale worktrees without removing
+```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show what would be pruned/removed without making changes |
+| `--merged` | Detect and remove worktrees whose branches are merged into main |
+| `--stale` | Remove worktrees with no recent commits |
+| `--stale-days` | Number of days to consider a worktree stale (default: 14, used with `--stale`) |
+| `--force` | Skip confirmation prompt when used with `--merged` or `--stale` |
+
+> **Note:** `--merged` and `--stale` are mutually exclusive. `--merged` works with or without `rimba init`. Without a config file, it falls back to auto-detecting the default branch.
+
+---
+
+### rimba update
+
+Check for the latest release on GitHub and update the binary in place.
+
+```sh
+rimba update             # Check and update to latest
+rimba update --force     # Also works on dev builds
+```
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Update even if running a development build |
+
+> **Note:** If the binary cannot be replaced due to file permissions, rimba automatically retries with `sudo`.
+
+---
+
+### rimba version
+
+Print version, commit, and build date.
+
+```sh
+rimba version
+# rimba v0.1.0 (commit: abc1234, built: 2026-01-01T00:00:00Z)
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,75 @@
+# Configuration Reference
+
+> Back to [README](../README.md) | See also: [Command Reference](commands.md)
+
+---
+
+## Overview
+
+`rimba init` creates a `.rimba.toml` file in the repo root. All fields are optional — sensible defaults are applied automatically.
+
+```toml
+worktree_dir = '../myrepo-worktrees'
+default_source = 'main'
+copy_files = ['.env', '.env.local', '.envrc', '.tool-versions', '.vscode']
+
+# Post-create hooks (run in new worktree directory)
+post_create = ['./gradlew build']
+
+# Open shortcuts (used by `rimba open --ide`, `--agent`, `-w`)
+[open]
+ide = 'code .'
+agent = 'claude'
+test = 'npm test'
+
+# Dependency management (optional — auto-detect is on by default)
+[deps]
+auto_detect = true
+
+# Manual module overrides (supplements or overrides auto-detected modules)
+[[deps.modules]]
+dir = 'node_modules'
+lockfile = 'package-lock.json'
+install = 'npm ci'
+
+[[deps.modules]]
+dir = 'api/vendor'
+lockfile = 'api/go.sum'
+install = 'go mod vendor'
+work_dir = 'api'
+```
+
+## Field Reference
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `worktree_dir` | Directory for worktrees (relative to repo root) | `../<repo-name>-worktrees` |
+| `default_source` | Branch to create worktrees from | Default branch (e.g. `main`) |
+| `copy_files` | Files or directories to copy from repo root into new worktrees | `.env`, `.env.local`, `.envrc`, `.tool-versions` |
+| `post_create` | Shell commands to run in new worktrees after creation | (none) |
+| `open.<name>` | Named shortcut command for `rimba open --with <name>` | (none) |
+| `deps.auto_detect` | Auto-detect dependency modules from lockfiles | `true` |
+| `deps.modules[].dir` | Dependency directory to clone (e.g. `node_modules`) | — |
+| `deps.modules[].lockfile` | Lockfile used to match worktrees (e.g. `pnpm-lock.yaml`) | — |
+| `deps.modules[].install` | Install command to run if no matching worktree is found | — |
+| `deps.modules[].work_dir` | Subdirectory to run the install command in | (repo root) |
+
+## Auto-Detected Ecosystems
+
+When `auto_detect` is enabled (default), rimba recognizes these lockfiles automatically:
+
+| Lockfile | Dep directory | Install command | Behavior |
+|----------|---------------|-----------------|----------|
+| `pnpm-lock.yaml` | `node_modules` | `pnpm install --frozen-lockfile` | Recursive clone + install fallback |
+| `yarn.lock` | `node_modules` | `yarn install` | Recursive clone + `.yarn/cache` |
+| `package-lock.json` | `node_modules` | `npm ci` | Recursive clone + install fallback |
+| `go.sum` | `vendor` | `go mod vendor` | Clone only (skip if no match) |
+
+> **Note:** Dependencies are shared using copy-on-write clones (`cp -c` on macOS, `cp --reflink=auto` on Linux) for near-instant copies on supported filesystems (APFS, Btrfs). Falls back to regular copy on other systems.
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `RIMBA_QUIET` | Suppress pre-execution hints (set to any value, e.g. `RIMBA_QUIET=1`) |
+| `NO_COLOR` | Disable colored output globally (per [no-color.org](https://no-color.org)) |


### PR DESCRIPTION
Closes #47

## Summary
- Move detailed command docs, configuration reference, and contributing guide out of README into dedicated files under `docs/`
- Add 7 previously undocumented commands: `status`, `log`, `archive`, `restore`, `merge-plan`, `conflict-check`, `exec`
- Document missing flags (`--stale`, `--stale-days`, `--archived`, `--json`) and organize all commands into 8 functional groups (Setup, Worktree Lifecycle, Inspection, Merging & Syncing, Bulk Operations, Hooks, Dependencies, Maintenance)
- Fix hook docs to accurately describe both post-merge and pre-commit hooks

## Test Plan
- [x] All 7 new commands verified present in `docs/commands.md`
- [x] All new flags verified present (`--stale`, `--stale-days`, `--dry-merge`, `--fail-fast`, `--concurrency`, `--limit`, `--since`, `--json`, `--archived`)
- [x] All 8 group headers verified present
- [x] README command table has all 24 commands in correct order
- [x] `make fmt` — clean
- [x] `make lint` — 0 issues
- [x] `make test` — all pass