### PR TITLE
[chore] Add rimba guard hooks to .githooks

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# BEGIN RIMBA HOOK
+# Installed by rimba — do not edit this block manually
+if command -v rimba >/dev/null 2>&1; then
+  _rimba_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  if [ "$_rimba_branch" = "main" ]; then
+    rimba clean --merged --force 2>/dev/null || true
+  fi
+fi
+# END RIMBA HOOK

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -20,3 +20,13 @@ fi
 
 # Run linter
 make lint
+
+# BEGIN RIMBA HOOK
+# Installed by rimba — do not edit this block manually
+_rimba_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ "$_rimba_branch" = "main" ] || [ "$_rimba_branch" = "master" ]; then
+  echo "rimba: direct commits to $_rimba_branch are not allowed."
+  echo "       Use 'rimba add <task>' to create a worktree branch."
+  exit 1
+fi
+# END RIMBA HOOK


### PR DESCRIPTION
## Summary
- Add a **pre-commit hook** block that prevents direct commits to `main`/`master` branches, directing users to use `rimba add <task>` instead
- Add a **post-merge hook** that automatically runs `rimba clean --merged --force` after merging to `main`, cleaning up fully-merged worktrees

N/A

## Test plan
- [x] Verify pre-commit hook blocks commits on `main` branch
- [x] Verify pre-commit hook allows commits on feature branches
- [x] Verify post-merge hook triggers cleanup after merging to `main`
- [x] Verify post-merge hook is a no-op when `rimba` is not installed