### PR TITLE
[feat] Auto-derive opinionated config fields

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -101,7 +101,10 @@ directory is already personal.`,
 				return err
 			}
 
-			cfg := config.DefaultConfig(repoName, defaultBranch)
+			// Write minimal config — only copy_files (everything else auto-derived)
+			cfg := &config.Config{
+				CopyFiles: config.DefaultCopyFiles(),
+			}
 
 			if err := os.MkdirAll(dirPath, 0750); err != nil {
 				return fmt.Errorf("failed to create config directory: %w", err)
@@ -117,8 +120,8 @@ directory is already personal.`,
 				}
 			}
 
-			// Create the worktree directory
-			wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
+			// Create the worktree directory using convention
+			wtDir := filepath.Join(repoRoot, config.DefaultWorktreeDir(repoName))
 			if err := os.MkdirAll(wtDir, 0750); err != nil {
 				return fmt.Errorf("failed to create worktree directory: %w", err)
 			}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -54,7 +54,7 @@ func TestInitSuccess(t *testing.T) {
 
 	// Verify worktree dir was created
 	repoName := filepath.Base(repoDir)
-	wtDir := filepath.Join(repoDir, "../"+repoName+"-worktrees")
+	wtDir := filepath.Join(repoDir, config.DefaultWorktreeDir(repoName))
 	if _, err := os.Stat(wtDir); os.IsNotExist(err) {
 		t.Errorf("worktree dir not created at %s", wtDir)
 	}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"path/filepath"
+
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/git"
 	mcppkg "github.com/lugassawan/rimba/internal/mcp"
@@ -33,6 +35,14 @@ To configure in Claude Code, add to .claude/settings.json:
 
 		// Config is optional — some tools work without it.
 		cfg, _ := config.Resolve(repoRoot)
+		if cfg != nil {
+			repoName := filepath.Base(repoRoot)
+			var defaultBranch string
+			if cfg.DefaultSource == "" {
+				defaultBranch, _ = git.DefaultBranch(r)
+			}
+			cfg.FillDefaults(repoName, defaultBranch)
+		}
 
 		hctx := &mcppkg.HandlerContext{
 			Runner:   r,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -57,6 +58,18 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		// Auto-derive missing fields
+		repoName := filepath.Base(repoRoot)
+		var defaultBranch string
+		if cfg.DefaultSource == "" {
+			defaultBranch, err = git.DefaultBranch(r)
+			if err != nil {
+				return err
+			}
+		}
+		cfg.FillDefaults(repoName, defaultBranch)
+
 		cmd.SetContext(config.WithConfig(cmd.Context(), cfg))
 		return nil
 	},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,7 @@ import (
 const (
 	testRepoName      = "test-repo"
 	testDefaultBranch = "main"
+	testDevelopBranch = "develop"
 	fatalSave         = "Save: %v"
 	fatalLoad         = "Load: %v"
 )
@@ -31,6 +32,62 @@ func TestDefaultConfig(t *testing.T) {
 	if !reflect.DeepEqual(cfg.CopyFiles, expected) {
 		t.Errorf("CopyFiles = %v, want %v", cfg.CopyFiles, expected)
 	}
+}
+
+func TestDefaultCopyFiles(t *testing.T) {
+	got := config.DefaultCopyFiles()
+	expected := []string{".env", ".env.local", ".envrc", ".tool-versions"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("DefaultCopyFiles() = %v, want %v", got, expected)
+	}
+}
+
+func TestFillDefaults(t *testing.T) {
+	t.Run("fills all empty fields", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.FillDefaults("myrepo", testDefaultBranch)
+
+		if cfg.WorktreeDir != "../myrepo-worktrees" {
+			t.Errorf("WorktreeDir = %q, want %q", cfg.WorktreeDir, "../myrepo-worktrees")
+		}
+		if cfg.DefaultSource != testDefaultBranch {
+			t.Errorf("DefaultSource = %q, want %q", cfg.DefaultSource, testDefaultBranch)
+		}
+		expected := config.DefaultCopyFiles()
+		if !reflect.DeepEqual(cfg.CopyFiles, expected) {
+			t.Errorf("CopyFiles = %v, want %v", cfg.CopyFiles, expected)
+		}
+	})
+
+	t.Run("preserves explicit values", func(t *testing.T) {
+		cfg := &config.Config{
+			WorktreeDir:   "../custom-wt",
+			DefaultSource: testDevelopBranch,
+			CopyFiles:     []string{".env"},
+		}
+		cfg.FillDefaults("myrepo", testDefaultBranch)
+
+		if cfg.WorktreeDir != "../custom-wt" {
+			t.Errorf("WorktreeDir = %q, want %q", cfg.WorktreeDir, "../custom-wt")
+		}
+		if cfg.DefaultSource != testDevelopBranch {
+			t.Errorf("DefaultSource = %q, want %q", cfg.DefaultSource, testDevelopBranch)
+		}
+		if !reflect.DeepEqual(cfg.CopyFiles, []string{".env"}) {
+			t.Errorf("CopyFiles = %v, want [.env]", cfg.CopyFiles)
+		}
+	})
+
+	t.Run("preserves explicitly empty CopyFiles", func(t *testing.T) {
+		cfg := &config.Config{
+			CopyFiles: []string{}, // explicitly empty — should NOT be overridden
+		}
+		cfg.FillDefaults("myrepo", testDefaultBranch)
+
+		if cfg.CopyFiles == nil || len(cfg.CopyFiles) != 0 {
+			t.Errorf("CopyFiles = %v, want empty non-nil slice", cfg.CopyFiles)
+		}
+	})
 }
 
 func TestSaveAndLoad(t *testing.T) {
@@ -92,65 +149,57 @@ func TestFromContextNil(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	tests := []struct {
-		name    string
-		cfg     config.Config
-		wantErr string
+		name string
+		cfg  config.Config
 	}{
 		{
-			name: "valid config",
+			name: "fully populated config",
 			cfg:  config.Config{WorktreeDir: "../worktrees", DefaultSource: testDefaultBranch},
 		},
 		{
-			name:    "empty worktree_dir",
-			cfg:     config.Config{DefaultSource: testDefaultBranch},
-			wantErr: config.ErrMsgEmptyWorktreeDir,
+			name: "empty worktree_dir is valid",
+			cfg:  config.Config{DefaultSource: testDefaultBranch},
 		},
 		{
-			name:    "empty default_source",
-			cfg:     config.Config{WorktreeDir: "../worktrees"},
-			wantErr: config.ErrMsgEmptyDefaultSource,
+			name: "empty default_source is valid",
+			cfg:  config.Config{WorktreeDir: "../worktrees"},
 		},
 		{
-			name:    "both empty",
-			cfg:     config.Config{},
-			wantErr: config.ErrMsgEmptyWorktreeDir,
+			name: "all empty is valid",
+			cfg:  config.Config{},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.cfg.Validate()
-			if tt.wantErr == "" {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatal("expected error, got nil")
-			}
-			if !strings.Contains(err.Error(), tt.wantErr) {
-				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
+			if err := tt.cfg.Validate(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 		})
 	}
 }
 
-func TestLoadInvalidValues(t *testing.T) {
+func TestLoadMinimalConfig(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, config.FileName)
 
-	// Valid TOML but missing required fields
+	// Valid TOML with only copy_files — empty worktree_dir/default_source is now valid
 	if err := os.WriteFile(path, []byte("copy_files = ['.env']\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err := config.Load(path)
-	if err == nil {
-		t.Fatal("expected error for missing required fields")
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), config.ErrMsgEmptyWorktreeDir) {
-		t.Errorf("error %q does not mention worktree_dir", err.Error())
+	if len(cfg.CopyFiles) != 1 || cfg.CopyFiles[0] != ".env" {
+		t.Errorf("CopyFiles = %v, want [.env]", cfg.CopyFiles)
+	}
+	if cfg.WorktreeDir != "" {
+		t.Errorf("WorktreeDir = %q, want empty", cfg.WorktreeDir)
+	}
+	if cfg.DefaultSource != "" {
+		t.Errorf("DefaultSource = %q, want empty", cfg.DefaultSource)
 	}
 }
 
@@ -226,14 +275,14 @@ func TestLoadWithoutOpenSection(t *testing.T) {
 
 func TestMergeScalarOverrides(t *testing.T) {
 	team := &config.Config{WorktreeDir: "../wt", DefaultSource: testDefaultBranch}
-	local := &config.Config{WorktreeDir: "../local-wt", DefaultSource: "develop"}
+	local := &config.Config{WorktreeDir: "../local-wt", DefaultSource: testDevelopBranch}
 
 	merged := config.Merge(team, local)
 	if merged.WorktreeDir != "../local-wt" {
 		t.Errorf("WorktreeDir = %q, want %q", merged.WorktreeDir, "../local-wt")
 	}
-	if merged.DefaultSource != "develop" {
-		t.Errorf("DefaultSource = %q, want %q", merged.DefaultSource, "develop")
+	if merged.DefaultSource != testDevelopBranch {
+		t.Errorf("DefaultSource = %q, want %q", merged.DefaultSource, testDevelopBranch)
 	}
 }
 
@@ -326,7 +375,7 @@ func TestMergeInputsNotMutated(t *testing.T) {
 		DefaultSource: testDefaultBranch,
 	}
 	local := &config.Config{
-		DefaultSource: "develop",
+		DefaultSource: testDevelopBranch,
 	}
 
 	_ = config.Merge(team, local)
@@ -370,7 +419,7 @@ func TestLoadDirTeamAndLocal(t *testing.T) {
 		t.Fatalf(fatalSave, err)
 	}
 
-	local := &config.Config{DefaultSource: "develop"}
+	local := &config.Config{DefaultSource: testDevelopBranch}
 	if err := config.Save(filepath.Join(rimbaDir, config.LocalFile), local); err != nil {
 		t.Fatalf(fatalSave, err)
 	}
@@ -379,8 +428,8 @@ func TestLoadDirTeamAndLocal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadDir: %v", err)
 	}
-	if cfg.DefaultSource != "develop" {
-		t.Errorf("DefaultSource = %q, want %q", cfg.DefaultSource, "develop")
+	if cfg.DefaultSource != testDevelopBranch {
+		t.Errorf("DefaultSource = %q, want %q", cfg.DefaultSource, testDevelopBranch)
 	}
 	if cfg.WorktreeDir != team.WorktreeDir {
 		t.Errorf("WorktreeDir = %q, want %q", cfg.WorktreeDir, team.WorktreeDir)
@@ -429,24 +478,24 @@ func TestLoadDirMissingTeamFile(t *testing.T) {
 	}
 }
 
-func TestLoadDirValidationError(t *testing.T) {
+func TestLoadDirMinimalConfig(t *testing.T) {
 	dir := t.TempDir()
 	rimbaDir := filepath.Join(dir, config.DirName)
 	if err := os.MkdirAll(rimbaDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 
-	// Write invalid config (missing required fields)
+	// Minimal config with only copy_files — now valid (fields auto-derived later)
 	if err := os.WriteFile(filepath.Join(rimbaDir, config.TeamFile), []byte("copy_files = ['.env']\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err := config.LoadDir(rimbaDir)
-	if err == nil {
-		t.Fatal("expected validation error")
+	cfg, err := config.LoadDir(rimbaDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), config.ErrMsgEmptyWorktreeDir) {
-		t.Errorf("error = %q, want substring %q", err.Error(), config.ErrMsgEmptyWorktreeDir)
+	if len(cfg.CopyFiles) != 1 || cfg.CopyFiles[0] != ".env" {
+		t.Errorf("CopyFiles = %v, want [.env]", cfg.CopyFiles)
 	}
 }
 

--- a/tests/e2e/add_test.go
+++ b/tests/e2e/add_test.go
@@ -420,12 +420,14 @@ func TestAddShowsSkippedFiles(t *testing.T) {
 }
 
 // loadConfig is a test helper that loads the rimba config from a repo.
+// It calls FillDefaults to auto-derive missing fields (worktree_dir, default_source).
 func loadConfig(t *testing.T, repo string) *config.Config {
 	t.Helper()
 	cfg, err := config.Resolve(repo)
 	if err != nil {
 		t.Fatalf("failed to load config: %v", err)
 	}
+	cfg.FillDefaults(filepath.Base(repo), branchMain)
 	return cfg
 }
 


### PR DESCRIPTION
Closes #80

## Summary
- Add `FillDefaults` method and `DefaultCopyFiles` function to config package for auto-deriving `worktree_dir`, `default_source`, and `copy_files` when not explicitly set
- `rimba init` now writes minimal config (only `copy_files`) — `worktree_dir` and `default_source` are auto-derived at runtime
- Existing configs with explicit values continue working unchanged (backward compatible)

## Changes
- **`internal/config/config.go`**: Add `FillDefaults`, `DefaultCopyFiles`; add `omitempty` to TOML tags for `worktree_dir`/`default_source`; relax `Validate`; update `DefaultConfig` to use `FillDefaults`
- **`cmd/root.go`**: Call `FillDefaults` in `PersistentPreRunE` after `config.Resolve`
- **`cmd/mcp.go`**: Call `FillDefaults` when config is available
- **`cmd/init.go`**: Write minimal config (only `copy_files`); derive worktree dir inline
- **Tests**: New `TestFillDefaults`, `TestDefaultCopyFiles`; updated validation and e2e tests

## Test Plan
- [x] `make fmt` — clean
- [x] `make lint` — 0 issues
- [x] `make test` — all 18 packages pass, 0 failures
- [x] Fresh `rimba init` writes only `copy_files` to settings.toml
- [x] `rimba add` works with minimal config (auto-derives worktree_dir and default_source)
- [x] Existing configs with explicit values still work (backward compat)