### PR TITLE
[feat] Add debug timing for dependency installation

### DIFF
--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -18,6 +18,19 @@ func WrapRunner(r git.Runner) git.Runner {
 	return &TimedRunner{Inner: r}
 }
 
+// StartTimer logs the start of a labelled operation and returns a function
+// that logs elapsed time when called. No-op when RIMBA_DEBUG is unset.
+func StartTimer(label string) func() {
+	if !enabled() {
+		return func() {}
+	}
+	logf("%s: start", label)
+	start := time.Now()
+	return func() {
+		logf("%s: %s", label, time.Since(start).Round(time.Millisecond))
+	}
+}
+
 // TimedRunner decorates a git.Runner, logging each command with elapsed time to stderr.
 type TimedRunner struct {
 	Inner git.Runner
@@ -27,7 +40,7 @@ func (r *TimedRunner) Run(args ...string) (string, error) {
 	label := "git " + strings.Join(args, " ")
 	start := time.Now()
 	out, err := r.Inner.Run(args...)
-	fmt.Fprintf(os.Stderr, "[debug] %s: %s\n", label, time.Since(start).Round(time.Millisecond))
+	logf("%s: %s", label, time.Since(start).Round(time.Millisecond))
 	return out, err
 }
 
@@ -35,8 +48,14 @@ func (r *TimedRunner) RunInDir(dir string, args ...string) (string, error) {
 	label := fmt.Sprintf("git %s [%s]", strings.Join(args, " "), filepath.Base(dir))
 	start := time.Now()
 	out, err := r.Inner.RunInDir(dir, args...)
-	fmt.Fprintf(os.Stderr, "[debug] %s: %s\n", label, time.Since(start).Round(time.Millisecond))
+	logf("%s: %s", label, time.Since(start).Round(time.Millisecond))
 	return out, err
+}
+
+// logf writes a formatted debug line to stderr.
+// Leading \n ensures the line is not appended to an active spinner.
+func logf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "\n[debug] "+format+"\n", args...)
 }
 
 func enabled() bool {

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -1,7 +1,9 @@
 package debug
 
 import (
+	"io"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -76,5 +78,47 @@ func TestTimedRunnerRunInDir(t *testing.T) {
 	}
 	if !stub.runInDirCalled {
 		t.Error("inner runner RunInDir was not called")
+	}
+}
+
+func TestStartTimerEnabled(t *testing.T) {
+	t.Setenv("RIMBA_DEBUG", "1")
+
+	r, w, _ := os.Pipe()
+	origStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	stop := StartTimer("test-op")
+	stop()
+
+	w.Close()
+	output, _ := io.ReadAll(r)
+
+	if !strings.Contains(string(output), "[debug] test-op: start") {
+		t.Errorf("expected start line, got %q", output)
+	}
+	if !strings.Contains(string(output), "[debug] test-op: 0s") {
+		t.Errorf("expected duration line, got %q", output)
+	}
+}
+
+func TestStartTimerDisabled(t *testing.T) {
+	t.Setenv("RIMBA_DEBUG", "")
+	os.Unsetenv("RIMBA_DEBUG")
+
+	r, w, _ := os.Pipe()
+	origStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	stop := StartTimer("test-op")
+	stop()
+
+	w.Close()
+	output, _ := io.ReadAll(r)
+
+	if len(output) != 0 {
+		t.Errorf("expected no output when disabled, got %q", output)
 	}
 }

--- a/internal/deps/manager.go
+++ b/internal/deps/manager.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/debug"
 	"github.com/lugassawan/rimba/internal/git"
 )
 
@@ -66,6 +67,7 @@ func ResolveModules(worktreePath, service string, autoDetect bool, configModules
 }
 
 func (m *Manager) install(worktreePath, sourceWT string, modules []Module, existingEntries []git.WorktreeEntry, onProgress ProgressFunc) []InstallResult {
+	defer debug.StartTimer("installing dependencies")()
 	results := make([]InstallResult, 0, len(modules))
 
 	hashed, err := HashModules(worktreePath, modules)


### PR DESCRIPTION
## Summary
- Extract private `logf` helper in debug package, consolidating `[debug]` format with leading `\n` to prevent collision with spinner output on stderr
- Add `StartTimer(label)` function that logs start/elapsed time, gated by `RIMBA_DEBUG`
- Instrument `Manager.install()` with `defer debug.StartTimer("installing dependencies")()` — the single funnel point for both `PostCreateSetup` and `rimba deps install`

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Verified debug lines appear on own lines, no collision with spinner text

N/A