### PR TITLE
[refactor] Restructure version output with OS and arch info

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,12 @@ var versionCmd = &cobra.Command{
 	Short:       "Print the version information",
 	Annotations: map[string]string{"skipConfig": "true"},
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Fprintf(cmd.OutOrStdout(), "rimba %s (commit: %s, built: %s)\n", version, commit, date)
+		w := cmd.OutOrStdout()
+		fmt.Fprintf(w, "rimba %s\n", version)
+		fmt.Fprintf(w, "commit: %s\n", commit)
+		fmt.Fprintf(w, "built:  %s\n", date)
+		fmt.Fprintf(w, "os:     %s\n", runtime.GOOS)
+		fmt.Fprintf(w, "arch:   %s\n", runtime.GOARCH)
 	},
 }
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -19,10 +19,13 @@ func TestVersionCmd(t *testing.T) {
 	versionCmd.Run(cmd, nil)
 
 	out := buf.String()
-	if !strings.Contains(out, "rimba") {
-		t.Errorf("version output %q does not contain 'rimba'", out)
+	for _, want := range []string{"rimba", version, "commit:", "built:", "os:", "arch:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("version output %q does not contain %q", out, want)
+		}
 	}
-	if !strings.Contains(out, version) {
-		t.Errorf("version output %q does not contain version %q", out, version)
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 5 {
+		t.Errorf("expected 5 lines, got %d: %q", len(lines), out)
 	}
 }

--- a/tests/e2e/version_test.go
+++ b/tests/e2e/version_test.go
@@ -12,6 +12,10 @@ func TestVersionPrintsInfo(t *testing.T) {
 	repo := setupRepo(t)
 	r := rimbaSuccess(t, repo, "version")
 	assertContains(t, r.Stdout, "rimba")
+	assertContains(t, r.Stdout, "commit:")
+	assertContains(t, r.Stdout, "built:")
+	assertContains(t, r.Stdout, "os:")
+	assertContains(t, r.Stdout, "arch:")
 }
 
 func TestVersionWorksOutsideRepo(t *testing.T) {


### PR DESCRIPTION
## Summary
- Restructure `rimba version` from single-line to multi-line format for better readability
- Add OS (`runtime.GOOS`) and architecture (`runtime.GOARCH`) to version output
- Align labels with consistent spacing for clean vertical layout

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Formatter passes (`make fmt`)
- [x] Verified output visually with `go run . version`

N/A