### PR TITLE
[feat] Auto-push after rimba sync (#73)

### DIFF
--- a/internal/git/sync.go
+++ b/internal/git/sync.go
@@ -29,3 +29,21 @@ func IsMergeBaseAncestor(r Runner, ancestor, descendant string) bool {
 	_, err := r.Run("merge-base", "--is-ancestor", ancestor, descendant)
 	return err == nil
 }
+
+// HasUpstream checks whether the current branch in dir has a remote tracking branch.
+func HasUpstream(r Runner, dir string) bool {
+	_, err := r.RunInDir(dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+	return err == nil
+}
+
+// Push runs `git push` inside the given directory.
+func Push(r Runner, dir string) error {
+	_, err := r.RunInDir(dir, "push")
+	return err
+}
+
+// PushForceWithLease runs `git push --force-with-lease` inside the given directory.
+func PushForceWithLease(r Runner, dir string) error {
+	_, err := r.RunInDir(dir, "push", "--force-with-lease")
+	return err
+}

--- a/tests/e2e/sync_test.go
+++ b/tests/e2e/sync_test.go
@@ -1,7 +1,10 @@
 package e2e_test
 
 import (
+	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -227,4 +230,223 @@ func TestSyncNoArgsNoAll(t *testing.T) {
 	repo := setupInitializedRepo(t)
 	r := rimbaFail(t, repo, "sync")
 	assertContains(t, r.Stderr, "provide a task name or use --all")
+}
+
+// syncSetupWithRemote creates a test repo backed by a bare remote, initialises rimba,
+// adds a worktree, pushes its branch to set up upstream tracking, then commits on main
+// (via the bare repo round-trip) so there's something to sync.
+// Returns (repo path, worktree path, bare remote path).
+func syncSetupWithRemote(t *testing.T, task string) (string, string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	// 1. Create a bare repo as fake origin.
+	bareDir := filepath.Join(dir, "origin.git")
+	if err := os.MkdirAll(bareDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitBare(t, bareDir, "init", "--bare", "-b", "main")
+
+	// 2. Clone the bare repo to create the working repo.
+	repo := filepath.Join(dir, "repo")
+	cmd := exec.Command("git", "clone", bareDir, repo)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clone: %s: %v", out, err)
+	}
+	testutil.GitCmd(t, repo, "config", "user.email", "test@test.com")
+	testutil.GitCmd(t, repo, "config", "user.name", "Test")
+
+	// Create initial commit and push to origin.
+	testutil.CreateFile(t, repo, "README.md", "# Test\n")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "initial commit")
+	testutil.GitCmd(t, repo, "push", "-u", "origin", "main")
+
+	// 3. rimba init + commit artifacts
+	rimbaSuccess(t, repo, "init")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "rimba init")
+	testutil.GitCmd(t, repo, "push")
+
+	// 4. rimba add <task>
+	rimbaSuccess(t, repo, "add", task)
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.BranchName(defaultPrefix, task)
+	wtPath := resolver.WorktreePath(wtDir, branch)
+
+	// 5. Push the worktree branch to set upstream tracking.
+	testutil.GitCmd(t, wtPath, "push", "-u", "origin", branch)
+
+	// 6. Commit on main so there's something to sync.
+	testutil.CreateFile(t, repo, fileFromMain, contentMainChg)
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", commitUpdateMsg)
+	testutil.GitCmd(t, repo, "push")
+
+	return repo, wtPath, bareDir
+}
+
+// gitBare runs a git command in the bare repository.
+func gitBare(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %s: %v", args, dir, out, err)
+	}
+	return string(out)
+}
+
+// bareRepoHEAD returns the HEAD commit SHA of a branch in the bare repo.
+func bareRepoHEAD(t *testing.T, bareDir, branch string) string {
+	t.Helper()
+	return strings.TrimSpace(gitBare(t, bareDir, "rev-parse", branch))
+}
+
+func TestSyncPushDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, wtPath, bareDir := syncSetupWithRemote(t, "push-default")
+	branch := resolver.BranchName(defaultPrefix, "push-default")
+
+	// Get worktree HEAD before sync
+	beforeSHA := strings.TrimSpace(testutil.GitCmd(t, wtPath, "rev-parse", "HEAD"))
+
+	r := rimbaSuccess(t, repo, "sync", "push-default")
+	assertContains(t, r.Stdout, "Rebased")
+	assertContains(t, r.Stdout, "Pushed")
+
+	// Verify remote branch was updated (different from before sync)
+	remoteSHA := bareRepoHEAD(t, bareDir, branch)
+	if remoteSHA == beforeSHA {
+		t.Error("expected remote branch to be updated after sync+push")
+	}
+
+	// Verify worktree HEAD matches remote
+	localSHA := strings.TrimSpace(testutil.GitCmd(t, wtPath, "rev-parse", "HEAD"))
+	if remoteSHA != localSHA {
+		t.Errorf("remote SHA %q != local SHA %q", remoteSHA, localSHA)
+	}
+}
+
+func TestSyncPushDefaultMerge(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, wtPath, bareDir := syncSetupWithRemote(t, "push-merge")
+	branch := resolver.BranchName(defaultPrefix, "push-merge")
+
+	r := rimbaSuccess(t, repo, "sync", "push-merge", "--merge")
+	assertContains(t, r.Stdout, "Merged")
+	assertContains(t, r.Stdout, "Pushed")
+
+	// Verify remote branch was updated
+	remoteSHA := bareRepoHEAD(t, bareDir, branch)
+	localSHA := strings.TrimSpace(testutil.GitCmd(t, wtPath, "rev-parse", "HEAD"))
+	if remoteSHA != localSHA {
+		t.Errorf("remote SHA %q != local SHA %q", remoteSHA, localSHA)
+	}
+}
+
+func TestSyncNoPush(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, _, bareDir := syncSetupWithRemote(t, "no-push")
+	branch := resolver.BranchName(defaultPrefix, "no-push")
+
+	// Record remote SHA before sync
+	beforeSHA := bareRepoHEAD(t, bareDir, branch)
+
+	r := rimbaSuccess(t, repo, "sync", "no-push", "--no-push")
+	assertContains(t, r.Stdout, "Rebased")
+	assertNotContains(t, r.Stdout, "Pushed")
+
+	// Verify remote branch was NOT updated
+	afterSHA := bareRepoHEAD(t, bareDir, branch)
+	if afterSHA != beforeSHA {
+		t.Errorf("expected remote unchanged, but SHA changed from %q to %q", beforeSHA, afterSHA)
+	}
+}
+
+func TestSyncPushNoUpstream(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	// Use syncSetup which has no remote — push should be silently skipped
+	repo, _ := syncSetup(t, "push-noup")
+
+	r := rimbaSuccess(t, repo, "sync", "push-noup")
+	assertContains(t, r.Stdout, "Rebased")
+	// "Pushed <branch> to origin" should NOT appear since there's no upstream
+	assertNotContains(t, r.Stdout, "Pushed "+defaultPrefix+"push-noup")
+	// No push error should appear
+	assertNotContains(t, r.Stderr, "push failed")
+}
+
+func TestSyncAllPushDefault(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	dir := t.TempDir()
+
+	// Create bare repo
+	bareDir := filepath.Join(dir, "origin.git")
+	if err := os.MkdirAll(bareDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitBare(t, bareDir, "init", "--bare", "-b", "main")
+
+	// Clone
+	repo := filepath.Join(dir, "repo")
+	cloneCmd := exec.Command("git", "clone", bareDir, repo)
+	if out, err := cloneCmd.CombinedOutput(); err != nil {
+		t.Fatalf("clone: %s: %v", out, err)
+	}
+	testutil.GitCmd(t, repo, "config", "user.email", "test@test.com")
+	testutil.GitCmd(t, repo, "config", "user.name", "Test")
+
+	testutil.CreateFile(t, repo, "README.md", "# Test\n")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "initial commit")
+	testutil.GitCmd(t, repo, "push", "-u", "origin", "main")
+
+	rimbaSuccess(t, repo, "init")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "rimba init")
+	testutil.GitCmd(t, repo, "push")
+
+	// Add two worktrees with upstream
+	rimbaSuccess(t, repo, "add", "sync-push-1")
+	rimbaSuccess(t, repo, "add", "sync-push-2")
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+
+	branch1 := resolver.BranchName(defaultPrefix, "sync-push-1")
+	branch2 := resolver.BranchName(defaultPrefix, "sync-push-2")
+	wt1 := resolver.WorktreePath(wtDir, branch1)
+	wt2 := resolver.WorktreePath(wtDir, branch2)
+
+	testutil.GitCmd(t, wt1, "push", "-u", "origin", branch1)
+	testutil.GitCmd(t, wt2, "push", "-u", "origin", branch2)
+
+	// Commit on main
+	testutil.CreateFile(t, repo, fileFromMain, contentMainChg)
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", commitUpdateMsg)
+	testutil.GitCmd(t, repo, "push")
+
+	r := rimbaSuccess(t, repo, "sync", "--all")
+	assertContains(t, r.Stdout, "2 pushed")
 }


### PR DESCRIPTION
## Summary
- Push is now the default behavior after `rimba sync`; use `--no-push` to opt out
- Rebase uses `git push --force-with-lease` (safe — refuses if remote was updated by someone else), merge uses `git push`
- Silently skips push when no upstream tracking branch is configured
- `--all` summary includes pushed and push-failed counts with recovery hints

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)
- [x] New sync push tests cover: default push, merge push, `--no-push`, no-upstream skip, `--all` push

Closes #73