### PR TITLE
[docs] Fix stale documentation

### DIFF
--- a/.claude/skills/rimba/SKILL.md
+++ b/.claude/skills/rimba/SKILL.md
@@ -22,8 +22,8 @@ curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/insta
 | See all worktrees | `rimba list` or `rimba list --json` |
 | Check worktree health | `rimba status` |
 | Navigate to a worktree | `cd $(rimba open <task>)` |
-| Update from source branch | `rimba sync <task>` or `rimba sync` (all) |
-| Finish a feature | `rimba merge <task>` then `rimba remove <task>` |
+| Update from source branch | `rimba sync <task>` or `rimba sync --all` |
+| Finish a feature | `rimba merge <task>` (auto-removes worktree) |
 | Clean up merged work | `rimba clean --merged` |
 | Pause a task | `rimba archive <task>` (keeps branch) |
 | Run across worktrees | `rimba exec "<cmd>"` |

--- a/.cursor/rules/rimba.mdc
+++ b/.cursor/rules/rimba.mdc
@@ -16,8 +16,8 @@ See AGENTS.md at the repo root for full documentation.
 2. `rimba list` — list all worktrees
 3. `rimba status` — health overview (dirty, stale, behind)
 4. `rimba open <task>` — print path or run shortcut (--ide, --agent)
-5. `rimba sync [task]` — rebase worktree(s) onto source
-6. `rimba merge <task>` — fast-forward merge into source
+5. `rimba sync [task]` — rebase worktree(s) onto main
+6. `rimba merge <task>` — merge into main and auto-clean up
 7. `rimba remove <task>` — delete worktree + branch
 8. `rimba archive <task>` — remove worktree, keep branch
 9. `rimba exec <cmd>` — run across all worktrees
@@ -27,7 +27,7 @@ See AGENTS.md at the repo root for full documentation.
 ## Workflow Recipes
 
 **New feature:** `rimba add <task>` then work in the worktree directory.
-**Finish feature:** `rimba merge <task>` then `rimba remove <task>`.
+**Finish feature:** `rimba merge <task>` (auto-removes worktree).
 **Housekeeping:** `rimba status` then `rimba clean --merged`.
 
 ## JSON Output

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ See AGENTS.md at the repo root for full rimba documentation.
 
 - `rimba add <task>` — create worktree
 - `rimba list` / `rimba status` — inspect worktrees
-- `rimba merge <task>` — merge back to source branch
+- `rimba merge <task>` — merge into main and auto-clean up
 - `rimba clean --merged` — remove merged worktrees
 - `rimba exec <cmd>` — run command across all worktrees
 - `rimba mcp` — start MCP server for AI tool integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/insta
 | Concern | Commands |
 |---------|----------|
 | Create & navigate | `rimba add <task>`, `rimba open <task>` |
-| Inspect | `rimba list`, `rimba status`, `rimba log [task]` |
+| Inspect | `rimba list`, `rimba status`, `rimba log` |
 | Sync & merge | `rimba sync [task]`, `rimba merge <task>` |
 | Clean up | `rimba clean --merged`, `rimba archive <task>`, `rimba remove <task>` |
 | Cross-cutting | `rimba exec <cmd>`, `rimba conflict-check`, `rimba deps status` |
@@ -43,8 +43,7 @@ rimba clean --merged        # remove worktrees whose branches are merged
 
 **Merge and clean up:**
 ```sh
-rimba merge my-feature      # fast-forward merge into source branch
-rimba remove my-feature     # remove worktree + branch
+rimba merge my-feature      # merge into main and auto-clean up
 ```
 
 ## JSON Output

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -514,7 +514,7 @@ rimba update --force     # Also works on dev builds
 |------|-------------|
 | `--force` | Update even if running a development build |
 
-> **Note:** If the binary cannot be replaced due to file permissions, rimba automatically retries with `sudo`.
+> **Note:** If the binary cannot be replaced due to file permissions, rimba installs to `~/.local/bin` instead.
 
 ---
 

--- a/internal/agentfile/content.go
+++ b/internal/agentfile/content.go
@@ -28,7 +28,7 @@ curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/insta
 | Concern | Commands |
 |---------|----------|
 | Create & navigate | ` + "`" + `rimba add <task>` + "`" + `, ` + "`" + `rimba open <task>` + "`" + ` |
-| Inspect | ` + "`" + `rimba list` + "`" + `, ` + "`" + `rimba status` + "`" + `, ` + "`" + `rimba log [task]` + "`" + ` |
+| Inspect | ` + "`" + `rimba list` + "`" + `, ` + "`" + `rimba status` + "`" + `, ` + "`" + `rimba log` + "`" + ` |
 | Sync & merge | ` + "`" + `rimba sync [task]` + "`" + `, ` + "`" + `rimba merge <task>` + "`" + ` |
 | Clean up | ` + "`" + `rimba clean --merged` + "`" + `, ` + "`" + `rimba archive <task>` + "`" + `, ` + "`" + `rimba remove <task>` + "`" + ` |
 | Cross-cutting | ` + "`" + `rimba exec <cmd>` + "`" + `, ` + "`" + `rimba conflict-check` + "`" + `, ` + "`" + `rimba deps status` + "`" + ` |
@@ -50,8 +50,7 @@ rimba clean --merged        # remove worktrees whose branches are merged
 
 **Merge and clean up:**
 ` + "```" + `sh
-rimba merge my-feature      # fast-forward merge into source branch
-rimba remove my-feature     # remove worktree + branch
+rimba merge my-feature      # merge into main and auto-clean up
 ` + "```" + `
 
 ## JSON Output
@@ -83,7 +82,7 @@ See AGENTS.md at the repo root for full rimba documentation.
 
 - ` + "`" + `rimba add <task>` + "`" + ` — create worktree
 - ` + "`" + `rimba list` + "`" + ` / ` + "`" + `rimba status` + "`" + ` — inspect worktrees
-- ` + "`" + `rimba merge <task>` + "`" + ` — merge back to source branch
+- ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
 - ` + "`" + `rimba clean --merged` + "`" + ` — remove merged worktrees
 - ` + "`" + `rimba exec <cmd>` + "`" + ` — run command across all worktrees
 - ` + "`" + `rimba mcp` + "`" + ` — start MCP server for AI tool integration
@@ -124,8 +123,8 @@ See AGENTS.md at the repo root for full documentation.
 2. ` + "`" + `rimba list` + "`" + ` — list all worktrees
 3. ` + "`" + `rimba status` + "`" + ` — health overview (dirty, stale, behind)
 4. ` + "`" + `rimba open <task>` + "`" + ` — print path or run shortcut (--ide, --agent)
-5. ` + "`" + `rimba sync [task]` + "`" + ` — rebase worktree(s) onto source
-6. ` + "`" + `rimba merge <task>` + "`" + ` — fast-forward merge into source
+5. ` + "`" + `rimba sync [task]` + "`" + ` — rebase worktree(s) onto main
+6. ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
 7. ` + "`" + `rimba remove <task>` + "`" + ` — delete worktree + branch
 8. ` + "`" + `rimba archive <task>` + "`" + ` — remove worktree, keep branch
 9. ` + "`" + `rimba exec <cmd>` + "`" + ` — run across all worktrees
@@ -135,7 +134,7 @@ See AGENTS.md at the repo root for full documentation.
 ## Workflow Recipes
 
 **New feature:** ` + "`" + `rimba add <task>` + "`" + ` then work in the worktree directory.
-**Finish feature:** ` + "`" + `rimba merge <task>` + "`" + ` then ` + "`" + `rimba remove <task>` + "`" + `.
+**Finish feature:** ` + "`" + `rimba merge <task>` + "`" + ` (auto-removes worktree).
 **Housekeeping:** ` + "`" + `rimba status` + "`" + ` then ` + "`" + `rimba clean --merged` + "`" + `.
 
 ## JSON Output
@@ -177,8 +176,8 @@ curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/insta
 | See all worktrees | ` + "`" + `rimba list` + "`" + ` or ` + "`" + `rimba list --json` + "`" + ` |
 | Check worktree health | ` + "`" + `rimba status` + "`" + ` |
 | Navigate to a worktree | ` + "`" + `cd $(rimba open <task>)` + "`" + ` |
-| Update from source branch | ` + "`" + `rimba sync <task>` + "`" + ` or ` + "`" + `rimba sync` + "`" + ` (all) |
-| Finish a feature | ` + "`" + `rimba merge <task>` + "`" + ` then ` + "`" + `rimba remove <task>` + "`" + ` |
+| Update from source branch | ` + "`" + `rimba sync <task>` + "`" + ` or ` + "`" + `rimba sync --all` + "`" + ` |
+| Finish a feature | ` + "`" + `rimba merge <task>` + "`" + ` (auto-removes worktree) |
 | Clean up merged work | ` + "`" + `rimba clean --merged` + "`" + ` |
 | Pause a task | ` + "`" + `rimba archive <task>` + "`" + ` (keeps branch) |
 | Run across worktrees | ` + "`" + `rimba exec "<cmd>"` + "`" + ` |


### PR DESCRIPTION
## Summary
- Fix incorrect sudo claim in `rimba update` docs — actually falls back to `~/.local/bin`
- Fix misleading "merge then remove" recipe — `rimba merge` auto-cleans up
- Fix `rimba log [task]` — `log` takes no positional arguments
- Fix `rimba sync` (all) syntax — correct form is `rimba sync --all`
- Fix "merge into source branch" terminology — actually merges into main
- Update both checked-in docs and `internal/agentfile/content.go` templates, plus generated files (`.cursor/rules/rimba.mdc`, `.github/copilot-instructions.md`)

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Grep confirms no remaining stale patterns

N/A