### PR TITLE
[docs] Add monorepo support and RIMBA_DEBUG to documentation

### DIFF
--- a/.claude/skills/rimba/SKILL.md
+++ b/.claude/skills/rimba/SKILL.md
@@ -19,7 +19,9 @@ curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/insta
 | User wants to... | Run |
 |-------------------|-----|
 | Start a new task | `rimba add <task>` |
+| Start a task in a monorepo service | `rimba add service/task` (auto-detects service from repo dirs) |
 | See all worktrees | `rimba list` or `rimba list --json` |
+| Filter by service (monorepo) | `rimba list --service <svc>` |
 | Check worktree health | `rimba status` |
 | Navigate to a worktree | `cd $(rimba open <task>)` |
 | Update from source branch | `rimba sync <task>` or `rimba sync --all` |
@@ -40,7 +42,7 @@ Commands supporting `--json`: `list`, `status`, `exec`, `conflict-check`, `deps 
 
 ### Data Shapes
 
-**list:** `[{task, type, branch, path, is_current, status: {dirty, ahead, behind}}]`
+**list:** `[{task, type, service?, branch, path, is_current, status: {dirty, ahead, behind}}]`
 **status:** `{summary: {total, dirty, stale, behind}, worktrees: [...], stale_days}`
 **exec:** `{command, results: [{task, branch, path, exit_code, stdout, stderr}], success}`
 **conflict-check:** `{overlaps: [{file, branches, severity}], dry_merges?, total_files, total_branches}`
@@ -54,6 +56,8 @@ Commands supporting `--json`: `list`, `status`, `exec`, `conflict-check`, `deps 
 | "config not found" | rimba not initialized | Run `rimba init` |
 | "branch already exists" | Task name in use | Pick a different task name |
 | "worktree has uncommitted changes" | Dirty worktree | Commit or stash changes, or use `--force` |
+
+> **Tip:** Use `RIMBA_DEBUG=1 rimba <cmd>` to log git command timing to stderr when troubleshooting performance issues.
 
 ## Best Practices
 

--- a/.cursor/rules/rimba.mdc
+++ b/.cursor/rules/rimba.mdc
@@ -27,6 +27,7 @@ See AGENTS.md at the repo root for full documentation.
 ## Workflow Recipes
 
 **New feature:** `rimba add <task>` then work in the worktree directory.
+**Monorepo feature:** `rimba add service/task` — auto-detects service from repo directories.
 **Finish feature:** `rimba merge <task>` (auto-removes worktree).
 **Housekeeping:** `rimba status` then `rimba clean --merged`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,8 +7,8 @@ See AGENTS.md at the repo root for full rimba documentation.
 
 ### Key Commands
 
-- `rimba add <task>` — create worktree
-- `rimba list` / `rimba status` — inspect worktrees
+- `rimba add <task>` — create worktree (`rimba add service/task` for monorepos)
+- `rimba list` / `rimba status` — inspect worktrees (`--service <svc>` to filter)
 - `rimba merge <task>` — merge into main and auto-clean up
 - `rimba clean --merged` — remove merged worktrees
 - `rimba exec <cmd>` — run command across all worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/insta
 
 | Concern | Commands |
 |---------|----------|
-| Create & navigate | `rimba add <task>`, `rimba open <task>` |
+| Create & navigate | `rimba add <task>` (or `rimba add service/task` for monorepos), `rimba open <task>` |
 | Inspect | `rimba list`, `rimba status`, `rimba log` |
 | Sync & merge | `rimba sync [task]`, `rimba merge <task>` |
 | Clean up | `rimba clean --merged`, `rimba archive <task>`, `rimba remove <task>` |
@@ -46,6 +46,22 @@ rimba clean --merged        # remove worktrees whose branches are merged
 rimba merge my-feature      # merge into main and auto-clean up
 ```
 
+## Monorepo (Service-Scoped Worktrees)
+
+In monorepos, prefix the task with a service directory name to create service-scoped branches:
+
+```sh
+rimba add auth-api/my-feature           # branch: auth-api/feature/my-feature
+rimba add auth-api/my-feature --bugfix  # branch: auth-api/bugfix/my-feature
+rimba list --service auth-api           # filter worktrees by service
+```
+
+**How it works:** rimba auto-detects services — if the first segment before `/` matches a directory in the repo root, it becomes the service scope. No configuration needed.
+
+**Branch pattern:** `<service>/<prefix>/<task>` (e.g. `auth-api/feature/my-feature`)
+
+MCP tools also accept `service/task` format in the `task` parameter.
+
 ## JSON Output
 
 Commands that support `--json`: list, status, exec, conflict-check, deps status.
@@ -58,5 +74,6 @@ Error: `{"version": "...", "command": "...", "error": "...", "code": "..."}`
 - Prefer `rimba archive` over `rimba remove` to preserve branches for later reference
 - Use `--force` only when you understand the implications (skips dirty checks)
 - Never modify `.rimba/settings.toml` programmatically without asking the user
+- Use `RIMBA_DEBUG=1 rimba <cmd>` to log git command timing to stderr when troubleshooting
 
 <!-- END RIMBA -->

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - **Duplicate worktrees** — copy an existing worktree with auto-suffixed or custom name
 - **Local merge** — merge worktree branches into main or other worktrees with auto-cleanup
 - **Sync worktrees** — rebase or merge onto the latest main branch, with bulk sync support
+- **Monorepo support** — service-scoped worktrees with auto-detected 3-segment branch naming (`service/prefix/task`)
 
 🔧 **Automation**
 
@@ -94,7 +95,7 @@ rimba remove my-feature
 | Command | Description |
 |---------|-------------|
 | `rimba init` | Initialize rimba in the current repository |
-| `rimba add <task>` | Create a new worktree with auto-prefixed branch |
+| `rimba add <task>` | Create a new worktree with auto-prefixed branch (`service/task` for monorepos) |
 | `rimba remove <task>` | Remove a worktree and delete its branch |
 | `rimba rename <old> <new>` | Rename a worktree's task, branch, and directory |
 | `rimba duplicate <task>` | Create a copy of an existing worktree |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,13 +39,17 @@ rimba init --agent-files    # Also install AI agent instruction files
 
 ### rimba add
 
-Create a new worktree with a branch named `<prefix><task>` and copy dotfiles from the repo root.
+Create a new worktree with a branch named `<prefix><task>` and copy dotfiles from the repo root. In monorepos, prefix the task with a service directory name to create service-scoped branches.
 
 ```sh
 rimba add my-feature
 rimba add my-feature --bugfix        # Use bugfix/ prefix instead of feature/
 rimba add my-feature -s develop      # Branch from a different source
+rimba add auth-api/my-feature        # Monorepo: branch auth-api/feature/my-feature
+rimba add auth-api/my-feature --bugfix  # Monorepo: branch auth-api/bugfix/my-feature
 ```
+
+> **Monorepo:** If the first segment before `/` matches a directory in the repo root, rimba treats it as a service scope. The branch uses a 3-segment pattern: `<service>/<prefix>/<task>`. No configuration needed — detection is automatic.
 
 | Flag | Description |
 |------|-------------|
@@ -146,6 +150,7 @@ rimba list --type bugfix        # Show only bugfix worktrees
 rimba list --dirty              # Show only dirty worktrees
 rimba list --behind             # Show only worktrees behind upstream
 rimba list --archived           # Show archived branches (not in any active worktree)
+rimba list --service auth-api   # Show only worktrees for a service (monorepo)
 rimba list --json               # Output as JSON
 ```
 
@@ -174,6 +179,7 @@ TASK            TYPE     BRANCH              PATH              STATUS
 | `--dirty` | Show only worktrees with uncommitted changes |
 | `--behind` | Show only worktrees behind their upstream branch |
 | `--archived` | Show archived branches not in any active worktree (mutually exclusive with other filters) |
+| `--service` | Filter by service name (monorepo) |
 
 ### rimba status
 
@@ -469,7 +475,7 @@ claude mcp add rimba rimba mcp
 | Tool | Description | Required Parameters |
 |------|-------------|---------------------|
 | `list` | List all worktrees with branch, path, and status | — |
-| `add` | Create a new worktree for a task | `task` |
+| `add` | Create a new worktree for a task (supports `service/task` for monorepos) | `task` |
 | `remove` | Remove a worktree and optionally delete its branch | `task` |
 | `status` | Show worktree dashboard with summary stats and age info | — |
 | `sync` | Sync worktree(s) with the main branch via rebase or merge, then push | `task` or `all` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,5 +98,6 @@ When `auto_detect` is enabled (default), rimba recognizes these lockfiles automa
 
 | Variable | Description |
 |----------|-------------|
+| `RIMBA_DEBUG` | Log git command timing to stderr (set to any value, e.g. `RIMBA_DEBUG=1`) |
 | `RIMBA_QUIET` | Suppress pre-execution hints (set to any value, e.g. `RIMBA_QUIET=1`) |
 | `NO_COLOR` | Disable colored output globally (per [no-color.org](https://no-color.org)) |

--- a/internal/agentfile/content.go
+++ b/internal/agentfile/content.go
@@ -27,7 +27,7 @@ curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/insta
 
 | Concern | Commands |
 |---------|----------|
-| Create & navigate | ` + "`" + `rimba add <task>` + "`" + `, ` + "`" + `rimba open <task>` + "`" + ` |
+| Create & navigate | ` + "`" + `rimba add <task>` + "`" + ` (or ` + "`" + `rimba add service/task` + "`" + ` for monorepos), ` + "`" + `rimba open <task>` + "`" + ` |
 | Inspect | ` + "`" + `rimba list` + "`" + `, ` + "`" + `rimba status` + "`" + `, ` + "`" + `rimba log` + "`" + ` |
 | Sync & merge | ` + "`" + `rimba sync [task]` + "`" + `, ` + "`" + `rimba merge <task>` + "`" + ` |
 | Clean up | ` + "`" + `rimba clean --merged` + "`" + `, ` + "`" + `rimba archive <task>` + "`" + `, ` + "`" + `rimba remove <task>` + "`" + ` |
@@ -53,6 +53,22 @@ rimba clean --merged        # remove worktrees whose branches are merged
 rimba merge my-feature      # merge into main and auto-clean up
 ` + "```" + `
 
+## Monorepo (Service-Scoped Worktrees)
+
+In monorepos, prefix the task with a service directory name to create service-scoped branches:
+
+` + "```" + `sh
+rimba add auth-api/my-feature           # branch: auth-api/feature/my-feature
+rimba add auth-api/my-feature --bugfix  # branch: auth-api/bugfix/my-feature
+rimba list --service auth-api           # filter worktrees by service
+` + "```" + `
+
+**How it works:** rimba auto-detects services — if the first segment before ` + "`" + `/` + "`" + ` matches a directory in the repo root, it becomes the service scope. No configuration needed.
+
+**Branch pattern:** ` + "`" + `<service>/<prefix>/<task>` + "`" + ` (e.g. ` + "`" + `auth-api/feature/my-feature` + "`" + `)
+
+MCP tools also accept ` + "`" + `service/task` + "`" + ` format in the ` + "`" + `task` + "`" + ` parameter.
+
 ## JSON Output
 
 Commands that support ` + "`" + `--json` + "`" + `: list, status, exec, conflict-check, deps status.
@@ -65,6 +81,7 @@ Error: ` + "`" + `{"version": "...", "command": "...", "error": "...", "code": "
 - Prefer ` + "`" + `rimba archive` + "`" + ` over ` + "`" + `rimba remove` + "`" + ` to preserve branches for later reference
 - Use ` + "`" + `--force` + "`" + ` only when you understand the implications (skips dirty checks)
 - Never modify ` + "`" + `.rimba/settings.toml` + "`" + ` programmatically without asking the user
+- Use ` + "`" + `RIMBA_DEBUG=1 rimba <cmd>` + "`" + ` to log git command timing to stderr when troubleshooting
 
 <!-- END RIMBA -->`
 }
@@ -80,8 +97,8 @@ See AGENTS.md at the repo root for full rimba documentation.
 
 ### Key Commands
 
-- ` + "`" + `rimba add <task>` + "`" + ` — create worktree
-- ` + "`" + `rimba list` + "`" + ` / ` + "`" + `rimba status` + "`" + ` — inspect worktrees
+- ` + "`" + `rimba add <task>` + "`" + ` — create worktree (` + "`" + `rimba add service/task` + "`" + ` for monorepos)
+- ` + "`" + `rimba list` + "`" + ` / ` + "`" + `rimba status` + "`" + ` — inspect worktrees (` + "`" + `--service <svc>` + "`" + ` to filter)
 - ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
 - ` + "`" + `rimba clean --merged` + "`" + ` — remove merged worktrees
 - ` + "`" + `rimba exec <cmd>` + "`" + ` — run command across all worktrees
@@ -134,6 +151,7 @@ See AGENTS.md at the repo root for full documentation.
 ## Workflow Recipes
 
 **New feature:** ` + "`" + `rimba add <task>` + "`" + ` then work in the worktree directory.
+**Monorepo feature:** ` + "`" + `rimba add service/task` + "`" + ` — auto-detects service from repo directories.
 **Finish feature:** ` + "`" + `rimba merge <task>` + "`" + ` (auto-removes worktree).
 **Housekeeping:** ` + "`" + `rimba status` + "`" + ` then ` + "`" + `rimba clean --merged` + "`" + `.
 
@@ -173,7 +191,9 @@ curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/insta
 | User wants to... | Run |
 |-------------------|-----|
 | Start a new task | ` + "`" + `rimba add <task>` + "`" + ` |
+| Start a task in a monorepo service | ` + "`" + `rimba add service/task` + "`" + ` (auto-detects service from repo dirs) |
 | See all worktrees | ` + "`" + `rimba list` + "`" + ` or ` + "`" + `rimba list --json` + "`" + ` |
+| Filter by service (monorepo) | ` + "`" + `rimba list --service <svc>` + "`" + ` |
 | Check worktree health | ` + "`" + `rimba status` + "`" + ` |
 | Navigate to a worktree | ` + "`" + `cd $(rimba open <task>)` + "`" + ` |
 | Update from source branch | ` + "`" + `rimba sync <task>` + "`" + ` or ` + "`" + `rimba sync --all` + "`" + ` |
@@ -194,7 +214,7 @@ Commands supporting ` + "`" + `--json` + "`" + `: ` + "`" + `list` + "`" + `, ` 
 
 ### Data Shapes
 
-**list:** ` + "`" + `[{task, type, branch, path, is_current, status: {dirty, ahead, behind}}]` + "`" + `
+**list:** ` + "`" + `[{task, type, service?, branch, path, is_current, status: {dirty, ahead, behind}}]` + "`" + `
 **status:** ` + "`" + `{summary: {total, dirty, stale, behind}, worktrees: [...], stale_days}` + "`" + `
 **exec:** ` + "`" + `{command, results: [{task, branch, path, exit_code, stdout, stderr}], success}` + "`" + `
 **conflict-check:** ` + "`" + `{overlaps: [{file, branches, severity}], dry_merges?, total_files, total_branches}` + "`" + `
@@ -208,6 +228,8 @@ Commands supporting ` + "`" + `--json` + "`" + `: ` + "`" + `list` + "`" + `, ` 
 | "config not found" | rimba not initialized | Run ` + "`" + `rimba init` + "`" + ` |
 | "branch already exists" | Task name in use | Pick a different task name |
 | "worktree has uncommitted changes" | Dirty worktree | Commit or stash changes, or use ` + "`" + `--force` + "`" + ` |
+
+> **Tip:** Use ` + "`" + `RIMBA_DEBUG=1 rimba <cmd>` + "`" + ` to log git command timing to stderr when troubleshooting performance issues.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary
- Document monorepo service-scoped worktrees across all doc surfaces: agent file templates (`content.go`), generated output files (AGENTS.md, copilot, cursor, claude skill), `docs/commands.md`, `docs/configuration.md`, and `README.md`
- Add `RIMBA_DEBUG` environment variable to configuration reference, AGENTS.md best practices, and claude skill tip
- Verified template-to-output parity by building and running `rimba init --agent-files` in a temp repo

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Formatter clean (`make fmt`)
- [x] `rimba init --agent-files` generates output matching the manually updated files

N/A