### PR TITLE
[fix] Respect core.hooksPath in HooksDir resolution

### DIFF
--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -68,6 +68,30 @@ func TestHooksDir(t *testing.T) {
 	}
 }
 
+func TestHooksDirWithCoreHooksPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+
+	// Set core.hooksPath to .githooks
+	testutil.GitCmd(t, repo, "config", "core.hooksPath", ".githooks")
+
+	r := &git.ExecRunner{Dir: repo}
+	dir, err := git.HooksDir(r)
+	if err != nil {
+		t.Fatalf("HooksDir: %v", err)
+	}
+
+	// Resolve symlinks for macOS /private/var vs /var
+	wantDir, _ := filepath.EvalSymlinks(filepath.Join(repo, ".githooks"))
+	gotDir, _ := filepath.EvalSymlinks(dir)
+	if gotDir != wantDir {
+		t.Errorf("HooksDir = %q, want %q", gotDir, wantDir)
+	}
+}
+
 func TestMainRepoRoot(t *testing.T) {
 	if testing.Short() {
 		t.Skip(skipIntegration)


### PR DESCRIPTION
## Summary
- `HooksDir()` now checks `git config core.hooksPath` before falling back to `<git-common-dir>/hooks`
- Relative `core.hooksPath` values are resolved against the main repo root
- E2E tests use a `resolveHooksDir` helper instead of hardcoding `.git/hooks`

## Test Plan
- [x] Unit tests: 3 new mock tests for absolute, relative, and error scenarios
- [x] Integration test: real repo with `core.hooksPath=.githooks`
- [x] E2E test: `TestHookInstallWithCoreHooksPath` verifies install/status/uninstall cycle
- [x] All existing tests pass (`make test` — 0 failures)
- [x] Lint clean (`make lint` — 0 issues)

Closes #68