### PR TITLE
[feat] Add monorepo support to MCP tool handlers (#97)

### DIFF
--- a/internal/mcp/tool_add.go
+++ b/internal/mcp/tool_add.go
@@ -14,9 +14,9 @@ import (
 
 func registerAddTool(s *server.MCPServer, hctx *HandlerContext) {
 	tool := mcp.NewTool("add",
-		mcp.WithDescription("Create a new worktree for a task"),
+		mcp.WithDescription("Create a new worktree for a task (supports 'service/task' for monorepo)"),
 		mcp.WithString("task",
-			mcp.Description("Task identifier (e.g. 'my-feature', 'JIRA-123')"),
+			mcp.Description("Task identifier (e.g. 'my-feature', 'JIRA-123', or 'auth-api/my-feature' for monorepo)"),
 			mcp.Required(),
 		),
 		mcp.WithString("type",
@@ -43,6 +43,8 @@ func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 			return mcp.NewToolResultError("task is required"), nil
 		}
 
+		service, task := operations.ResolveTaskInput(task, hctx.RepoRoot)
+
 		prefixType := req.GetString("type", "feature")
 
 		cfg, cfgErr := hctx.requireConfig()
@@ -68,6 +70,7 @@ func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		result, err := operations.AddWorktree(hctx.Runner, operations.AddParams{
 			Task:          task,
+			Service:       service,
 			Prefix:        prefix,
 			Source:        source,
 			RepoRoot:      hctx.RepoRoot,

--- a/internal/mcp/tool_add_test.go
+++ b/internal/mcp/tool_add_test.go
@@ -9,8 +9,10 @@ import (
 )
 
 const (
-	branchFeatureMyTask = "feature/my-task"
-	sourceMain          = "main"
+	taskMyTask                 = "my-task"
+	branchFeatureMyTask        = "feature/my-task"
+	branchServiceFeatureMyTask = "auth-api/feature/my-task"
+	sourceMain                 = "main"
 )
 
 func TestAddToolRequiresTask(t *testing.T) {
@@ -93,8 +95,8 @@ func TestAddToolSuccess(t *testing.T) {
 
 	result := callTool(t, handler, map[string]any{"task": "my-task", "skip_deps": true, "skip_hooks": true})
 	data := unmarshalJSON[addResult](t, result)
-	if data.Task != "my-task" {
-		t.Errorf("task = %q, want %q", data.Task, "my-task")
+	if data.Task != taskMyTask {
+		t.Errorf("task = %q, want %q", data.Task, taskMyTask)
 	}
 	if data.Branch != branchFeatureMyTask {
 		t.Errorf("branch = %q, want %q", data.Branch, branchFeatureMyTask)
@@ -216,8 +218,8 @@ func TestAddToolCopyEntriesSkipsMissing(t *testing.T) {
 
 	result := callTool(t, handler, map[string]any{"task": "my-task", "skip_deps": true, "skip_hooks": true})
 	data := unmarshalJSON[addResult](t, result)
-	if data.Task != "my-task" {
-		t.Errorf("task = %q, want %q", data.Task, "my-task")
+	if data.Task != taskMyTask {
+		t.Errorf("task = %q, want %q", data.Task, taskMyTask)
 	}
 }
 
@@ -327,6 +329,43 @@ func TestAddToolPathAlreadyExists(t *testing.T) {
 	errText := resultError(t, result)
 	if !strings.Contains(errText, "already exists") {
 		t.Errorf("expected 'already exists' error, got: %s", errText)
+	}
+}
+
+func TestAddToolServiceScoped(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "auth-api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitRevParse {
+				return "", errors.New("not found")
+			}
+			if len(args) > 0 && args[0] == gitWorktree {
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+	cfg := testConfig()
+	cfg.CopyFiles = nil
+	hctx := &HandlerContext{
+		Runner:   r,
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"task": "auth-api/my-task", "skip_deps": true, "skip_hooks": true})
+	data := unmarshalJSON[addResult](t, result)
+	if data.Task != taskMyTask {
+		t.Errorf("task = %q, want %q", data.Task, taskMyTask)
+	}
+	if data.Branch != branchServiceFeatureMyTask {
+		t.Errorf("branch = %q, want %q", data.Branch, branchServiceFeatureMyTask)
 	}
 }
 

--- a/internal/mcp/tool_list_test.go
+++ b/internal/mcp/tool_list_test.go
@@ -283,7 +283,7 @@ func TestListToolBareEntrySkipped(t *testing.T) {
 	items := unmarshalJSON[[]listItem](t, result)
 	// Only the feature worktree should appear (bare is skipped)
 	for _, item := range items {
-		if item.Branch == "main" {
+		if item.Branch == sourceMain {
 			t.Error("bare entry should be skipped")
 		}
 	}

--- a/internal/mcp/tool_merge.go
+++ b/internal/mcp/tool_merge.go
@@ -10,13 +10,13 @@ import (
 
 func registerMergeTool(s *server.MCPServer, hctx *HandlerContext) {
 	tool := mcp.NewTool("merge",
-		mcp.WithDescription("Merge a worktree branch into main or another worktree"),
+		mcp.WithDescription("Merge a worktree branch into main or another worktree (supports 'service/task' for monorepo)"),
 		mcp.WithString("source",
-			mcp.Description("Source task to merge"),
+			mcp.Description("Source task to merge (e.g. 'my-task' or 'auth-api/my-task' for monorepo)"),
 			mcp.Required(),
 		),
 		mcp.WithString("into",
-			mcp.Description("Target task to merge into (default: main branch)"),
+			mcp.Description("Target task to merge into (default: main branch; supports 'service/task' for monorepo)"),
 		),
 		mcp.WithBoolean("no_ff",
 			mcp.Description("Force a merge commit (no fast-forward)"),
@@ -38,19 +38,29 @@ func handleMerge(hctx *HandlerContext) server.ToolHandlerFunc {
 			return mcp.NewToolResultError("source is required"), nil
 		}
 
+		sourceService, sourceTask := operations.ResolveTaskInput(sourceTask, hctx.RepoRoot)
+
+		intoTask := req.GetString("into", "")
+		var intoService string
+		if intoTask != "" {
+			intoService, intoTask = operations.ResolveTaskInput(intoTask, hctx.RepoRoot)
+		}
+
 		cfg, cfgErr := hctx.requireConfig()
 		if cfgErr != nil {
 			return mcp.NewToolResultError(cfgErr.Error()), nil
 		}
 
 		result, err := operations.MergeWorktree(hctx.Runner, operations.MergeParams{
-			SourceTask: sourceTask,
-			IntoTask:   req.GetString("into", ""),
-			RepoRoot:   hctx.RepoRoot,
-			MainBranch: cfg.DefaultSource,
-			NoFF:       req.GetBool("no_ff", false),
-			Keep:       req.GetBool("keep", false),
-			Delete:     req.GetBool("delete", false),
+			SourceTask:    sourceTask,
+			SourceService: sourceService,
+			IntoTask:      intoTask,
+			IntoService:   intoService,
+			RepoRoot:      hctx.RepoRoot,
+			MainBranch:    cfg.DefaultSource,
+			NoFF:          req.GetBool("no_ff", false),
+			Keep:          req.GetBool("keep", false),
+			Delete:        req.GetBool("delete", false),
 		}, nil)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil

--- a/internal/mcp/tool_merge_test.go
+++ b/internal/mcp/tool_merge_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -61,17 +63,14 @@ func TestMergeToolSourceNotFound(t *testing.T) {
 
 // mergeHappyPathRunner builds a mock runner for the happy-path merge-to-main
 // scenario. The boolean pointers let callers observe which git operations ran.
-func mergeHappyPathRunner(porcelain string, mergedCalled, removedCalled, deletedCalled *bool) *mockRunner {
+func mergeHappyPathRunner(porcelain string, removedCalled *bool) *mockRunner {
 	return &mockRunner{
-		run: mergeHappyPathRun(porcelain, removedCalled, deletedCalled),
+		run: mergeHappyPathRun(porcelain, removedCalled),
 		runInDir: func(dir string, args ...string) (string, error) {
 			if len(args) >= 1 && args[0] == gitStatus {
 				return "", nil
 			}
 			if len(args) >= 1 && args[0] == mergeCmd {
-				if mergedCalled != nil {
-					*mergedCalled = true
-				}
 				return "", nil
 			}
 			return "", nil
@@ -79,7 +78,7 @@ func mergeHappyPathRunner(porcelain string, mergedCalled, removedCalled, deleted
 	}
 }
 
-func mergeHappyPathRun(porcelain string, removedCalled, deletedCalled *bool) func(args ...string) (string, error) {
+func mergeHappyPathRun(porcelain string, removedCalled *bool) func(args ...string) (string, error) {
 	return func(args ...string) (string, error) {
 		if len(args) >= 2 && args[0] == gitWorktree && args[1] == gitList {
 			return porcelain, nil
@@ -91,9 +90,6 @@ func mergeHappyPathRun(porcelain string, removedCalled, deletedCalled *bool) fun
 			return "", nil
 		}
 		if len(args) >= 2 && args[0] == gitBranch && args[1] == "-D" {
-			if deletedCalled != nil {
-				*deletedCalled = true
-			}
 			return "", nil
 		}
 		return "", nil
@@ -106,7 +102,7 @@ func TestMergeToolHappyPathMergeToMain(t *testing.T) {
 		struct{ path, branch string }{"/repo/.worktrees/feature-my-task", branchFeatureMyTask},
 	)
 
-	r := mergeHappyPathRunner(porcelain, nil, nil, nil)
+	r := mergeHappyPathRunner(porcelain, nil)
 	hctx := testContext(r)
 	handler := handleMerge(hctx)
 
@@ -131,7 +127,7 @@ func TestMergeToolKeepSourceWorktree(t *testing.T) {
 	)
 
 	var removeWorktreeCalled bool
-	r := mergeHappyPathRunner(porcelain, nil, &removeWorktreeCalled, nil)
+	r := mergeHappyPathRunner(porcelain, &removeWorktreeCalled)
 	hctx := testContext(r)
 	handler := handleMerge(hctx)
 
@@ -204,7 +200,7 @@ func TestMergeToolIntoAnotherWorktreeWithDelete(t *testing.T) {
 		struct{ path, branch string }{"/repo/.worktrees/feature-target", "feature/target"},
 	)
 
-	r := mergeHappyPathRunner(porcelain, nil, nil, nil)
+	r := mergeHappyPathRunner(porcelain, nil)
 	hctx := testContext(r)
 	handler := handleMerge(hctx)
 
@@ -458,7 +454,7 @@ func TestMergeToolListWorktreesFails(t *testing.T) {
 // arguments via the provided pointer.
 func mergeNoFFRunner(porcelain string, mergeArgs *[]string) *mockRunner {
 	return &mockRunner{
-		run: mergeHappyPathRun(porcelain, nil, nil),
+		run: mergeHappyPathRun(porcelain, nil),
 		runInDir: func(dir string, args ...string) (string, error) {
 			if len(args) >= 1 && args[0] == gitStatus {
 				return "", nil
@@ -469,6 +465,40 @@ func mergeNoFFRunner(porcelain string, mergeArgs *[]string) *mockRunner {
 			}
 			return "", nil
 		},
+	}
+}
+
+func TestMergeToolServiceScoped(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "auth-api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	porcelain := worktreePorcelain(
+		struct{ path, branch string }{tmpDir, "main"},
+		struct{ path, branch string }{tmpDir + "/.worktrees/auth-api-feature-my-task", branchServiceFeatureMyTask},
+	)
+
+	r := mergeHappyPathRunner(porcelain, nil)
+	hctx := &HandlerContext{
+		Runner:   r,
+		Config:   testConfig(),
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleMerge(hctx)
+
+	result := callTool(t, handler, map[string]any{"source": "auth-api/my-task"})
+	data := unmarshalJSON[mergeResult](t, result)
+
+	if data.Source != branchServiceFeatureMyTask {
+		t.Errorf("expected source 'auth-api/feature/my-task', got %q", data.Source)
+	}
+	if data.Into != "main" {
+		t.Errorf("expected into 'main', got %q", data.Into)
+	}
+	if !data.SourceRemoved {
+		t.Errorf("expected source to be removed (auto-cleanup)")
 	}
 }
 

--- a/internal/mcp/tool_remove.go
+++ b/internal/mcp/tool_remove.go
@@ -10,9 +10,9 @@ import (
 
 func registerRemoveTool(s *server.MCPServer, hctx *HandlerContext) {
 	tool := mcp.NewTool("remove",
-		mcp.WithDescription("Remove a worktree and optionally delete its branch"),
+		mcp.WithDescription("Remove a worktree and optionally delete its branch (supports 'service/task' for monorepo)"),
 		mcp.WithString("task",
-			mcp.Description("Task identifier of the worktree to remove"),
+			mcp.Description("Task identifier of the worktree to remove (e.g. 'my-task' or 'auth-api/my-task' for monorepo)"),
 			mcp.Required(),
 		),
 		mcp.WithBoolean("keep_branch",
@@ -32,12 +32,14 @@ func handleRemove(hctx *HandlerContext) server.ToolHandlerFunc {
 			return mcp.NewToolResultError("task is required"), nil
 		}
 
+		service, task := operations.ResolveTaskInput(task, hctx.RepoRoot)
+
 		keepBranch := req.GetBool("keep_branch", false)
 		force := req.GetBool("force", false)
 
 		r := hctx.Runner
 
-		wt, findErr := operations.FindWorktree(r, "", task)
+		wt, findErr := operations.FindWorktree(r, service, task)
 		if findErr != nil {
 			return mcp.NewToolResultError(findErr.Error()), nil
 		}

--- a/internal/mcp/tool_remove_test.go
+++ b/internal/mcp/tool_remove_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -183,6 +185,52 @@ func TestRemoveToolRemoveWorktreeFails(t *testing.T) {
 	errText := resultError(t, result)
 	if !strings.Contains(errText, "has changes") {
 		t.Errorf("expected removal error, got: %s", errText)
+	}
+}
+
+func TestRemoveToolServiceScoped(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "auth-api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	porcelain := worktreePorcelain(
+		struct{ path, branch string }{tmpDir, "main"},
+		struct{ path, branch string }{tmpDir + "/.worktrees/auth-api-feature-login", "auth-api/feature/login"},
+	)
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == gitWorktree && args[1] == gitList {
+				return porcelain, nil
+			}
+			if len(args) >= 2 && args[0] == gitWorktree && args[1] == gitRemove {
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == gitBranch {
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+	hctx := &HandlerContext{
+		Runner:   r,
+		Config:   testConfig(),
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleRemove(hctx)
+
+	result := callTool(t, handler, map[string]any{"task": "auth-api/login"})
+	data := unmarshalJSON[removeResult](t, result)
+	if data.Task != "login" {
+		t.Errorf("task = %q, want %q", data.Task, "login")
+	}
+	if data.Branch != "auth-api/feature/login" {
+		t.Errorf("branch = %q, want %q", data.Branch, "auth-api/feature/login")
+	}
+	if !data.WorktreeRemoved {
+		t.Error("expected worktree_removed=true")
 	}
 }
 

--- a/internal/mcp/tool_sync.go
+++ b/internal/mcp/tool_sync.go
@@ -13,9 +13,9 @@ import (
 
 func registerSyncTool(s *server.MCPServer, hctx *HandlerContext) {
 	tool := mcp.NewTool("sync",
-		mcp.WithDescription("Sync worktree(s) with the main branch via rebase or merge, then push"),
+		mcp.WithDescription("Sync worktree(s) with the main branch via rebase or merge, then push (supports 'service/task' for monorepo)"),
 		mcp.WithString("task",
-			mcp.Description("Single task to sync"),
+			mcp.Description("Single task to sync (e.g. 'my-task' or 'auth-api/my-task' for monorepo)"),
 		),
 		mcp.WithBoolean("all",
 			mcp.Description("Sync all eligible worktrees"),
@@ -58,6 +58,11 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 			return mcp.NewToolResultError("provide a task name or set all=true to sync all worktrees"), nil
 		}
 
+		var service string
+		if task != "" {
+			service, task = operations.ResolveTaskInput(task, hctx.RepoRoot)
+		}
+
 		r := hctx.Runner
 
 		// Fetch (non-fatal)
@@ -80,14 +85,14 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 		}
 
 		if !all {
-			return syncSingle(r, task, worktrees, prefixes, opts)
+			return syncSingle(r, service, task, worktrees, prefixes, opts)
 		}
 		return syncMultiple(r, worktrees, prefixes, opts, includeInherited)
 	}
 }
 
-func syncSingle(r git.Runner, task string, worktrees []resolver.WorktreeInfo, prefixes []string, opts syncOpts) (*mcp.CallToolResult, error) {
-	wt, found := resolver.FindBranchForTask("", task, worktrees, prefixes)
+func syncSingle(r git.Runner, service, task string, worktrees []resolver.WorktreeInfo, prefixes []string, opts syncOpts) (*mcp.CallToolResult, error) {
+	wt, found := resolver.FindBranchForTask(service, task, worktrees, prefixes)
 	if !found {
 		return mcp.NewToolResultError("worktree not found for task \"" + task + "\""), nil
 	}

--- a/internal/mcp/tool_sync_test.go
+++ b/internal/mcp/tool_sync_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -232,6 +234,41 @@ func TestSyncSingleMergeMode(t *testing.T) {
 		t.Fatalf("expected 1 result, got %d", len(data.Results))
 	}
 	if !data.Results[0].Synced {
+		t.Errorf("expected synced=true")
+	}
+}
+
+func TestSyncSingleServiceScoped(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "auth-api"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	porcelain := worktreePorcelain(
+		struct{ path, branch string }{tmpDir, "main"},
+		struct{ path, branch string }{tmpDir + "/.worktrees/auth-api-feature-my-task", branchServiceFeatureMyTask},
+	)
+
+	r := newSyncMockRunner(porcelain, syncMockConfig{}, nil, nil)
+	hctx := &HandlerContext{
+		Runner:   r,
+		Config:   testConfig(),
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleSync(hctx)
+
+	result := callTool(t, handler, map[string]any{"task": "auth-api/my-task"})
+	data := unmarshalJSON[syncResult](t, result)
+
+	if len(data.Results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(data.Results))
+	}
+	sr := data.Results[0]
+	if sr.Branch != branchServiceFeatureMyTask {
+		t.Errorf("expected branch 'auth-api/feature/my-task', got %q", sr.Branch)
+	}
+	if !sr.Synced {
 		t.Errorf("expected synced=true")
 	}
 }


### PR DESCRIPTION
## Summary
- Add `operations.ResolveTaskInput` calls to all 4 MCP tool handlers (`add`, `remove`, `sync`, `merge`) so callers can pass service-scoped task identifiers like `auth-api/my-task`
- Update tool descriptions to document monorepo input format
- Add service-scoped test cases using real temp directories for all 4 handlers

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New tests: `TestAddToolServiceScoped`, `TestRemoveToolServiceScoped`, `TestSyncSingleServiceScoped`, `TestMergeToolServiceScoped`
- [x] Existing tests unaffected (backward compatible — `RepoRoot: "/repo"` returns empty service)

Closes #97