### PR TITLE
[ci] Enforce issue reference in PRs and add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+<!-- Describe what changed and why. Use bullet points. -->
+-
+
+## Test Plan
+<!-- How did you verify this works? Check the boxes. -->
+- [ ] Unit tests pass (`make test`)
+- [ ] Linter passes (`make lint`)
+- [ ]
+
+<!-- Link to the GitHub issue this PR addresses.
+     Use: Closes #<number>, Fixes #<number>, or Resolves #<number>
+     For ad-hoc changes without an issue, replace with: N/A -->
+Closes #

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,3 +31,28 @@ jobs:
             echo "::error::PR description must not be empty"
             exit 1
           fi
+
+      - name: Validate issue reference
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Allow ad-hoc PRs that explicitly opt out with "N/A" on its own line
+          if echo "$PR_BODY" | grep -qE '^\s*N/A\s*$'; then
+            echo "Issue reference opted out with N/A — skipping check"
+            exit 0
+          fi
+
+          # Require a GitHub closing keyword (case-insensitive)
+          if ! echo "$PR_BODY" | grep -iqE '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+'; then
+            echo "::error::PR body must reference an issue with a closing keyword"
+            echo ""
+            echo "Add one of these to your PR description:"
+            echo "  Closes #123"
+            echo "  Fixes #123"
+            echo "  Resolves #123"
+            echo ""
+            echo "For ad-hoc changes without an issue, add 'N/A' on its own line."
+            echo ""
+            echo "See: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Add `.github/PULL_REQUEST_TEMPLATE.md` with Summary, Test Plan, and issue reference sections to guide contributors
- Add "Validate issue reference" CI step in `pr.yml` that requires a GitHub closing keyword (`Closes #N`, `Fixes #N`, `Resolves #N`) in PR descriptions
- Support `N/A` opt-out on its own line for ad-hoc PRs without a tracking issue

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Verified all 9 closing keyword variants match (close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved)
- [x] Verified non-closing references are rejected (e.g., "See #123")
- [x] Verified standalone `N/A` triggers opt-out but embedded `N/A` in text does not
- [ ] CI workflow runs on this PR and passes

Closes #65