### PR TITLE
[feat] Add --personal flag to rimba init (#46)

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -336,6 +336,141 @@ func TestInitWithoutFlagSkipsAgentFiles(t *testing.T) {
 	}
 }
 
+func TestInitPersonalFreshInit(t *testing.T) {
+	repoDir := t.TempDir()
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().Bool(flagPersonal, true, "")
+
+	if err := initCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("initCmd.RunE: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Initialized rimba") {
+		t.Errorf("output = %q, want 'Initialized rimba'", out)
+	}
+
+	// Verify .rimba/settings.toml was created
+	teamPath := filepath.Join(repoDir, config.DirName, config.TeamFile)
+	if _, err := os.Stat(teamPath); os.IsNotExist(err) {
+		t.Errorf("settings.toml not created at %s", teamPath)
+	}
+
+	// Verify .rimba/settings.local.toml was NOT created
+	localPath := filepath.Join(repoDir, config.DirName, config.LocalFile)
+	if _, err := os.Stat(localPath); err == nil {
+		t.Error("settings.local.toml should not be created in personal mode")
+	}
+
+	// Verify .gitignore has .rimba/ not .rimba/settings.local.toml
+	data, err := os.ReadFile(filepath.Join(repoDir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	dirEntry := config.DirName + "/"
+	if !strings.Contains(content, dirEntry) {
+		t.Errorf(".gitignore should contain %q, got:\n%s", dirEntry, content)
+	}
+	localEntry := filepath.Join(config.DirName, config.LocalFile)
+	if strings.Contains(content, localEntry) {
+		t.Errorf(".gitignore should not contain %q in personal mode, got:\n%s", localEntry, content)
+	}
+}
+
+func TestInitPersonalMigration(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// Pre-create legacy .rimba.toml
+	legacyCfg := &config.Config{WorktreeDir: "../wt", DefaultSource: "main"}
+	if err := config.Save(filepath.Join(repoDir, config.FileName), legacyCfg); err != nil {
+		t.Fatalf("save legacy config: %v", err)
+	}
+
+	// Pre-create .gitignore with legacy entry
+	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte(config.FileName+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().Bool(flagPersonal, true, "")
+
+	if err := initCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("initCmd.RunE: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Migrated rimba config") {
+		t.Errorf("output should contain 'Migrated rimba config', got:\n%s", out)
+	}
+
+	// Verify legacy file is gone
+	if _, err := os.Stat(filepath.Join(repoDir, config.FileName)); !os.IsNotExist(err) {
+		t.Error("legacy .rimba.toml should have been removed")
+	}
+
+	// Verify .rimba/settings.toml exists and is loadable
+	cfg, err := config.LoadDir(filepath.Join(repoDir, config.DirName))
+	if err != nil {
+		t.Fatalf("LoadDir after migration: %v", err)
+	}
+	if cfg.WorktreeDir != "../wt" {
+		t.Errorf("WorktreeDir = %q, want %q", cfg.WorktreeDir, "../wt")
+	}
+
+	// Verify .rimba/settings.local.toml was NOT created
+	localPath := filepath.Join(repoDir, config.DirName, config.LocalFile)
+	if _, err := os.Stat(localPath); err == nil {
+		t.Error("settings.local.toml should not be created in personal mode")
+	}
+
+	// Verify .gitignore updated with .rimba/ not legacy entry
+	data, err := os.ReadFile(filepath.Join(repoDir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if strings.Contains(content, config.FileName) {
+		t.Error(".gitignore should not contain legacy entry after migration")
+	}
+	dirEntry := config.DirName + "/"
+	if !strings.Contains(content, dirEntry) {
+		t.Errorf(".gitignore should contain %q, got:\n%s", dirEntry, content)
+	}
+	localEntry := filepath.Join(config.DirName, config.LocalFile)
+	if strings.Contains(content, localEntry) {
+		t.Errorf(".gitignore should not contain %q in personal mode, got:\n%s", localEntry, content)
+	}
+}
+
 func TestInitRepoRootError(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	skipE2E       = "skipping e2e test"
+	branchMain    = "main"
 	defaultPrefix = "feature/"
 	bugfixPrefix  = "bugfix/"
 	configFile    = ".rimba.toml" // legacy — kept for migration tests


### PR DESCRIPTION
## Summary
- Add `--personal` flag to `rimba init` that gitignores the entire `.rimba/` directory instead of just `settings.local.toml`
- In personal mode, `settings.local.toml` is not created since the whole directory is already personal
- Works with both fresh init and legacy migration flows

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] `rimba init --personal` creates `.rimba/settings.toml` and gitignores `.rimba/`
- [x] `rimba init --personal` does NOT create `settings.local.toml`
- [x] `rimba init --personal` with legacy `.rimba.toml` migrates correctly
- [x] Existing `rimba init` (team mode) behavior unchanged

Closes #46