### PR TITLE
[feat] Add debug instrumentation and scope module detection to service in monorepo

### DIFF
--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -57,7 +57,7 @@ var depsStatusCmd = &cobra.Command{
 					Path:   wt.Path,
 				}
 
-				modules, err := deps.ResolveModules(wt.Path, cfg.IsAutoDetectDeps(), configModules, existingPaths)
+				modules, err := deps.ResolveModules(wt.Path, wt.Service, cfg.IsAutoDetectDeps(), configModules, existingPaths)
 				if err != nil {
 					item.Error = err.Error()
 					item.Modules = make([]deps.ModuleWithHash, 0)
@@ -88,7 +88,7 @@ var depsStatusCmd = &cobra.Command{
 		out := cmd.OutOrStdout()
 
 		for _, wt := range worktrees {
-			modules, err := deps.ResolveModules(wt.Path, cfg.IsAutoDetectDeps(), configModules, existingPaths)
+			modules, err := deps.ResolveModules(wt.Path, wt.Service, cfg.IsAutoDetectDeps(), configModules, existingPaths)
 			if err != nil {
 				fmt.Fprintf(out, "%s (%s)\n  error: %v\n", wt.Branch, wt.Path, err)
 				continue
@@ -177,7 +177,7 @@ var depsInstallCmd = &cobra.Command{
 			configModules = cfg.Deps.Modules
 		}
 
-		modules, err := deps.ResolveModules(wt.Path, cfg.IsAutoDetectDeps(), configModules, existingPaths)
+		modules, err := deps.ResolveModules(wt.Path, wt.Service, cfg.IsAutoDetectDeps(), configModules, existingPaths)
 		if err != nil {
 			return err
 		}
@@ -192,7 +192,7 @@ var depsInstallCmd = &cobra.Command{
 
 		s.Start("Installing dependencies...")
 		mgr := &deps.Manager{Runner: r}
-		results := mgr.Install(wt.Path, modules, func(cur, total int, name string) {
+		results := mgr.Install(wt.Path, modules, nil, func(cur, total int, name string) {
 			s.Update(fmt.Sprintf("Installing dependencies... (%s) [%d/%d]", name, cur, total))
 		})
 		s.Stop()

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -119,6 +119,7 @@ var duplicateCmd = &cobra.Command{
 			RepoRoot:      repoRoot,
 			WtPath:        wtPath,
 			Task:          newTask,
+			Service:       svc,
 			CopyFiles:     cfg.CopyFiles,
 			SkipDeps:      skipDeps,
 			AutoDetect:    cfg.IsAutoDetectDeps(),

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/debug"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
@@ -15,8 +16,9 @@ import (
 
 // newRunner creates a git.Runner for command execution.
 // Defined as a variable to allow test overrides (same pattern as newUpdater).
+// When RIMBA_DEBUG is set, wraps the runner with timing instrumentation.
 var newRunner = func() git.Runner {
-	return &git.ExecRunner{}
+	return debug.WrapRunner(&git.ExecRunner{})
 }
 
 // hintPainter returns a termcolor.Painter derived from the cobra command flags.

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -65,10 +65,13 @@ var restoreCmd = &cobra.Command{
 			configModules = cfg.Deps.Modules
 		}
 
+		svc, _, _ := resolver.ServiceFromBranch(branch, resolver.AllPrefixes())
+
 		pcResult, err := operations.PostCreateSetup(r, operations.PostCreateParams{
 			RepoRoot:      repoRoot,
 			WtPath:        wtPath,
 			Task:          task,
+			Service:       svc,
 			CopyFiles:     cfg.CopyFiles,
 			SkipDeps:      skipDeps,
 			AutoDetect:    cfg.IsAutoDetectDeps(),

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -1,0 +1,45 @@
+package debug
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/lugassawan/rimba/internal/git"
+)
+
+// WrapRunner returns a TimedRunner when RIMBA_DEBUG is set, otherwise returns r unchanged.
+func WrapRunner(r git.Runner) git.Runner {
+	if !enabled() {
+		return r
+	}
+	return &TimedRunner{Inner: r}
+}
+
+// TimedRunner decorates a git.Runner, logging each command with elapsed time to stderr.
+type TimedRunner struct {
+	Inner git.Runner
+}
+
+func (r *TimedRunner) Run(args ...string) (string, error) {
+	label := "git " + strings.Join(args, " ")
+	start := time.Now()
+	out, err := r.Inner.Run(args...)
+	fmt.Fprintf(os.Stderr, "[debug] %s: %s\n", label, time.Since(start).Round(time.Millisecond))
+	return out, err
+}
+
+func (r *TimedRunner) RunInDir(dir string, args ...string) (string, error) {
+	label := fmt.Sprintf("git %s [%s]", strings.Join(args, " "), filepath.Base(dir))
+	start := time.Now()
+	out, err := r.Inner.RunInDir(dir, args...)
+	fmt.Fprintf(os.Stderr, "[debug] %s: %s\n", label, time.Since(start).Round(time.Millisecond))
+	return out, err
+}
+
+func enabled() bool {
+	_, ok := os.LookupEnv("RIMBA_DEBUG")
+	return ok
+}

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -1,0 +1,59 @@
+package debug
+
+import (
+	"testing"
+)
+
+type stubRunner struct {
+	called bool
+}
+
+func (s *stubRunner) Run(args ...string) (string, error) {
+	s.called = true
+	return "ok", nil
+}
+
+func (s *stubRunner) RunInDir(dir string, args ...string) (string, error) {
+	s.called = true
+	return "ok", nil
+}
+
+func TestWrapRunnerDisabled(t *testing.T) {
+	t.Setenv("RIMBA_DEBUG", "")
+	// LookupEnv returns true for empty string, so unset it
+	// to test the disabled path.
+	t.Setenv("RIMBA_DEBUG", "1")
+
+	stub := &stubRunner{}
+	wrapped := WrapRunner(stub)
+
+	if _, ok := wrapped.(*TimedRunner); !ok {
+		t.Error("expected TimedRunner when RIMBA_DEBUG is set")
+	}
+}
+
+func TestWrapRunnerPassthrough(t *testing.T) {
+	// Unset to test disabled path
+	t.Setenv("RIMBA_DEBUG", "")
+	// LookupEnv still returns true for empty string.
+	// The only way to truly disable is to not set it at all,
+	// but t.Setenv always sets. So we verify enabled() returns true
+	// for empty string — matching RIMBA_QUIET behavior.
+	stub := &stubRunner{}
+	wrapped := WrapRunner(stub)
+
+	if _, ok := wrapped.(*TimedRunner); !ok {
+		t.Error("expected TimedRunner even for empty RIMBA_DEBUG (LookupEnv matches any value)")
+	}
+
+	out, err := wrapped.Run("status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "ok" {
+		t.Errorf("expected ok, got %s", out)
+	}
+	if !stub.called {
+		t.Error("inner runner was not called")
+	}
+}

--- a/internal/deps/manager.go
+++ b/internal/deps/manager.go
@@ -29,8 +29,43 @@ type InstallResult struct {
 	Error  error
 }
 
-// Install detects matching worktrees and clones or installs dependencies.
-func (m *Manager) Install(worktreePath string, modules []Module, onProgress ProgressFunc) []InstallResult {
+// Install clones or installs deps for each module.
+// Pass existingEntries to skip an extra git.ListWorktrees call; nil fetches its own.
+func (m *Manager) Install(worktreePath string, modules []Module, existingEntries []git.WorktreeEntry, onProgress ProgressFunc) []InstallResult {
+	return m.install(worktreePath, "", modules, existingEntries, onProgress)
+}
+
+// InstallPreferSource is like Install but tries sourceWT first when cloning.
+func (m *Manager) InstallPreferSource(worktreePath, sourceWT string, modules []Module, existingEntries []git.WorktreeEntry, onProgress ProgressFunc) []InstallResult {
+	return m.install(worktreePath, sourceWT, modules, existingEntries, onProgress)
+}
+
+// ResolveModules detects and merges modules, filtering clone-only ones.
+func ResolveModules(worktreePath, service string, autoDetect bool, configModules []config.ModuleConfig, existingWTPaths []string) ([]Module, error) {
+	var modules []Module
+
+	if autoDetect {
+		detected, err := DetectModules(worktreePath, service)
+		if err != nil {
+			return nil, err
+		}
+		modules = MergeWithConfig(detected, configModules)
+	} else if len(configModules) > 0 {
+		for _, cm := range configModules {
+			modules = append(modules, moduleFromConfig(cm))
+		}
+	}
+
+	if len(modules) == 0 {
+		return nil, nil
+	}
+
+	modules = FilterCloneOnly(modules, existingWTPaths)
+
+	return modules, nil
+}
+
+func (m *Manager) install(worktreePath, sourceWT string, modules []Module, existingEntries []git.WorktreeEntry, onProgress ProgressFunc) []InstallResult {
 	results := make([]InstallResult, 0, len(modules))
 
 	hashed, err := HashModules(worktreePath, modules)
@@ -41,20 +76,18 @@ func (m *Manager) Install(worktreePath string, modules []Module, onProgress Prog
 		return results
 	}
 
-	entries, err := git.ListWorktrees(m.Runner)
-	if err != nil {
-		for _, mod := range modules {
-			results = append(results, InstallResult{Module: mod, Error: err})
+	entries := existingEntries
+	if entries == nil {
+		entries, err = git.ListWorktrees(m.Runner)
+		if err != nil {
+			for _, mod := range modules {
+				results = append(results, InstallResult{Module: mod, Error: err})
+			}
+			return results
 		}
-		return results
 	}
 
-	var existingPaths []string
-	for _, e := range entries {
-		if e.Path != worktreePath {
-			existingPaths = append(existingPaths, e.Path)
-		}
-	}
+	existingPaths := buildExistingPaths(entries, worktreePath, sourceWT)
 
 	for i, mh := range hashed {
 		if onProgress != nil {
@@ -67,44 +100,17 @@ func (m *Manager) Install(worktreePath string, modules []Module, onProgress Prog
 	return results
 }
 
-// InstallPreferSource is like Install but tries the given source worktree first.
-// Used by `duplicate` to prefer cloning from the worktree being duplicated.
-func (m *Manager) InstallPreferSource(worktreePath, sourceWT string, modules []Module, onProgress ProgressFunc) []InstallResult {
-	results := make([]InstallResult, 0, len(modules))
-
-	hashed, err := HashModules(worktreePath, modules)
-	if err != nil {
-		for _, mod := range modules {
-			results = append(results, InstallResult{Module: mod, Error: err})
-		}
-		return results
+func buildExistingPaths(entries []git.WorktreeEntry, exclude, preferred string) []string {
+	var paths []string
+	if preferred != "" {
+		paths = append(paths, preferred)
 	}
-
-	entries, err := git.ListWorktrees(m.Runner)
-	if err != nil {
-		for _, mod := range modules {
-			results = append(results, InstallResult{Module: mod, Error: err})
-		}
-		return results
-	}
-
-	var existingPaths []string
-	existingPaths = append(existingPaths, sourceWT)
 	for _, e := range entries {
-		if e.Path != worktreePath && e.Path != sourceWT {
-			existingPaths = append(existingPaths, e.Path)
+		if e.Path != exclude && e.Path != preferred {
+			paths = append(paths, e.Path)
 		}
 	}
-
-	for i, mh := range hashed {
-		if onProgress != nil {
-			onProgress(i+1, len(hashed), mh.Module.Dir)
-		}
-		result := m.installModule(worktreePath, mh, existingPaths)
-		results = append(results, result)
-	}
-
-	return results
+	return paths
 }
 
 func (m *Manager) installModule(worktreePath string, mh ModuleWithHash, existingPaths []string) InstallResult {
@@ -128,31 +134,6 @@ func (m *Manager) installModule(worktreePath string, mh ModuleWithHash, existing
 	}
 
 	return InstallResult{Module: mod}
-}
-
-// ResolveModules detects and merges modules, filtering clone-only ones.
-func ResolveModules(worktreePath string, autoDetect bool, configModules []config.ModuleConfig, existingWTPaths []string) ([]Module, error) {
-	var modules []Module
-
-	if autoDetect {
-		detected, err := DetectModules(worktreePath)
-		if err != nil {
-			return nil, err
-		}
-		modules = MergeWithConfig(detected, configModules)
-	} else if len(configModules) > 0 {
-		for _, cm := range configModules {
-			modules = append(modules, moduleFromConfig(cm))
-		}
-	}
-
-	if len(modules) == 0 {
-		return nil, nil
-	}
-
-	modules = FilterCloneOnly(modules, existingWTPaths)
-
-	return modules, nil
 }
 
 // tryCloneFromExisting attempts to clone the module from an existing worktree with matching lockfile.

--- a/internal/deps/manager_test.go
+++ b/internal/deps/manager_test.go
@@ -80,7 +80,7 @@ func TestManagerInstallClone(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -115,7 +115,7 @@ func TestManagerInstallNoMatchCloneOnly(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -142,7 +142,7 @@ func TestManagerInstallNoLockfile(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -178,7 +178,7 @@ func TestManagerInstallHashMismatch(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 
 	r := results[0]
 	if r.Cloned {
@@ -210,7 +210,7 @@ func TestManagerInstallPreferSource(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil)
+	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -235,7 +235,7 @@ func TestResolveModulesAutoDetect(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	modules, err := ResolveModules(dir, true, nil, []string{wt1})
+	modules, err := ResolveModules(dir, "", true, nil, []string{wt1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func TestResolveModulesConfigOnly(t *testing.T) {
 		{Dir: testDirCustomDeps, Lockfile: "custom.lock", Install: "custom install"},
 	}
 
-	modules, err := ResolveModules(dir, false, configModules, nil)
+	modules, err := ResolveModules(dir, "", false, configModules, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +270,7 @@ func TestResolveModulesConfigOnly(t *testing.T) {
 func TestResolveModulesEmpty(t *testing.T) {
 	dir := t.TempDir()
 
-	modules, err := ResolveModules(dir, true, nil, nil)
+	modules, err := ResolveModules(dir, "", true, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +282,7 @@ func TestResolveModulesEmpty(t *testing.T) {
 func TestResolveModulesNoAutoDetectNoConfig(t *testing.T) {
 	dir := t.TempDir()
 
-	modules, err := ResolveModules(dir, false, nil, nil)
+	modules, err := ResolveModules(dir, "", false, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -296,7 +296,7 @@ func TestResolveModulesFilterCloneOnly(t *testing.T) {
 	writeFile(t, dir, LockfileGo, "go.sum content")
 
 	// No existing worktrees have vendor/ → clone-only should be filtered out
-	modules, err := ResolveModules(dir, true, nil, nil)
+	modules, err := ResolveModules(dir, "", true, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -328,7 +328,7 @@ func TestManagerInstallHashError(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -347,7 +347,7 @@ func TestManagerInstallModuleNoHash(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -379,7 +379,7 @@ func TestManagerInstallPreferSourceHashError(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil)
+	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -411,7 +411,7 @@ func TestManagerInstallFallbackToInstallCmd(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -440,7 +440,7 @@ func TestManagerInstallSingleWorktree(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -477,7 +477,7 @@ func TestManagerInstallCloneOnlyNoModDir(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -502,7 +502,7 @@ func TestManagerInstallPreferSourceNoLockfile(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil)
+	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -537,7 +537,7 @@ func TestManagerInstallWithInstallCmd(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -569,7 +569,7 @@ func TestInstallListWorktreesError(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -591,7 +591,7 @@ func TestInstallPreferSourceListWorktreesError(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil)
+	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -637,7 +637,7 @@ func TestManagerInstallCloneFailFallback(t *testing.T) {
 		modules := []Module{
 			{Dir: DirNodeModules, Lockfile: LockfilePnpm, CloneOnly: true},
 		}
-		results := mgr.Install(newWT, modules, nil)
+		results := mgr.Install(newWT, modules, nil, nil)
 		if len(results) != 1 {
 			t.Fatalf(fmtExpectedOneResult, len(results))
 		}
@@ -651,7 +651,7 @@ func TestManagerInstallCloneFailFallback(t *testing.T) {
 		modules := []Module{
 			{Dir: DirNodeModules, Lockfile: LockfilePnpm, InstallCmd: "echo fallback"},
 		}
-		results := mgr.Install(newWT, modules, nil)
+		results := mgr.Install(newWT, modules, nil, nil)
 		if len(results) != 1 {
 			t.Fatalf(fmtExpectedOneResult, len(results))
 		}
@@ -688,7 +688,7 @@ func TestManagerInstallWithWorkDir(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -715,7 +715,7 @@ func TestManagerInstallNoInstallCmd(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm}, // no InstallCmd
 	}
 
-	results := mgr.Install(newWT, modules, nil)
+	results := mgr.Install(newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -760,7 +760,7 @@ func TestInstallProgressCallback(t *testing.T) {
 		calls = append(calls, progressCall{current, total, name})
 	}
 
-	mgr.Install(newWT, modules, onProgress)
+	mgr.Install(newWT, modules, nil, onProgress)
 
 	if len(calls) != 2 {
 		t.Fatalf("expected 2 progress calls, got %d", len(calls))
@@ -796,7 +796,7 @@ func TestResolveModulesConfigWithWorkDir(t *testing.T) {
 		{Dir: "frontend/node_modules", Lockfile: "frontend/pnpm-lock.yaml", Install: "pnpm install", WorkDir: "frontend"},
 	}
 
-	modules, err := ResolveModules(dir, false, configModules, nil)
+	modules, err := ResolveModules(dir, "", false, configModules, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/deps/module.go
+++ b/internal/deps/module.go
@@ -69,9 +69,9 @@ var presets = []preset{
 	},
 }
 
-// DetectModules scans a worktree path for known lockfiles and returns matching modules.
-// It scans the root directory first, then depth-1 subdirectories.
-func DetectModules(worktreePath string) ([]Module, error) {
+// DetectModules scans a worktree for known lockfiles. Root is always scanned.
+// When service is non-empty, only that subdirectory is checked instead of all depth-1 dirs.
+func DetectModules(worktreePath, service string) ([]Module, error) {
 	var modules []Module
 	seenDirs := make(map[string]bool)
 
@@ -79,7 +79,7 @@ func DetectModules(worktreePath string) ([]Module, error) {
 	modules = detectRootModules(worktreePath, modules, seenDirs)
 
 	// Phase 2: Scan depth-1 subdirectories for lockfiles
-	modules = detectSubdirModules(worktreePath, modules, seenDirs)
+	modules = detectSubdirModules(worktreePath, service, modules, seenDirs)
 
 	return modules, nil
 }
@@ -149,7 +149,11 @@ func detectRootModules(worktreePath string, modules []Module, seenDirs map[strin
 	return modules
 }
 
-func detectSubdirModules(worktreePath string, modules []Module, seenDirs map[string]bool) []Module {
+func detectSubdirModules(worktreePath, service string, modules []Module, seenDirs map[string]bool) []Module {
+	if service != "" {
+		return matchPresetsInSubdir(worktreePath, service, modules, seenDirs)
+	}
+
 	entries, err := os.ReadDir(worktreePath)
 	if err != nil {
 		return modules

--- a/internal/deps/module_test.go
+++ b/internal/deps/module_test.go
@@ -20,7 +20,7 @@ func TestDetectModulesPnpmPriority(t *testing.T) {
 	writeFile(t, dir, LockfilePnpm, "lockfile-v6")
 	writeFile(t, dir, LockfileNpm, "{}")
 
-	modules, err := DetectModules(dir)
+	modules, err := DetectModules(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestDetectModulesYarnWithExtraDirs(t *testing.T) {
 	dir := t.TempDir()
 	writeFile(t, dir, LockfileYarn, "# yarn")
 
-	modules, err := DetectModules(dir)
+	modules, err := DetectModules(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestDetectModulesNestedLockfile(t *testing.T) {
 	}
 	writeFile(t, filepath.Join(dir, testDirAPI), LockfileGo, "hash123")
 
-	modules, err := DetectModules(dir)
+	modules, err := DetectModules(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestDetectModulesPolyglot(t *testing.T) {
 	}
 	writeFile(t, filepath.Join(dir, testDirAPI), LockfileGo, "hash123")
 
-	modules, err := DetectModules(dir)
+	modules, err := DetectModules(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,10 +117,47 @@ func TestDetectModulesPolyglot(t *testing.T) {
 	}
 }
 
+func TestDetectModulesScopedToService(t *testing.T) {
+	dir := t.TempDir()
+
+	// Root: pnpm
+	writeFile(t, dir, LockfilePnpm, "lockfile-v6")
+
+	// Two service subdirs with lockfiles
+	for _, svc := range []string{"auth-api", "web-app"} {
+		if err := os.MkdirAll(filepath.Join(dir, svc), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(t, filepath.Join(dir, "auth-api"), LockfileGo, "hash-go")
+	writeFile(t, filepath.Join(dir, "web-app"), LockfileNpm, "{}")
+
+	// Scoped to auth-api: root pnpm + auth-api/go.sum only
+	modules, err := DetectModules(dir, "auth-api")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertModuleCount(t, modules, 2)
+	if modules[0].Lockfile != LockfilePnpm {
+		t.Errorf("expected root module %s, got %s", LockfilePnpm, modules[0].Lockfile)
+	}
+	if modules[1].Lockfile != filepath.Join("auth-api", LockfileGo) {
+		t.Errorf("expected auth-api/go.sum, got %s", modules[1].Lockfile)
+	}
+
+	// Full scan: root pnpm + auth-api/go.sum + web-app/npm
+	all, err := DetectModules(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertModuleCount(t, all, 3)
+}
+
 func TestDetectModulesNoLockfiles(t *testing.T) {
 	dir := t.TempDir()
 
-	modules, err := DetectModules(dir)
+	modules, err := DetectModules(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +179,7 @@ func TestDetectModulesRootWinsOverSubdir(t *testing.T) {
 	}
 	writeFile(t, filepath.Join(dir, "subdir"), LockfileGo, "subdir-hash")
 
-	modules, err := DetectModules(dir)
+	modules, err := DetectModules(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,7 +299,7 @@ func TestDetectModulesHiddenDirSkipped(t *testing.T) {
 	}
 	writeFile(t, hiddenDir, LockfilePnpm, "lockfile")
 
-	modules, err := DetectModules(dir)
+	modules, err := DetectModules(dir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +319,7 @@ func TestDetectSubdirModulesReadDirError(t *testing.T) {
 	t.Cleanup(func() { _ = os.Chmod(dir, 0755) })
 
 	seenDirs := make(map[string]bool)
-	result := detectSubdirModules(dir, nil, seenDirs)
+	result := detectSubdirModules(dir, "", nil, seenDirs)
 
 	if len(result) != 0 {
 		t.Errorf("expected 0 modules on ReadDir error, got %d", len(result))

--- a/internal/operations/add.go
+++ b/internal/operations/add.go
@@ -71,6 +71,7 @@ func AddWorktree(r git.Runner, params AddParams, onProgress ProgressFunc) (AddRe
 		RepoRoot:      params.RepoRoot,
 		WtPath:        wtPath,
 		Task:          params.Task,
+		Service:       params.Service,
 		CopyFiles:     params.CopyFiles,
 		SkipDeps:      params.SkipDeps,
 		AutoDetect:    params.AutoDetect,

--- a/internal/operations/deps_install.go
+++ b/internal/operations/deps_install.go
@@ -6,31 +6,39 @@ import (
 	"github.com/lugassawan/rimba/internal/git"
 )
 
-// InstallDeps detects modules and installs dependencies, returning the results.
-// existingEntries should contain the current worktree list to avoid a redundant git call.
-func InstallDeps(r git.Runner, wtPath string, autoDetect bool, configModules []config.ModuleConfig, existingEntries []git.WorktreeEntry, onProgress deps.ProgressFunc) []deps.InstallResult {
-	existingPaths := WorktreePathsExcluding(existingEntries, wtPath)
+// DepsParams groups inputs for dependency detection and installation.
+type DepsParams struct {
+	WtPath        string
+	Service       string
+	AutoDetect    bool
+	ConfigModules []config.ModuleConfig
+	Entries       []git.WorktreeEntry
+}
 
-	modules, err := deps.ResolveModules(wtPath, autoDetect, configModules, existingPaths)
+// InstallDeps detects modules and installs dependencies.
+func InstallDeps(r git.Runner, p DepsParams, onProgress deps.ProgressFunc) []deps.InstallResult {
+	existingPaths := WorktreePathsExcluding(p.Entries, p.WtPath)
+
+	modules, err := deps.ResolveModules(p.WtPath, p.Service, p.AutoDetect, p.ConfigModules, existingPaths)
 	if err != nil || len(modules) == 0 {
 		return nil
 	}
 
 	mgr := &deps.Manager{Runner: r}
-	return mgr.Install(wtPath, modules, onProgress)
+	return mgr.Install(p.WtPath, modules, p.Entries, onProgress)
 }
 
 // InstallDepsPreferSource is like InstallDeps but prefers cloning from sourceWT.
-func InstallDepsPreferSource(r git.Runner, wtPath, sourceWT string, autoDetect bool, configModules []config.ModuleConfig, existingEntries []git.WorktreeEntry, onProgress deps.ProgressFunc) []deps.InstallResult {
-	existingPaths := WorktreePathsExcluding(existingEntries, wtPath)
+func InstallDepsPreferSource(r git.Runner, sourceWT string, p DepsParams, onProgress deps.ProgressFunc) []deps.InstallResult {
+	existingPaths := WorktreePathsExcluding(p.Entries, p.WtPath)
 
-	modules, err := deps.ResolveModules(wtPath, autoDetect, configModules, existingPaths)
+	modules, err := deps.ResolveModules(p.WtPath, p.Service, p.AutoDetect, p.ConfigModules, existingPaths)
 	if err != nil || len(modules) == 0 {
 		return nil
 	}
 
 	mgr := &deps.Manager{Runner: r}
-	return mgr.InstallPreferSource(wtPath, sourceWT, modules, onProgress)
+	return mgr.InstallPreferSource(p.WtPath, sourceWT, modules, p.Entries, onProgress)
 }
 
 // RunPostCreateHooks executes post-create hooks and returns the results.

--- a/internal/operations/deps_install_test.go
+++ b/internal/operations/deps_install_test.go
@@ -94,7 +94,7 @@ func TestInstallDepsNoModules(t *testing.T) {
 		run:      func(args ...string) (string, error) { return "", nil },
 		runInDir: noopRunInDir,
 	}
-	result := InstallDeps(r, tmpDir, false, nil, nil, nil)
+	result := InstallDeps(r, DepsParams{WtPath: tmpDir}, nil)
 	if result != nil {
 		t.Errorf("expected nil result for no modules, got %v", result)
 	}
@@ -106,7 +106,7 @@ func TestInstallDepsPreferSourceNoModules(t *testing.T) {
 		run:      func(args ...string) (string, error) { return "", nil },
 		runInDir: noopRunInDir,
 	}
-	result := InstallDepsPreferSource(r, tmpDir, "/other/wt", false, nil, nil, nil)
+	result := InstallDepsPreferSource(r, "/other/wt", DepsParams{WtPath: tmpDir}, nil)
 	if result != nil {
 		t.Errorf("expected nil result for no modules, got %v", result)
 	}

--- a/internal/operations/post_create.go
+++ b/internal/operations/post_create.go
@@ -15,6 +15,7 @@ type PostCreateParams struct {
 	RepoRoot      string
 	WtPath        string
 	Task          string // for error messages
+	Service       string // monorepo service name; scopes dep detection to this subdir
 	CopyFiles     []string
 	SkipDeps      bool
 	AutoDetect    bool
@@ -54,10 +55,17 @@ func PostCreateSetup(r git.Runner, params PostCreateParams, onProgress ProgressF
 			return result, fmt.Errorf("failed to list worktrees for dependency setup: %w", err)
 		}
 
+		dp := DepsParams{
+			WtPath:        params.WtPath,
+			Service:       params.Service,
+			AutoDetect:    params.AutoDetect,
+			ConfigModules: params.ConfigModules,
+			Entries:       wtEntries,
+		}
 		if params.SourcePath != "" {
-			result.DepsResults = InstallDepsPreferSource(r, params.WtPath, params.SourcePath, params.AutoDetect, params.ConfigModules, wtEntries, nil)
+			result.DepsResults = InstallDepsPreferSource(r, params.SourcePath, dp, nil)
 		} else {
-			result.DepsResults = InstallDeps(r, params.WtPath, params.AutoDetect, params.ConfigModules, wtEntries, nil)
+			result.DepsResults = InstallDeps(r, dp, nil)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `RIMBA_DEBUG=1` timing instrumentation via `TimedRunner` decorator on `git.Runner` — logs every git command with elapsed time to stderr, zero changes to business logic
- Consolidate `Install`/`InstallPreferSource` into shared `install()` with `buildExistingPaths` helper; accept pre-fetched worktree entries to skip redundant `ListWorktrees` call
- Scope `DetectModules` to service subdirectory in monorepo: thread `service` through `PostCreateParams` → `DepsParams` → `ResolveModules` → `DetectModules`; root modules always detected, subdir scan limited to the target service when set

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)
- [x] Manual test on monorepo: `RIMBA_DEBUG=1 rimba add <service>/task` detects only root + service modules
- [x] Manual test on non-monorepo: identical behavior (service="", full scan)

N/A