### PR TITLE
[feat] Add monorepo support for service-scoped worktrees

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -37,8 +37,6 @@ var addCmd = &cobra.Command{
 		service, task := operations.ResolveTaskInput(args[0], repoRoot)
 		prefix := resolvedPrefixString(cmd)
 
-		// If no explicit prefix flag was set and the input starts with a known prefix,
-		// use that prefix from the input
 		if !hasExplicitPrefixFlag(cmd) {
 			if candidate, _ := resolver.SplitServiceInput(args[0]); resolver.ValidPrefixType(candidate) {
 				if p, ok := resolver.PrefixString(resolver.PrefixType(candidate)); ok {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/hint"
 	"github.com/lugassawan/rimba/internal/operations"
+	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/spf13/cobra"
 )
@@ -24,7 +25,6 @@ var addCmd = &cobra.Command{
 	Long:  "Creates a new git worktree with a branch named <prefix><task> and copies dotfiles from the repo root.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		task := args[0]
 		cfg := config.FromContext(cmd.Context())
 
 		r := newRunner()
@@ -34,7 +34,18 @@ var addCmd = &cobra.Command{
 			return err
 		}
 
+		service, task := operations.ResolveTaskInput(args[0], repoRoot)
 		prefix := resolvedPrefixString(cmd)
+
+		// If no explicit prefix flag was set and the input starts with a known prefix,
+		// use that prefix from the input
+		if !hasExplicitPrefixFlag(cmd) {
+			if candidate, _ := resolver.SplitServiceInput(args[0]); resolver.ValidPrefixType(candidate) {
+				if p, ok := resolver.PrefixString(resolver.PrefixType(candidate)); ok {
+					prefix = p
+				}
+			}
+		}
 
 		source, _ := cmd.Flags().GetString(flagSource)
 		if source == "" {
@@ -61,6 +72,7 @@ var addCmd = &cobra.Command{
 		s.Start("Creating worktree...")
 		result, err := operations.AddWorktree(r, operations.AddParams{
 			Task:          task,
+			Service:       service,
 			Prefix:        prefix,
 			Source:        source,
 			RepoRoot:      repoRoot,
@@ -79,7 +91,11 @@ var addCmd = &cobra.Command{
 		s.Stop()
 
 		out := cmd.OutOrStdout()
-		fmt.Fprintf(out, "Created worktree for task %q\n", task)
+		if result.Service != "" {
+			fmt.Fprintf(out, "Created worktree for task %q (service: %s)\n", task, result.Service)
+		} else {
+			fmt.Fprintf(out, "Created worktree for task %q\n", task)
+		}
 		fmt.Fprintf(out, "  Branch: %s\n", result.Branch)
 		fmt.Fprintf(out, "  Path:   %s\n", result.Path)
 		if len(result.Copied) > 0 {

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -155,7 +155,8 @@ var depsInstallCmd = &cobra.Command{
 		}
 
 		prefixes := resolver.AllPrefixes()
-		wt, found := resolver.FindBranchForTask(task, worktrees, prefixes)
+		svc, resolvedTask := operations.ResolveTaskInput(task, repoRoot)
+		wt, found := resolver.FindBranchForTask(svc, resolvedTask, worktrees, prefixes)
 		if !found {
 			// Also try resolving as a worktree path
 			wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -55,8 +55,8 @@ var duplicateCmd = &cobra.Command{
 			return fmt.Errorf("cannot duplicate the default branch %q; use 'rimba add' instead", cfg.DefaultSource)
 		}
 
-		// Extract prefix from source branch
-		_, matchedPrefix := resolver.TaskFromBranch(wt.Branch, prefixes)
+		// Extract service and prefix from source branch
+		svc, _, matchedPrefix := resolver.ServiceFromBranch(wt.Branch, prefixes)
 		if matchedPrefix == "" {
 			matchedPrefix, _ = resolver.PrefixString(resolver.DefaultPrefixType)
 		}
@@ -70,7 +70,7 @@ var duplicateCmd = &cobra.Command{
 			// Auto-suffix: try task-1, task-2, etc.
 			for i := 1; i <= maxDuplicateSuffix; i++ {
 				candidate := fmt.Sprintf("%s-%d", task, i)
-				candidateBranch := resolver.BranchName(matchedPrefix, candidate)
+				candidateBranch := resolver.FullBranchName(svc, matchedPrefix, candidate)
 				if !git.BranchExists(r, candidateBranch) {
 					newTask = candidate
 					break
@@ -81,7 +81,7 @@ var duplicateCmd = &cobra.Command{
 			}
 		}
 
-		newBranch := resolver.BranchName(matchedPrefix, newTask)
+		newBranch := resolver.FullBranchName(svc, matchedPrefix, newTask)
 		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
 		wtPath := resolver.WorktreePath(wtDir, newBranch)
 

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -55,7 +55,6 @@ var duplicateCmd = &cobra.Command{
 			return fmt.Errorf("cannot duplicate the default branch %q; use 'rimba add' instead", cfg.DefaultSource)
 		}
 
-		// Extract service and prefix from source branch
 		svc, _, matchedPrefix := resolver.ServiceFromBranch(wt.Branch, prefixes)
 		if matchedPrefix == "" {
 			matchedPrefix, _ = resolver.PrefixString(resolver.DefaultPrefixType)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -66,7 +66,6 @@ func listWorktreeInfos(r git.Runner) ([]resolver.WorktreeInfo, error) {
 func findWorktree(r git.Runner, input string) (resolver.WorktreeInfo, error) {
 	repoRoot, err := git.MainRepoRoot(r)
 	if err != nil {
-		// Fallback: try without service resolution
 		return operations.FindWorktree(r, "", input)
 	}
 	service, task := operations.ResolveTaskInput(input, repoRoot)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -61,7 +61,14 @@ func listWorktreeInfos(r git.Runner) ([]resolver.WorktreeInfo, error) {
 	return operations.ListWorktreeInfos(r)
 }
 
-// findWorktree looks up a worktree by task name.
-func findWorktree(r git.Runner, task string) (resolver.WorktreeInfo, error) {
-	return operations.FindWorktree(r, task)
+// findWorktree looks up a worktree by user input (task or service/task).
+// It resolves the input to detect monorepo service names.
+func findWorktree(r git.Runner, input string) (resolver.WorktreeInfo, error) {
+	repoRoot, err := git.MainRepoRoot(r)
+	if err != nil {
+		// Fallback: try without service resolution
+		return operations.FindWorktree(r, "", input)
+	}
+	service, task := operations.ResolveTaskInput(input, repoRoot)
+	return operations.FindWorktree(r, service, task)
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -147,7 +147,6 @@ var listCmd = &cobra.Command{
 
 		rows = operations.FilterDetailsByStatus(rows, listDirty, listBehind)
 
-		// Filter by service
 		if listService != "" {
 			var filtered []resolver.WorktreeDetail
 			for _, row := range rows {
@@ -186,7 +185,6 @@ var listCmd = &cobra.Command{
 			return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
 		}
 
-		// Detect if any worktree has a service (monorepo mode)
 		hasService := false
 		for _, row := range rows {
 			if row.Service != "" {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -24,11 +24,13 @@ const (
 	flagBehind   = "behind"
 	flagArchived = "archived"
 	flagFull     = "full"
+	flagService  = "service"
 
-	hintType   = "Filter by prefix type (feature, bugfix, hotfix, etc.)"
-	hintDirty  = "Show only worktrees with uncommitted changes"
-	hintBehind = "Show only worktrees behind upstream"
-	hintFull   = "Show all columns including branch and path"
+	hintType    = "Filter by prefix type (feature, bugfix, hotfix, etc.)"
+	hintDirty   = "Show only worktrees with uncommitted changes"
+	hintBehind  = "Show only worktrees behind upstream"
+	hintFull    = "Show all columns including branch and path"
+	hintService = "Filter by service name (monorepo)"
 )
 
 // candidate holds a pre-filtered worktree entry before status collection.
@@ -48,6 +50,7 @@ var listCmd = &cobra.Command{
 		listBehind, _ := cmd.Flags().GetBool(flagBehind)
 		listArchived, _ := cmd.Flags().GetBool(flagArchived)
 		listFull, _ := cmd.Flags().GetBool(flagFull)
+		listService, _ := cmd.Flags().GetString(flagService)
 
 		if listArchived {
 			r := newRunner()
@@ -100,6 +103,7 @@ var listCmd = &cobra.Command{
 			hint.New(cmd, hintPainter(cmd)).
 				Add(flagFull, hintFull).
 				Add(flagType, hintType).
+				Add(flagService, hintService).
 				Add(flagDirty, hintDirty).
 				Add(flagBehind, hintBehind).
 				Show()
@@ -143,6 +147,17 @@ var listCmd = &cobra.Command{
 
 		rows = operations.FilterDetailsByStatus(rows, listDirty, listBehind)
 
+		// Filter by service
+		if listService != "" {
+			var filtered []resolver.WorktreeDetail
+			for _, row := range rows {
+				if row.Service == listService {
+					filtered = append(filtered, row)
+				}
+			}
+			rows = filtered
+		}
+
 		s.Stop()
 
 		if len(rows) == 0 {
@@ -160,6 +175,7 @@ var listCmd = &cobra.Command{
 			for i, r := range rows {
 				items[i] = output.ListItem{
 					Task:      r.Task,
+					Service:   r.Service,
 					Type:      r.Type,
 					Branch:    r.Branch,
 					Path:      r.Path,
@@ -170,25 +186,46 @@ var listCmd = &cobra.Command{
 			return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
 		}
 
+		// Detect if any worktree has a service (monorepo mode)
+		hasService := false
+		for _, row := range rows {
+			if row.Service != "" {
+				hasService = true
+				break
+			}
+		}
+
 		// Setup color painter
 		noColor, _ := cmd.Flags().GetBool(flagNoColor)
 		p := termcolor.NewPainter(noColor)
 
 		tbl := termcolor.NewTable(2)
 		if listFull {
-			tbl.AddRow(
+			header := []string{
 				p.Paint("TASK", termcolor.Bold),
+			}
+			if hasService {
+				header = append(header, p.Paint("SERVICE", termcolor.Bold))
+			}
+			header = append(header,
 				p.Paint("TYPE", termcolor.Bold),
 				p.Paint("BRANCH", termcolor.Bold),
 				p.Paint("PATH", termcolor.Bold),
 				p.Paint("STATUS", termcolor.Bold),
 			)
+			tbl.AddRow(header...)
 		} else {
-			tbl.AddRow(
+			header := []string{
 				p.Paint("TASK", termcolor.Bold),
+			}
+			if hasService {
+				header = append(header, p.Paint("SERVICE", termcolor.Bold))
+			}
+			header = append(header,
 				p.Paint("TYPE", termcolor.Bold),
 				p.Paint("STATUS", termcolor.Bold),
 			)
+			tbl.AddRow(header...)
 		}
 
 		for _, row := range rows {
@@ -206,9 +243,19 @@ var listCmd = &cobra.Command{
 			statusCell := colorStatus(p, row.Status)
 
 			if listFull {
-				tbl.AddRow(taskCell, typeCell, row.Branch, row.Path, statusCell)
+				cells := []string{taskCell}
+				if hasService {
+					cells = append(cells, row.Service)
+				}
+				cells = append(cells, typeCell, row.Branch, row.Path, statusCell)
+				tbl.AddRow(cells...)
 			} else {
-				tbl.AddRow(taskCell, typeCell, statusCell)
+				cells := []string{taskCell}
+				if hasService {
+					cells = append(cells, row.Service)
+				}
+				cells = append(cells, typeCell, statusCell)
+				tbl.AddRow(cells...)
 			}
 		}
 
@@ -221,6 +268,7 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 
 	listCmd.Flags().String(flagType, "", "filter by prefix type (e.g. feature, bugfix)")
+	listCmd.Flags().String(flagService, "", "filter by service name (monorepo)")
 	listCmd.Flags().Bool(flagDirty, false, "show only dirty worktrees")
 	listCmd.Flags().Bool(flagBehind, false, "show only worktrees behind upstream")
 	listCmd.Flags().Bool(flagArchived, false, "show archived branches (not in any active worktree)")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -185,46 +185,13 @@ var listCmd = &cobra.Command{
 			return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
 		}
 
-		hasService := false
-		for _, row := range rows {
-			if row.Service != "" {
-				hasService = true
-				break
-			}
-		}
+		hasService := resolver.HasService(rows)
 
-		// Setup color painter
 		noColor, _ := cmd.Flags().GetBool(flagNoColor)
 		p := termcolor.NewPainter(noColor)
 
 		tbl := termcolor.NewTable(2)
-		if listFull {
-			header := []string{
-				p.Paint("TASK", termcolor.Bold),
-			}
-			if hasService {
-				header = append(header, p.Paint("SERVICE", termcolor.Bold))
-			}
-			header = append(header,
-				p.Paint("TYPE", termcolor.Bold),
-				p.Paint("BRANCH", termcolor.Bold),
-				p.Paint("PATH", termcolor.Bold),
-				p.Paint("STATUS", termcolor.Bold),
-			)
-			tbl.AddRow(header...)
-		} else {
-			header := []string{
-				p.Paint("TASK", termcolor.Bold),
-			}
-			if hasService {
-				header = append(header, p.Paint("SERVICE", termcolor.Bold))
-			}
-			header = append(header,
-				p.Paint("TYPE", termcolor.Bold),
-				p.Paint("STATUS", termcolor.Bold),
-			)
-			tbl.AddRow(header...)
-		}
+		tbl.AddRow(listHeader(p, hasService, listFull)...)
 
 		for _, row := range rows {
 			taskCell := "  " + row.Task
@@ -239,22 +206,7 @@ var listCmd = &cobra.Command{
 			}
 
 			statusCell := colorStatus(p, row.Status)
-
-			if listFull {
-				cells := []string{taskCell}
-				if hasService {
-					cells = append(cells, row.Service)
-				}
-				cells = append(cells, typeCell, row.Branch, row.Path, statusCell)
-				tbl.AddRow(cells...)
-			} else {
-				cells := []string{taskCell}
-				if hasService {
-					cells = append(cells, row.Service)
-				}
-				cells = append(cells, typeCell, statusCell)
-				tbl.AddRow(cells...)
-			}
+			tbl.AddRow(listRow(taskCell, row, typeCell, statusCell, hasService, listFull)...)
 		}
 
 		tbl.Render(cmd.OutOrStdout())
@@ -290,6 +242,32 @@ func init() {
 }
 
 // listArchivedBranches shows branches not associated with any active worktree.
+func listHeader(p *termcolor.Painter, hasService, full bool) []string {
+	h := []string{p.Paint("TASK", termcolor.Bold)}
+	if hasService {
+		h = append(h, p.Paint("SERVICE", termcolor.Bold))
+	}
+	h = append(h, p.Paint("TYPE", termcolor.Bold))
+	if full {
+		h = append(h, p.Paint("BRANCH", termcolor.Bold), p.Paint("PATH", termcolor.Bold))
+	}
+	h = append(h, p.Paint("STATUS", termcolor.Bold))
+	return h
+}
+
+func listRow(taskCell string, row resolver.WorktreeDetail, typeCell, statusCell string, hasService, full bool) []string {
+	cells := []string{taskCell}
+	if hasService {
+		cells = append(cells, row.Service)
+	}
+	cells = append(cells, typeCell)
+	if full {
+		cells = append(cells, row.Branch, row.Path)
+	}
+	cells = append(cells, statusCell)
+	return cells
+}
+
 func listArchivedBranches(cmd *cobra.Command, r git.Runner, mainBranch string) error {
 	archived, err := operations.ListArchivedBranches(r, mainBranch)
 	if err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -146,16 +146,7 @@ var listCmd = &cobra.Command{
 		})
 
 		rows = operations.FilterDetailsByStatus(rows, listDirty, listBehind)
-
-		if listService != "" {
-			var filtered []resolver.WorktreeDetail
-			for _, row := range rows {
-				if row.Service == listService {
-					filtered = append(filtered, row)
-				}
-			}
-			rows = filtered
-		}
+		rows = resolver.FilterByService(rows, listService)
 
 		s.Stop()
 

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -16,6 +16,7 @@ import (
 func newListTestCmd() (*cobra.Command, *bytes.Buffer) {
 	cmd, buf := newTestCmd()
 	cmd.Flags().String(flagType, "", "")
+	cmd.Flags().String(flagService, "", "")
 	cmd.Flags().Bool(flagDirty, false, "")
 	cmd.Flags().Bool(flagBehind, false, "")
 	cmd.Flags().Bool(flagArchived, false, "")
@@ -617,6 +618,93 @@ func TestListFullMode(t *testing.T) {
 	}
 	if !strings.Contains(out, "STATUS") {
 		t.Error("full output should contain STATUS header")
+	}
+}
+
+func TestListWithServiceColumn(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{DefaultSource: branchMain, WorktreeDir: "worktrees"}
+
+	worktreeOut := strings.Join([]string{
+		wtPrefix + repoDir,
+		headABC123,
+		branchRefMain,
+		"",
+		wtPrefix + repoDir + "/worktrees/auth-api-feature-login",
+		headDEF456,
+		"branch refs/heads/auth-api/feature/login",
+		"",
+	}, "\n")
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			return worktreeOut, nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newListTestCmd()
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := listCmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf(fatalListRunE, err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "SERVICE") {
+		t.Error("expected SERVICE column header when monorepo worktrees exist")
+	}
+	if !strings.Contains(out, "auth-api") {
+		t.Error("expected auth-api in service column")
+	}
+}
+
+func TestListWithServiceColumnFull(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{DefaultSource: branchMain, WorktreeDir: "worktrees"}
+
+	worktreeOut := strings.Join([]string{
+		wtPrefix + repoDir,
+		headABC123,
+		branchRefMain,
+		"",
+		wtPrefix + repoDir + "/worktrees/auth-api-feature-login",
+		headDEF456,
+		"branch refs/heads/auth-api/feature/login",
+		"",
+	}, "\n")
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			return worktreeOut, nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newListTestCmd()
+	_ = cmd.Flags().Set(flagFull, "true")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := listCmd.RunE(cmd, nil)
+	if err != nil {
+		t.Fatalf(fatalListRunE, err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "SERVICE") {
+		t.Error("expected SERVICE column in full mode")
+	}
+	if !strings.Contains(out, "BRANCH") {
+		t.Error("expected BRANCH column in full mode")
 	}
 }
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -23,6 +23,7 @@ const (
 type logEntry struct {
 	branch     string
 	task       string
+	service    string
 	typeName   string
 	commitTime time.Time
 	subject    string
@@ -110,16 +111,17 @@ func collectLogEntries(r git.Runner, candidates []git.WorktreeEntry, s *spinner.
 	s.Update("Collecting commit info...")
 	results := parallel.Collect(len(candidates), 8, func(i int) logEntry {
 		e := candidates[i]
-		task, matchedPrefix := resolver.TaskFromBranch(e.Branch, prefixes)
+		svc, task, matchedPrefix := resolver.ServiceFromBranch(e.Branch, prefixes)
 		typeName := strings.TrimSuffix(matchedPrefix, "/")
 
 		ct, subject, err := git.LastCommitInfo(r, e.Branch)
 		if err != nil {
-			return logEntry{branch: e.Branch, task: task, typeName: typeName}
+			return logEntry{branch: e.Branch, task: task, service: svc, typeName: typeName}
 		}
 		return logEntry{
 			branch:     e.Branch,
 			task:       task,
+			service:    svc,
 			typeName:   typeName,
 			commitTime: ct,
 			subject:    subject,
@@ -145,13 +147,25 @@ func collectLogEntries(r git.Runner, candidates []git.WorktreeEntry, s *spinner.
 func renderLogTable(out io.Writer, p *termcolor.Painter, entries []logEntry) {
 	fmt.Fprintf(out, "Recent commits across %d worktree(s):\n\n", len(entries))
 
+	hasService := false
+	for _, e := range entries {
+		if e.service != "" {
+			hasService = true
+			break
+		}
+	}
+
 	tbl := termcolor.NewTable(2)
-	tbl.AddRow(
-		p.Paint("TASK", termcolor.Bold),
+	header := []string{p.Paint("TASK", termcolor.Bold)}
+	if hasService {
+		header = append(header, p.Paint("SERVICE", termcolor.Bold))
+	}
+	header = append(header,
 		p.Paint("TYPE", termcolor.Bold),
 		p.Paint("AGE", termcolor.Bold),
 		p.Paint("COMMIT", termcolor.Bold),
 	)
+	tbl.AddRow(header...)
 
 	for _, e := range entries {
 		typeCell := e.typeName
@@ -162,7 +176,12 @@ func renderLogTable(out io.Writer, p *termcolor.Painter, entries []logEntry) {
 		ageStr := resolver.FormatAge(e.commitTime)
 		ageCell := p.Paint(ageStr, resolver.AgeColor(e.commitTime))
 
-		tbl.AddRow("  "+e.task, typeCell, ageCell, e.subject)
+		cells := []string{"  " + e.task}
+		if hasService {
+			cells = append(cells, e.service)
+		}
+		cells = append(cells, typeCell, ageCell, e.subject)
+		tbl.AddRow(cells...)
 	}
 
 	tbl.Render(out)

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -143,17 +143,19 @@ func collectLogEntries(r git.Runner, candidates []git.WorktreeEntry, s *spinner.
 	return valid
 }
 
-// renderLogTable prints the log entries as a formatted table.
+func logEntriesHaveService(entries []logEntry) bool {
+	for _, e := range entries {
+		if e.service != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func renderLogTable(out io.Writer, p *termcolor.Painter, entries []logEntry) {
 	fmt.Fprintf(out, "Recent commits across %d worktree(s):\n\n", len(entries))
 
-	hasService := false
-	for _, e := range entries {
-		if e.service != "" {
-			hasService = true
-			break
-		}
-	}
+	hasService := logEntriesHaveService(entries)
 
 	tbl := termcolor.NewTable(2)
 	header := []string{p.Paint("TASK", termcolor.Bold)}

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -204,6 +204,47 @@ func TestLogWithLimit(t *testing.T) {
 	}
 }
 
+func TestLogWithServiceColumn(t *testing.T) {
+	ts := strconv.FormatInt(time.Now().Add(-1*time.Hour).Unix(), 10)
+
+	restore := overrideNewRunner(&mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case args[0] == cmdRevParse && args[1] == cmdShowToplevel:
+				return repoPath, nil
+			case args[0] == cmdSymbolicRef:
+				return refsRemotesOriginMain, nil
+			case args[0] == cmdWorktreeTest && args[1] == cmdList:
+				return strings.Join([]string{
+					wtRepo + headMainBlock,
+					"worktree /wt/auth-api-feature-login", headDEF456, "branch refs/heads/auth-api/feature/login", "",
+				}, "\n"), nil
+			case args[0] == cmdLog:
+				return ts + "\tadd login", nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	})
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().Int(flagLimit, 0, "")
+	cmd.Flags().String(flagSince, "", "")
+
+	if err := logCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("logCmd.RunE: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "SERVICE") {
+		t.Errorf("expected SERVICE column, got: %q", output)
+	}
+	if !strings.Contains(output, "auth-api") {
+		t.Errorf("expected auth-api service, got: %q", output)
+	}
+}
+
 func TestLogCommitInfoError(t *testing.T) {
 	restore := overrideNewRunner(logRunnerWithWorktree(func(_ string) (string, error) {
 		return "", errors.New("no commits")

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -34,7 +34,6 @@ var mergeCmd = &cobra.Command{
 		return completeWorktreeTasks(cmd, toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sourceTask := args[0]
 		cfg := config.FromContext(cmd.Context())
 
 		r := newRunner()
@@ -44,7 +43,12 @@ var mergeCmd = &cobra.Command{
 			return err
 		}
 
-		intoTask, _ := cmd.Flags().GetString(flagInto)
+		sourceService, sourceTask := operations.ResolveTaskInput(args[0], repoRoot)
+		intoTaskRaw, _ := cmd.Flags().GetString(flagInto)
+		var intoService, intoTask string
+		if intoTaskRaw != "" {
+			intoService, intoTask = operations.ResolveTaskInput(intoTaskRaw, repoRoot)
+		}
 		noFF, _ := cmd.Flags().GetBool(flagNoFF)
 		keep, _ := cmd.Flags().GetBool(flagKeep)
 		del, _ := cmd.Flags().GetBool(flagDelete)
@@ -60,13 +64,15 @@ var mergeCmd = &cobra.Command{
 
 		s.Start("Checking for uncommitted changes...")
 		result, err := operations.MergeWorktree(r, operations.MergeParams{
-			SourceTask: sourceTask,
-			IntoTask:   intoTask,
-			RepoRoot:   repoRoot,
-			MainBranch: cfg.DefaultSource,
-			NoFF:       noFF,
-			Keep:       keep,
-			Delete:     del,
+			SourceTask:    sourceTask,
+			SourceService: sourceService,
+			IntoTask:      intoTask,
+			IntoService:   intoService,
+			RepoRoot:      repoRoot,
+			MainBranch:    cfg.DefaultSource,
+			NoFF:          noFF,
+			Keep:          keep,
+			Delete:        del,
 		}, func(msg string) { s.Update(msg) })
 		if err != nil {
 			return err

--- a/cmd/prefix.go
+++ b/cmd/prefix.go
@@ -44,3 +44,13 @@ func resolvedPrefixString(cmd *cobra.Command) string {
 	s, _ := resolver.PrefixString(resolver.DefaultPrefixType)
 	return s
 }
+
+// hasExplicitPrefixFlag returns true if any prefix flag was explicitly set by the user.
+func hasExplicitPrefixFlag(cmd *cobra.Command) bool {
+	for _, pf := range prefixFlags {
+		if set, _ := cmd.Flags().GetBool(pf.Flag); set {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/prefix_test.go
+++ b/cmd/prefix_test.go
@@ -6,6 +6,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func TestHasExplicitPrefixFlag(t *testing.T) {
+	t.Run("no flag set", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		addPrefixFlags(cmd)
+		if hasExplicitPrefixFlag(cmd) {
+			t.Error("expected false when no flag set")
+		}
+	})
+
+	t.Run("bugfix flag set", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		addPrefixFlags(cmd)
+		if err := cmd.Flags().Set("bugfix", "true"); err != nil {
+			t.Fatal(err)
+		}
+		if !hasExplicitPrefixFlag(cmd) {
+			t.Error("expected true when bugfix flag set")
+		}
+	})
+}
+
 func TestResolvedPrefixString(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -109,10 +109,12 @@ func init() {
 	rootCmd.AddCommand(syncCmd)
 }
 
-func syncOne(sc *syncContext, task string, worktrees []resolver.WorktreeInfo, prefixes []string, useMerge, push bool) error {
-	wt, found := resolver.FindBranchForTask(task, worktrees, prefixes)
+func syncOne(sc *syncContext, input string, worktrees []resolver.WorktreeInfo, prefixes []string, useMerge, push bool) error {
+	repoRoot, _ := git.MainRepoRoot(sc.r)
+	service, task := operations.ResolveTaskInput(input, repoRoot)
+	wt, found := resolver.FindBranchForTask(service, task, worktrees, prefixes)
 	if !found {
-		return fmt.Errorf(operations.ErrWorktreeNotFoundFmt, task)
+		return fmt.Errorf(operations.ErrWorktreeNotFoundFmt, input)
 	}
 
 	dirty, err := git.IsDirty(sc.r, wt.Path)

--- a/internal/mcp/tool_remove.go
+++ b/internal/mcp/tool_remove.go
@@ -37,7 +37,7 @@ func handleRemove(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		r := hctx.Runner
 
-		wt, findErr := operations.FindWorktree(r, task)
+		wt, findErr := operations.FindWorktree(r, "", task)
 		if findErr != nil {
 			return mcp.NewToolResultError(findErr.Error()), nil
 		}

--- a/internal/mcp/tool_sync.go
+++ b/internal/mcp/tool_sync.go
@@ -87,7 +87,7 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 }
 
 func syncSingle(r git.Runner, task string, worktrees []resolver.WorktreeInfo, prefixes []string, opts syncOpts) (*mcp.CallToolResult, error) {
-	wt, found := resolver.FindBranchForTask(task, worktrees, prefixes)
+	wt, found := resolver.FindBranchForTask("", task, worktrees, prefixes)
 	if !found {
 		return mcp.NewToolResultError("worktree not found for task \"" + task + "\""), nil
 	}

--- a/internal/operations/add.go
+++ b/internal/operations/add.go
@@ -13,7 +13,7 @@ import (
 // AddParams holds the inputs for creating a new worktree.
 type AddParams struct {
 	Task          string
-	Service       string // monorepo service name (empty for standard)
+	Service       string
 	Prefix        string // e.g. "feature/"
 	Source        string // source branch
 	RepoRoot      string

--- a/internal/operations/add.go
+++ b/internal/operations/add.go
@@ -13,6 +13,7 @@ import (
 // AddParams holds the inputs for creating a new worktree.
 type AddParams struct {
 	Task          string
+	Service       string // monorepo service name (empty for standard)
 	Prefix        string // e.g. "feature/"
 	Source        string // source branch
 	RepoRoot      string
@@ -28,6 +29,7 @@ type AddParams struct {
 // AddResult holds the outcome of creating a worktree.
 type AddResult struct {
 	Task        string
+	Service     string
 	Branch      string
 	Path        string
 	Source      string
@@ -39,14 +41,15 @@ type AddResult struct {
 
 // AddWorktree creates a new worktree, copies files, installs deps, and runs hooks.
 func AddWorktree(r git.Runner, params AddParams, onProgress ProgressFunc) (AddResult, error) {
-	branch := resolver.BranchName(params.Prefix, params.Task)
+	branch := resolver.FullBranchName(params.Service, params.Prefix, params.Task)
 	wtPath := resolver.WorktreePath(params.WorktreeDir, branch)
 
 	result := AddResult{
-		Task:   params.Task,
-		Branch: branch,
-		Path:   wtPath,
-		Source: params.Source,
+		Task:    params.Task,
+		Service: params.Service,
+		Branch:  branch,
+		Path:    wtPath,
+		Source:  params.Source,
 	}
 
 	// Validate

--- a/internal/operations/input.go
+++ b/internal/operations/input.go
@@ -21,17 +21,14 @@ func ResolveTaskInput(input, repoRoot string) (service, task string) {
 		return "", input
 	}
 
-	// Known prefix → standard mode, sanitize rest
 	if resolver.ValidPrefixType(candidate) {
 		return "", resolver.SanitizeTask(rest)
 	}
 
-	// Check if candidate is a valid service directory
 	dirPath := filepath.Join(repoRoot, candidate)
 	if info, err := os.Stat(dirPath); err == nil && info.IsDir() {
 		return candidate, resolver.SanitizeTask(rest)
 	}
 
-	// Not a prefix, not a valid dir → treat full input as task
 	return "", resolver.SanitizeTask(input)
 }

--- a/internal/operations/input.go
+++ b/internal/operations/input.go
@@ -1,0 +1,37 @@
+package operations
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/lugassawan/rimba/internal/resolver"
+)
+
+// ResolveTaskInput parses user input into service and task components.
+// It validates that the candidate service directory exists in the repo root.
+//
+// Decision logic:
+//  1. No "/" in input → standard mode ("", input)
+//  2. Part before "/" is a known prefix → standard mode, sanitize rest
+//  3. Part before "/" is a directory in repoRoot → monorepo (service, sanitized rest)
+//  4. Otherwise → standard mode, sanitize full input
+func ResolveTaskInput(input, repoRoot string) (service, task string) {
+	candidate, rest := resolver.SplitServiceInput(input)
+	if candidate == "" {
+		return "", input
+	}
+
+	// Known prefix → standard mode, sanitize rest
+	if resolver.ValidPrefixType(candidate) {
+		return "", resolver.SanitizeTask(rest)
+	}
+
+	// Check if candidate is a valid service directory
+	dirPath := filepath.Join(repoRoot, candidate)
+	if info, err := os.Stat(dirPath); err == nil && info.IsDir() {
+		return candidate, resolver.SanitizeTask(rest)
+	}
+
+	// Not a prefix, not a valid dir → treat full input as task
+	return "", resolver.SanitizeTask(input)
+}

--- a/internal/operations/input_test.go
+++ b/internal/operations/input_test.go
@@ -1,0 +1,83 @@
+package operations_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/operations"
+)
+
+func TestResolveTaskInput(t *testing.T) {
+	// Create a temp dir with a service subdirectory
+	repoRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repoRoot, "auth-api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		input       string
+		wantService string
+		wantTask    string
+	}{
+		{
+			name:        "simple task",
+			input:       "my-task",
+			wantService: "",
+			wantTask:    "my-task",
+		},
+		{
+			name:        "known prefix",
+			input:       "feature/my-task",
+			wantService: "",
+			wantTask:    "my-task",
+		},
+		{
+			name:        "known prefix with multi-segment task",
+			input:       "feature/auth-redirect/part-1",
+			wantService: "",
+			wantTask:    "auth-redirect-part-1",
+		},
+		{
+			name:        "bugfix prefix",
+			input:       "bugfix/crash-fix",
+			wantService: "",
+			wantTask:    "crash-fix",
+		},
+		{
+			name:        "valid service directory",
+			input:       "auth-api/my-task",
+			wantService: "auth-api",
+			wantTask:    "my-task",
+		},
+		{
+			name:        "valid service with multi-segment task",
+			input:       "auth-api/auth-redirect/part-1",
+			wantService: "auth-api",
+			wantTask:    "auth-redirect-part-1",
+		},
+		{
+			name:        "non-existent directory falls back to standard",
+			input:       "no-such-dir/my-task",
+			wantService: "",
+			wantTask:    "no-such-dir-my-task",
+		},
+		{
+			name:        "non-existent dir with multi-segment",
+			input:       "no-such-dir/part-1/part-2",
+			wantService: "",
+			wantTask:    "no-such-dir-part-1-part-2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, task := operations.ResolveTaskInput(tt.input, repoRoot)
+			if service != tt.wantService || task != tt.wantTask {
+				t.Errorf("ResolveTaskInput(%q) = (%q, %q), want (%q, %q)",
+					tt.input, service, task, tt.wantService, tt.wantTask)
+			}
+		})
+	}
+}

--- a/internal/operations/merge.go
+++ b/internal/operations/merge.go
@@ -11,9 +11,9 @@ import (
 // MergeParams holds the inputs for a merge operation.
 type MergeParams struct {
 	SourceTask    string
-	SourceService string // monorepo service for source (empty for standard)
+	SourceService string
 	IntoTask      string // empty = merge into main
-	IntoService   string // monorepo service for target (empty for standard)
+	IntoService   string
 	RepoRoot      string
 	MainBranch    string
 	NoFF          bool

--- a/internal/operations/merge.go
+++ b/internal/operations/merge.go
@@ -10,13 +10,15 @@ import (
 
 // MergeParams holds the inputs for a merge operation.
 type MergeParams struct {
-	SourceTask string
-	IntoTask   string // empty = merge into main
-	RepoRoot   string
-	MainBranch string
-	NoFF       bool
-	Keep       bool
-	Delete     bool
+	SourceTask    string
+	SourceService string // monorepo service for source (empty for standard)
+	IntoTask      string // empty = merge into main
+	IntoService   string // monorepo service for target (empty for standard)
+	RepoRoot      string
+	MainBranch    string
+	NoFF          bool
+	Keep          bool
+	Delete        bool
 }
 
 // MergeResult holds the outcome of a merge operation.
@@ -47,7 +49,7 @@ func MergeWorktree(r git.Runner, params MergeParams, onProgress ProgressFunc) (M
 	prefixes := resolver.AllPrefixes()
 
 	// Resolve source
-	source, found := resolver.FindBranchForTask(params.SourceTask, worktrees, prefixes)
+	source, found := resolver.FindBranchForTask(params.SourceService, params.SourceTask, worktrees, prefixes)
 	if !found {
 		return MergeResult{}, fmt.Errorf(ErrWorktreeNotFoundFmt, params.SourceTask)
 	}
@@ -60,7 +62,7 @@ func MergeWorktree(r git.Runner, params MergeParams, onProgress ProgressFunc) (M
 		targetDir = params.RepoRoot
 		targetLabel = params.MainBranch
 	} else {
-		target, tgtFound := resolver.FindBranchForTask(params.IntoTask, worktrees, prefixes)
+		target, tgtFound := resolver.FindBranchForTask(params.IntoService, params.IntoTask, worktrees, prefixes)
 		if !tgtFound {
 			return MergeResult{}, fmt.Errorf(ErrWorktreeNotFoundFmt, params.IntoTask)
 		}

--- a/internal/operations/operations.go
+++ b/internal/operations/operations.go
@@ -51,7 +51,6 @@ func FindWorktree(r git.Runner, service, task string) (resolver.WorktreeInfo, er
 	prefixes := resolver.AllPrefixes()
 	wt, found := resolver.FindBranchForTask(service, task, worktrees, prefixes)
 	if !found {
-		// Check for ambiguity
 		if service == "" {
 			matches := resolver.FindAllBranchesForTask(task, worktrees, prefixes)
 			if len(matches) > 1 {

--- a/internal/operations/operations.go
+++ b/internal/operations/operations.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -26,25 +27,37 @@ func ListWorktreeInfos(r git.Runner) ([]resolver.WorktreeInfo, error) {
 		return nil, err
 	}
 
+	prefixes := resolver.AllPrefixes()
 	worktrees := make([]resolver.WorktreeInfo, len(entries))
 	for i, e := range entries {
+		svc, _, _ := resolver.ServiceFromBranch(e.Branch, prefixes)
 		worktrees[i] = resolver.WorktreeInfo{
-			Path:   e.Path,
-			Branch: e.Branch,
+			Path:    e.Path,
+			Branch:  e.Branch,
+			Service: svc,
 		}
 	}
 	return worktrees, nil
 }
 
-// FindWorktree looks up a worktree by task name.
-func FindWorktree(r git.Runner, task string) (resolver.WorktreeInfo, error) {
+// FindWorktree looks up a worktree by service and task name.
+// When service is empty and the task matches multiple services, an ambiguity error is returned.
+func FindWorktree(r git.Runner, service, task string) (resolver.WorktreeInfo, error) {
 	worktrees, err := ListWorktreeInfos(r)
 	if err != nil {
 		return resolver.WorktreeInfo{}, err
 	}
 
-	wt, found := resolver.FindBranchForTask(task, worktrees, resolver.AllPrefixes())
+	prefixes := resolver.AllPrefixes()
+	wt, found := resolver.FindBranchForTask(service, task, worktrees, prefixes)
 	if !found {
+		// Check for ambiguity
+		if service == "" {
+			matches := resolver.FindAllBranchesForTask(task, worktrees, prefixes)
+			if len(matches) > 1 {
+				return resolver.WorktreeInfo{}, ambiguityError(task, matches)
+			}
+		}
 		return resolver.WorktreeInfo{}, fmt.Errorf(ErrWorktreeNotFoundFmt, task)
 	}
 	return wt, nil
@@ -62,4 +75,14 @@ func FilterByType(worktrees []resolver.WorktreeInfo, prefixes []string, typeStr 
 		}
 	}
 	return out
+}
+
+// ambiguityError builds a descriptive error when a bare task matches multiple services.
+func ambiguityError(task string, matches []resolver.WorktreeInfo) error {
+	branches := make([]string, len(matches))
+	for i, m := range matches {
+		branches[i] = "  " + m.Branch
+	}
+	return fmt.Errorf("multiple worktrees match %q:\n%s\nSpecify the service: rimba <command> <service>/%s",
+		task, strings.Join(branches, "\n"), task)
 }

--- a/internal/operations/operations_test.go
+++ b/internal/operations/operations_test.go
@@ -83,6 +83,43 @@ func TestFindWorktree(t *testing.T) {
 	})
 }
 
+func TestFindWorktreeAmbiguity(t *testing.T) {
+	// Two service-scoped worktrees with the same task name
+	porcelain := strings.Join([]string{
+		"worktree /repo",
+		"HEAD abc123",
+		"branch refs/heads/main",
+		"",
+		"worktree /repo-worktrees/auth-api-feature-login",
+		"HEAD def456",
+		"branch refs/heads/auth-api/feature/login",
+		"",
+		"worktree /repo-worktrees/web-app-feature-login",
+		"HEAD ghi789",
+		"branch refs/heads/web-app/feature/login",
+		"",
+	}, "\n")
+
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return porcelain, nil },
+		runInDir: noopRunInDir,
+	}
+
+	_, err := FindWorktree(r, "", "login")
+	if err == nil {
+		t.Fatal("expected ambiguity error")
+	}
+	if !strings.Contains(err.Error(), "multiple worktrees match") {
+		t.Errorf("expected ambiguity error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "auth-api/feature/login") {
+		t.Errorf("expected error to list auth-api branch, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "web-app/feature/login") {
+		t.Errorf("expected error to list web-app branch, got: %v", err)
+	}
+}
+
 func TestFindWorktreeError(t *testing.T) {
 	r := &mockRunner{
 		run:      func(_ ...string) (string, error) { return "", errGitFailed },

--- a/internal/operations/operations_test.go
+++ b/internal/operations/operations_test.go
@@ -67,7 +67,7 @@ func TestFindWorktree(t *testing.T) {
 	}
 
 	t.Run("found", func(t *testing.T) {
-		wt, err := FindWorktree(r, "login")
+		wt, err := FindWorktree(r, "", "login")
 		if err != nil {
 			t.Fatalf("FindWorktree: %v", err)
 		}
@@ -77,7 +77,7 @@ func TestFindWorktree(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		if _, err := FindWorktree(r, "nonexistent"); err == nil {
+		if _, err := FindWorktree(r, "", "nonexistent"); err == nil {
 			t.Fatal("expected error for missing worktree")
 		}
 	})
@@ -88,7 +88,7 @@ func TestFindWorktreeError(t *testing.T) {
 		run:      func(_ ...string) (string, error) { return "", errGitFailed },
 		runInDir: noopRunInDir,
 	}
-	if _, err := FindWorktree(r, "login"); err == nil {
+	if _, err := FindWorktree(r, "", "login"); err == nil {
 		t.Fatal("expected error")
 	}
 }

--- a/internal/operations/rename.go
+++ b/internal/operations/rename.go
@@ -20,12 +20,12 @@ type RenameResult struct {
 func RenameWorktree(r git.Runner, wt resolver.WorktreeInfo, newTask, wtDir string, force bool) (RenameResult, error) {
 	prefixes := resolver.AllPrefixes()
 
-	_, matchedPrefix := resolver.TaskFromBranch(wt.Branch, prefixes)
+	svc, _, matchedPrefix := resolver.ServiceFromBranch(wt.Branch, prefixes)
 	if matchedPrefix == "" {
 		matchedPrefix, _ = resolver.PrefixString(resolver.DefaultPrefixType)
 	}
 
-	newBranch := resolver.BranchName(matchedPrefix, newTask)
+	newBranch := resolver.FullBranchName(svc, matchedPrefix, newTask)
 
 	if git.BranchExists(r, newBranch) {
 		return RenameResult{}, fmt.Errorf("branch %q already exists", newBranch)

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -5,6 +5,7 @@ import "github.com/lugassawan/rimba/internal/resolver"
 // ListItem represents a worktree entry in JSON output.
 type ListItem struct {
 	Task      string                  `json:"task"`
+	Service   string                  `json:"service,omitempty"`
 	Type      string                  `json:"type"`
 	Branch    string                  `json:"branch"`
 	Path      string                  `json:"path"`

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -39,13 +39,12 @@ func SanitizeTask(task string) string {
 // "auth-api/feature/auth-redirect" → ("auth-api", "auth-redirect", "feature/")
 // "feature/auth-redirect"          → ("", "auth-redirect", "feature/")
 func ServiceFromBranch(branch string, prefixes []string) (service, task, matchedPrefix string) {
-	// Try direct prefix match first (standard mode)
 	for _, p := range prefixes {
 		if t, ok := strings.CutPrefix(branch, p); ok {
 			return "", t, p
 		}
 	}
-	// Try service/prefix/task pattern (monorepo mode)
+
 	if i := strings.Index(branch, "/"); i > 0 {
 		rest := branch[i+1:]
 		for _, p := range prefixes {
@@ -84,7 +83,7 @@ func TaskFromBranch(branch string, prefixes []string) (task, matchedPrefix strin
 type WorktreeInfo struct {
 	Path    string
 	Branch  string
-	Service string // extracted from branch, empty for standard
+	Service string
 }
 
 // FindBranchForTask searches worktrees for one matching the given service and task.
@@ -92,17 +91,14 @@ type WorktreeInfo struct {
 // When service is empty, it searches for prefix/task patterns and falls back
 // to a cross-service task search (returning the match only if unambiguous).
 func FindBranchForTask(service, task string, worktrees []WorktreeInfo, prefixes []string) (WorktreeInfo, bool) {
-	// Try prefix-based match (with or without service)
 	if wt, ok := findByPrefix(service, task, worktrees, prefixes); ok {
 		return wt, true
 	}
 
-	// Fallback: exact branch name match
 	if wt, ok := findExact(task, worktrees); ok {
 		return wt, true
 	}
 
-	// Fallback: task-only search across all services (monorepo convenience)
 	if service == "" {
 		matches := FindAllBranchesForTask(task, worktrees, prefixes)
 		if len(matches) == 1 {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -10,6 +10,53 @@ func BranchName(prefix, task string) string {
 	return prefix + task
 }
 
+// FullBranchName constructs the branch name with optional service prefix.
+// Monorepo: "auth-api" + "feature/" + "my-task" → "auth-api/feature/my-task"
+// Standard: "" + "feature/" + "my-task" → "feature/my-task"
+func FullBranchName(service, prefix, task string) string {
+	if service != "" {
+		return service + "/" + prefix + task
+	}
+	return prefix + task
+}
+
+// SplitServiceInput splits input on the first "/" and returns the candidate
+// service name and the rest. Returns ("", input) if no "/" is found.
+// The caller is responsible for validating whether candidate is a real service.
+func SplitServiceInput(input string) (candidate, rest string) {
+	if i := strings.Index(input, "/"); i > 0 {
+		return input[:i], input[i+1:]
+	}
+	return "", input
+}
+
+// SanitizeTask replaces "/" with "-" in a task name.
+func SanitizeTask(task string) string {
+	return strings.ReplaceAll(task, "/", "-")
+}
+
+// ServiceFromBranch extracts the service, task, and matched prefix from a branch.
+// "auth-api/feature/auth-redirect" → ("auth-api", "auth-redirect", "feature/")
+// "feature/auth-redirect"          → ("", "auth-redirect", "feature/")
+func ServiceFromBranch(branch string, prefixes []string) (service, task, matchedPrefix string) {
+	// Try direct prefix match first (standard mode)
+	for _, p := range prefixes {
+		if t, ok := strings.CutPrefix(branch, p); ok {
+			return "", t, p
+		}
+	}
+	// Try service/prefix/task pattern (monorepo mode)
+	if i := strings.Index(branch, "/"); i > 0 {
+		rest := branch[i+1:]
+		for _, p := range prefixes {
+			if t, ok := strings.CutPrefix(rest, p); ok {
+				return branch[:i], t, p
+			}
+		}
+	}
+	return "", branch, ""
+}
+
 // DirName converts a branch name to a directory-safe name.
 // e.g. "feature/my-task" → "feature-my-task"
 func DirName(branch string) string {
@@ -35,27 +82,74 @@ func TaskFromBranch(branch string, prefixes []string) (task, matchedPrefix strin
 
 // WorktreeInfo holds parsed information about a worktree.
 type WorktreeInfo struct {
-	Path   string
-	Branch string
+	Path    string
+	Branch  string
+	Service string // extracted from branch, empty for standard
 }
 
-// FindBranchForTask searches worktrees for one matching the given task.
-// It tries each prefix+task combination, then falls back to exact branch name match.
-func FindBranchForTask(task string, worktrees []WorktreeInfo, prefixes []string) (WorktreeInfo, bool) {
+// FindBranchForTask searches worktrees for one matching the given service and task.
+// When service is non-empty, it searches for service/prefix/task patterns.
+// When service is empty, it searches for prefix/task patterns and falls back
+// to a cross-service task search (returning the match only if unambiguous).
+func FindBranchForTask(service, task string, worktrees []WorktreeInfo, prefixes []string) (WorktreeInfo, bool) {
+	// Try prefix-based match (with or without service)
+	if wt, ok := findByPrefix(service, task, worktrees, prefixes); ok {
+		return wt, true
+	}
+
+	// Fallback: exact branch name match
+	if wt, ok := findExact(task, worktrees); ok {
+		return wt, true
+	}
+
+	// Fallback: task-only search across all services (monorepo convenience)
+	if service == "" {
+		matches := FindAllBranchesForTask(task, worktrees, prefixes)
+		if len(matches) == 1 {
+			return matches[0], true
+		}
+	}
+
+	return WorktreeInfo{}, false
+}
+
+// FindAllBranchesForTask returns all worktrees matching a task name
+// across all services. Used for disambiguation.
+func FindAllBranchesForTask(task string, worktrees []WorktreeInfo, prefixes []string) []WorktreeInfo {
+	var matches []WorktreeInfo
+	for _, wt := range worktrees {
+		_, t, _ := ServiceFromBranch(wt.Branch, prefixes)
+		if t == task {
+			matches = append(matches, wt)
+		}
+	}
+	return matches
+}
+
+// findByPrefix searches worktrees for a prefix+task match, optionally scoped to a service.
+func findByPrefix(service, task string, worktrees []WorktreeInfo, prefixes []string) (WorktreeInfo, bool) {
 	for _, p := range prefixes {
-		target := BranchName(p, task)
+		var target string
+		if service != "" {
+			target = FullBranchName(service, p, task)
+		} else {
+			target = BranchName(p, task)
+		}
 		for _, wt := range worktrees {
 			if wt.Branch == target {
 				return wt, true
 			}
 		}
 	}
+	return WorktreeInfo{}, false
+}
 
+// findExact searches worktrees for an exact branch name match.
+func findExact(task string, worktrees []WorktreeInfo) (WorktreeInfo, bool) {
 	for _, wt := range worktrees {
 		if wt.Branch == task {
 			return wt, true
 		}
 	}
-
 	return WorktreeInfo{}, false
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -104,7 +104,7 @@ func TestFindBranchForTask(t *testing.T) {
 	prefixes := resolver.AllPrefixes()
 
 	t.Run("match with prefix", func(t *testing.T) {
-		wt, ok := resolver.FindBranchForTask(taskLogin, worktrees, prefixes)
+		wt, ok := resolver.FindBranchForTask("", taskLogin, worktrees, prefixes)
 		if !ok {
 			t.Fatal(msgExpectedMatch)
 		}
@@ -114,7 +114,7 @@ func TestFindBranchForTask(t *testing.T) {
 	})
 
 	t.Run("cross-prefix match", func(t *testing.T) {
-		wt, ok := resolver.FindBranchForTask(taskCrash, worktrees, prefixes)
+		wt, ok := resolver.FindBranchForTask("", taskCrash, worktrees, prefixes)
 		if !ok {
 			t.Fatal(msgExpectedMatch)
 		}
@@ -124,7 +124,7 @@ func TestFindBranchForTask(t *testing.T) {
 	})
 
 	t.Run("match with full branch name", func(t *testing.T) {
-		wt, ok := resolver.FindBranchForTask(bugfixPrefix+taskCrash, worktrees, prefixes)
+		wt, ok := resolver.FindBranchForTask("", bugfixPrefix+taskCrash, worktrees, prefixes)
 		if !ok {
 			t.Fatal(msgExpectedMatch)
 		}
@@ -134,11 +134,176 @@ func TestFindBranchForTask(t *testing.T) {
 	})
 
 	t.Run("no match", func(t *testing.T) {
-		_, ok := resolver.FindBranchForTask("nonexistent", worktrees, prefixes)
+		_, ok := resolver.FindBranchForTask("", "nonexistent", worktrees, prefixes)
 		if ok {
 			t.Fatal("expected no match")
 		}
 	})
+}
+
+func TestFullBranchName(t *testing.T) {
+	tests := []struct {
+		service, prefix, task, want string
+	}{
+		{"auth-api", featurePrefix, "my-task", "auth-api/feature/my-task"},
+		{"auth-api", bugfixPrefix, "login-fix", "auth-api/bugfix/login-fix"},
+		{"", featurePrefix, "my-task", "feature/my-task"},
+		{"", "", "bare", "bare"},
+	}
+	for _, tt := range tests {
+		got := resolver.FullBranchName(tt.service, tt.prefix, tt.task)
+		if got != tt.want {
+			t.Errorf("FullBranchName(%q, %q, %q) = %q, want %q", tt.service, tt.prefix, tt.task, got, tt.want)
+		}
+	}
+}
+
+func TestSplitServiceInput(t *testing.T) {
+	tests := []struct {
+		input         string
+		wantCandidate string
+		wantRest      string
+	}{
+		{"auth-api/my-task", "auth-api", "my-task"},
+		{"auth-api/my-task/part-1", "auth-api", "my-task/part-1"},
+		{"feature/my-task", "feature", "my-task"},
+		{"my-task", "", "my-task"},
+		{"", "", ""},
+	}
+	for _, tt := range tests {
+		candidate, rest := resolver.SplitServiceInput(tt.input)
+		if candidate != tt.wantCandidate || rest != tt.wantRest {
+			t.Errorf("SplitServiceInput(%q) = (%q, %q), want (%q, %q)", tt.input, candidate, rest, tt.wantCandidate, tt.wantRest)
+		}
+	}
+}
+
+func TestSanitizeTask(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"my-task", "my-task"},
+		{"auth-redirect/part-1", "auth-redirect-part-1"},
+		{"a/b/c", "a-b-c"},
+		{"no-slash", "no-slash"},
+	}
+	for _, tt := range tests {
+		got := resolver.SanitizeTask(tt.input)
+		if got != tt.want {
+			t.Errorf("SanitizeTask(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestServiceFromBranch(t *testing.T) {
+	prefixes := resolver.AllPrefixes()
+
+	tests := []struct {
+		branch     string
+		wantSvc    string
+		wantTask   string
+		wantPrefix string
+	}{
+		{"feature/my-task", "", "my-task", featurePrefix},
+		{"bugfix/login-fix", "", "login-fix", bugfixPrefix},
+		{"auth-api/feature/my-task", "auth-api", "my-task", featurePrefix},
+		{"auth-api/bugfix/crash", "auth-api", "crash", bugfixPrefix},
+		{"bare-branch", "", "bare-branch", ""},
+		{"unknown/prefix", "", "unknown/prefix", ""},
+	}
+	for _, tt := range tests {
+		svc, task, prefix := resolver.ServiceFromBranch(tt.branch, prefixes)
+		if svc != tt.wantSvc || task != tt.wantTask || prefix != tt.wantPrefix {
+			t.Errorf("ServiceFromBranch(%q) = (%q, %q, %q), want (%q, %q, %q)",
+				tt.branch, svc, task, prefix, tt.wantSvc, tt.wantTask, tt.wantPrefix)
+		}
+	}
+}
+
+func TestFindBranchForTaskWithService(t *testing.T) {
+	worktrees := []resolver.WorktreeInfo{
+		{Path: "/wt/feature-login", Branch: featurePrefix + taskLogin},
+		{Path: "/wt/auth-api-feature-login", Branch: "auth-api/" + featurePrefix + taskLogin},
+		{Path: "/wt/web-app-feature-login", Branch: "web-app/" + featurePrefix + taskLogin},
+		{Path: "/wt/bugfix-crash", Branch: bugfixPrefix + taskCrash},
+	}
+
+	prefixes := resolver.AllPrefixes()
+
+	t.Run("monorepo match with service", func(t *testing.T) {
+		wt, ok := resolver.FindBranchForTask("auth-api", taskLogin, worktrees, prefixes)
+		if !ok {
+			t.Fatal(msgExpectedMatch)
+		}
+		if wt.Branch != "auth-api/"+featurePrefix+taskLogin {
+			t.Errorf(fmtGotBranch, wt.Branch, "auth-api/"+featurePrefix+taskLogin)
+		}
+	})
+
+	t.Run("standard match without service", func(t *testing.T) {
+		wt, ok := resolver.FindBranchForTask("", taskCrash, worktrees, prefixes)
+		if !ok {
+			t.Fatal(msgExpectedMatch)
+		}
+		if wt.Branch != bugfixPrefix+taskCrash {
+			t.Errorf(fmtGotBranch, wt.Branch, bugfixPrefix+taskCrash)
+		}
+	})
+
+	t.Run("bare task finds standard match first", func(t *testing.T) {
+		wt, ok := resolver.FindBranchForTask("", taskLogin, worktrees, prefixes)
+		if !ok {
+			t.Fatal(msgExpectedMatch)
+		}
+		// Should find the standard (non-service) branch first
+		if wt.Branch != featurePrefix+taskLogin {
+			t.Errorf(fmtGotBranch, wt.Branch, featurePrefix+taskLogin)
+		}
+	})
+
+	t.Run("bare task with only monorepo matches and ambiguity", func(t *testing.T) {
+		// Remove the standard worktree, keep only service-scoped ones
+		monoOnly := []resolver.WorktreeInfo{
+			{Path: "/wt/auth-api-feature-login", Branch: "auth-api/" + featurePrefix + taskLogin},
+			{Path: "/wt/web-app-feature-login", Branch: "web-app/" + featurePrefix + taskLogin},
+		}
+		_, ok := resolver.FindBranchForTask("", taskLogin, monoOnly, prefixes)
+		if ok {
+			t.Fatal("expected no match due to ambiguity (2 services)")
+		}
+	})
+
+	t.Run("bare task with single monorepo match", func(t *testing.T) {
+		singleMono := []resolver.WorktreeInfo{
+			{Path: "/wt/auth-api-feature-login", Branch: "auth-api/" + featurePrefix + taskLogin},
+		}
+		wt, ok := resolver.FindBranchForTask("", taskLogin, singleMono, prefixes)
+		if !ok {
+			t.Fatal(msgExpectedMatch)
+		}
+		if wt.Branch != "auth-api/"+featurePrefix+taskLogin {
+			t.Errorf(fmtGotBranch, wt.Branch, "auth-api/"+featurePrefix+taskLogin)
+		}
+	})
+}
+
+func TestFindAllBranchesForTask(t *testing.T) {
+	worktrees := []resolver.WorktreeInfo{
+		{Path: "/wt/feature-login", Branch: featurePrefix + taskLogin},
+		{Path: "/wt/auth-api-feature-login", Branch: "auth-api/" + featurePrefix + taskLogin},
+		{Path: "/wt/web-app-feature-login", Branch: "web-app/" + featurePrefix + taskLogin},
+	}
+	prefixes := resolver.AllPrefixes()
+
+	matches := resolver.FindAllBranchesForTask(taskLogin, worktrees, prefixes)
+	if len(matches) != 3 {
+		t.Fatalf("expected 3 matches, got %d", len(matches))
+	}
+
+	noMatches := resolver.FindAllBranchesForTask("nonexistent", worktrees, prefixes)
+	if len(noMatches) != 0 {
+		t.Fatalf("expected 0 matches, got %d", len(noMatches))
+	}
 }
 
 func TestAllPrefixes(t *testing.T) {

--- a/internal/resolver/worktree_detail.go
+++ b/internal/resolver/worktree_detail.go
@@ -70,6 +70,16 @@ func FormatStatus(s WorktreeStatus) string {
 	return strings.Join(parts, " ")
 }
 
+// HasService reports whether any detail in the slice has a non-empty service.
+func HasService(details []WorktreeDetail) bool {
+	for _, d := range details {
+		if d.Service != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // SortDetailsByTask sorts a slice of WorktreeDetail by task name ascending.
 func SortDetailsByTask(details []WorktreeDetail) {
 	slices.SortFunc(details, func(a, b WorktreeDetail) int {

--- a/internal/resolver/worktree_detail.go
+++ b/internal/resolver/worktree_detail.go
@@ -17,6 +17,7 @@ type WorktreeStatus struct {
 // WorktreeDetail holds the resolved view of a worktree with extracted task and type.
 type WorktreeDetail struct {
 	Task      string         `json:"task"`
+	Service   string         `json:"service,omitempty"`
 	Type      string         `json:"type"`
 	Branch    string         `json:"branch"`
 	Path      string         `json:"path"`
@@ -24,10 +25,10 @@ type WorktreeDetail struct {
 	Status    WorktreeStatus `json:"status"`
 }
 
-// NewWorktreeDetail constructs a WorktreeDetail by resolving the task name and type
-// from the branch using the given prefixes.
+// NewWorktreeDetail constructs a WorktreeDetail by resolving the task name, service,
+// and type from the branch using the given prefixes.
 func NewWorktreeDetail(branch string, prefixes []string, path string, status WorktreeStatus, isCurrent bool) WorktreeDetail {
-	task, matchedPrefix := TaskFromBranch(branch, prefixes)
+	svc, task, matchedPrefix := ServiceFromBranch(branch, prefixes)
 
 	typeLabel := ""
 	if matchedPrefix != "" {
@@ -36,6 +37,7 @@ func NewWorktreeDetail(branch string, prefixes []string, path string, status Wor
 
 	return WorktreeDetail{
 		Task:      task,
+		Service:   svc,
 		Type:      typeLabel,
 		Branch:    branch,
 		Path:      path,

--- a/internal/resolver/worktree_detail.go
+++ b/internal/resolver/worktree_detail.go
@@ -80,6 +80,21 @@ func HasService(details []WorktreeDetail) bool {
 	return false
 }
 
+// FilterByService returns only details matching the given service name.
+// If service is empty, returns the original slice unchanged.
+func FilterByService(details []WorktreeDetail, service string) []WorktreeDetail {
+	if service == "" {
+		return details
+	}
+	var filtered []WorktreeDetail
+	for _, d := range details {
+		if d.Service == service {
+			filtered = append(filtered, d)
+		}
+	}
+	return filtered
+}
+
 // SortDetailsByTask sorts a slice of WorktreeDetail by task name ascending.
 func SortDetailsByTask(details []WorktreeDetail) {
 	slices.SortFunc(details, func(a, b WorktreeDetail) int {

--- a/internal/resolver/worktree_detail_test.go
+++ b/internal/resolver/worktree_detail_test.go
@@ -152,6 +152,42 @@ func TestHasService(t *testing.T) {
 	})
 }
 
+func TestFilterByService(t *testing.T) {
+	details := []resolver.WorktreeDetail{
+		{Task: "login", Service: "auth-api"},
+		{Task: "signup", Service: "web-app"},
+		{Task: "plain", Service: ""},
+	}
+
+	t.Run("filter by auth-api", func(t *testing.T) {
+		got := resolver.FilterByService(details, "auth-api")
+		if len(got) != 1 || got[0].Task != "login" {
+			t.Errorf("expected [login], got %v", got)
+		}
+	})
+
+	t.Run("filter by web-app", func(t *testing.T) {
+		got := resolver.FilterByService(details, "web-app")
+		if len(got) != 1 || got[0].Task != "signup" {
+			t.Errorf("expected [signup], got %v", got)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		got := resolver.FilterByService(details, "unknown")
+		if len(got) != 0 {
+			t.Errorf("expected empty, got %v", got)
+		}
+	})
+
+	t.Run("empty service returns original", func(t *testing.T) {
+		got := resolver.FilterByService(details, "")
+		if len(got) != len(details) {
+			t.Errorf("expected %d items, got %d", len(details), len(got))
+		}
+	})
+}
+
 func TestNewWorktreeDetailUnknownPrefix(t *testing.T) {
 	const customBranch = "custom-branch"
 	prefixes := resolver.AllPrefixes()

--- a/internal/resolver/worktree_detail_test.go
+++ b/internal/resolver/worktree_detail_test.go
@@ -109,6 +109,49 @@ func TestSortDetailsByTaskEmpty(t *testing.T) {
 	resolver.SortDetailsByTask(details) // should not panic
 }
 
+func TestNewWorktreeDetailWithService(t *testing.T) {
+	prefixes := resolver.AllPrefixes()
+	d := resolver.NewWorktreeDetail("auth-api/feature/login", prefixes, "/wt/auth-api-feature-login", resolver.WorktreeStatus{}, false)
+
+	if d.Service != "auth-api" {
+		t.Errorf("Service = %q, want %q", d.Service, "auth-api")
+	}
+	if d.Task != "login" {
+		t.Errorf("Task = %q, want %q", d.Task, "login")
+	}
+	if d.Type != "feature" {
+		t.Errorf("Type = %q, want %q", d.Type, "feature")
+	}
+}
+
+func TestHasService(t *testing.T) {
+	t.Run("with service", func(t *testing.T) {
+		details := []resolver.WorktreeDetail{
+			{Task: "login", Service: ""},
+			{Task: "signup", Service: "auth-api"},
+		}
+		if !resolver.HasService(details) {
+			t.Error("expected true when a detail has service")
+		}
+	})
+
+	t.Run("without service", func(t *testing.T) {
+		details := []resolver.WorktreeDetail{
+			{Task: "login"},
+			{Task: "signup"},
+		}
+		if resolver.HasService(details) {
+			t.Error("expected false when no detail has service")
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		if resolver.HasService(nil) {
+			t.Error("expected false for nil slice")
+		}
+	})
+}
+
 func TestNewWorktreeDetailUnknownPrefix(t *testing.T) {
 	const customBranch = "custom-branch"
 	prefixes := resolver.AllPrefixes()

--- a/tests/e2e/monorepo_test.go
+++ b/tests/e2e/monorepo_test.go
@@ -1,0 +1,142 @@
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/resolver"
+)
+
+// setupMonorepoRepo creates an initialized repo with a service subdirectory.
+func setupMonorepoRepo(t *testing.T, services ...string) string {
+	t.Helper()
+	repo := setupInitializedRepo(t)
+	for _, svc := range services {
+		if err := os.Mkdir(filepath.Join(repo, svc), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return repo
+}
+
+func TestMonorepoAddCreatesWorktree(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupMonorepoRepo(t, "auth-api")
+
+	r := rimbaSuccess(t, repo, "add", "auth-api/my-task")
+	assertContains(t, r.Stdout, msgCreatedWorktree)
+	assertContains(t, r.Stdout, "service: auth-api")
+
+	// Verify branch name includes service
+	assertContains(t, r.Stdout, "auth-api/feature/my-task")
+
+	// Verify worktree directory exists
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.FullBranchName("auth-api", defaultPrefix, "my-task")
+	wtPath := resolver.WorktreePath(wtDir, branch)
+	assertFileExists(t, wtPath)
+}
+
+func TestMonorepoAddWithPrefix(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupMonorepoRepo(t, "auth-api")
+
+	r := rimbaSuccess(t, repo, "add", "--bugfix", "auth-api/crash-fix")
+	assertContains(t, r.Stdout, "auth-api/bugfix/crash-fix")
+}
+
+func TestMonorepoAddMultiSegmentTask(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupMonorepoRepo(t, "auth-api")
+
+	r := rimbaSuccess(t, repo, "add", "auth-api/auth-redirect/part-1")
+	assertContains(t, r.Stdout, "auth-api/feature/auth-redirect-part-1")
+}
+
+func TestNonMonorepoFallback(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+
+	// "no-such-dir" doesn't exist, so treated as standard with sanitization
+	r := rimbaSuccess(t, repo, "add", "no-such-dir/my-task")
+	assertContains(t, r.Stdout, "feature/no-such-dir-my-task")
+}
+
+func TestStandardAddUnchanged(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+
+	r := rimbaSuccess(t, repo, "add", "simple-task")
+	assertContains(t, r.Stdout, "feature/simple-task")
+	assertNotContains(t, r.Stdout, "service:")
+}
+
+func TestMonorepoRemove(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupMonorepoRepo(t, "auth-api")
+
+	rimbaSuccess(t, repo, "add", "auth-api/my-task")
+	r := rimbaSuccess(t, repo, "remove", "auth-api/my-task")
+	assertContains(t, r.Stdout, "Removed worktree")
+}
+
+func TestMonorepoListShowsServiceColumn(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupMonorepoRepo(t, "auth-api")
+
+	rimbaSuccess(t, repo, "add", "auth-api/my-task")
+	r := rimbaSuccess(t, repo, "list")
+	assertContains(t, r.Stdout, "SERVICE")
+	assertContains(t, r.Stdout, "auth-api")
+}
+
+func TestMonorepoListServiceFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupMonorepoRepo(t, "auth-api", "web-app")
+
+	rimbaSuccess(t, repo, "add", "auth-api/task-a")
+	rimbaSuccess(t, repo, "add", "web-app/task-b")
+
+	// Filter by auth-api
+	r := rimbaSuccess(t, repo, "list", "--service", "auth-api")
+	assertContains(t, r.Stdout, "task-a")
+	assertNotContains(t, r.Stdout, "task-b")
+}
+
+func TestStandardListNoServiceColumn(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+
+	rimbaSuccess(t, repo, "add", "plain-task")
+	r := rimbaSuccess(t, repo, "list")
+	assertNotContains(t, r.Stdout, "SERVICE")
+}


### PR DESCRIPTION
## Summary
- Support 3-segment branch naming (`service/type/task`) for monorepo workflows alongside existing 2-segment names (`type/task`)
- Auto-detect monorepo mode by validating service directory exists in repo root — no config changes needed
- Add `--service` filter flag to `rimba list` and conditional SERVICE column in list/log output

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] 9 new E2E tests covering monorepo add, remove, list, filtering, backwards compatibility
- [x] All existing tests continue to pass (backwards compatible)

Closes #101