### PR TITLE
[feat] Install dependency modules in parallel

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -81,6 +81,7 @@ var addCmd = &cobra.Command{
 			ConfigModules: configModules,
 			SkipHooks:     skipHooks,
 			PostCreate:    cfg.PostCreate,
+			Concurrency:   cfg.DepsConcurrency(),
 		}, func(msg string) { s.Update(msg) })
 		if err != nil {
 			return err

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -191,7 +191,7 @@ var depsInstallCmd = &cobra.Command{
 		defer s.Stop()
 
 		s.Start("Installing dependencies...")
-		mgr := &deps.Manager{Runner: r}
+		mgr := &deps.Manager{Runner: r, Concurrency: cfg.DepsConcurrency()}
 		results := mgr.Install(wt.Path, modules, nil, func(msg string) {
 			s.Update("Installing dependencies... " + msg)
 		})

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -127,6 +127,7 @@ var duplicateCmd = &cobra.Command{
 			SkipHooks:     skipHooks,
 			PostCreate:    cfg.PostCreate,
 			SourcePath:    wt.Path,
+			Concurrency:   cfg.DepsConcurrency(),
 		}, func(msg string) { s.Update(msg) })
 		if err != nil {
 			return err

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -78,6 +78,7 @@ var restoreCmd = &cobra.Command{
 			ConfigModules: configModules,
 			SkipHooks:     skipHooks,
 			PostCreate:    cfg.PostCreate,
+			Concurrency:   cfg.DepsConcurrency(),
 		}, func(msg string) { s.Update(msg) })
 		if err != nil {
 			return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,8 +33,7 @@ type Config struct {
 type DepsConfig struct {
 	AutoDetect *bool          `toml:"auto_detect,omitempty"`
 	Modules    []ModuleConfig `toml:"modules,omitempty"`
-	// Concurrency caps parallel module installs.
-	// 0 or unset = auto (min(NumCPU, 4)); 1 = sequential; N >= 1 = cap at N.
+	// Concurrency caps parallel module installs. 0 = auto.
 	Concurrency int `toml:"concurrency,omitempty"`
 }
 
@@ -55,8 +54,7 @@ func (c *Config) IsAutoDetectDeps() bool {
 	return *c.Deps.AutoDetect
 }
 
-// DepsConcurrency returns the configured concurrency for dependency installation.
-// Returns 0 when unset; Manager resolves 0 to its own default (min(NumCPU, 4)).
+// DepsConcurrency returns the configured install concurrency, or 0 if unset.
 func (c *Config) DepsConcurrency() int {
 	if c.Deps == nil {
 		return 0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,8 +31,9 @@ type Config struct {
 
 // DepsConfig holds optional dependency management settings.
 type DepsConfig struct {
-	AutoDetect *bool          `toml:"auto_detect,omitempty"`
-	Modules    []ModuleConfig `toml:"modules,omitempty"`
+	AutoDetect  *bool          `toml:"auto_detect,omitempty"`
+	Modules     []ModuleConfig `toml:"modules,omitempty"`
+	Concurrency int            `toml:"concurrency,omitempty"`
 }
 
 // ModuleConfig defines a manually configured dependency module.
@@ -50,6 +51,15 @@ func (c *Config) IsAutoDetectDeps() bool {
 		return true
 	}
 	return *c.Deps.AutoDetect
+}
+
+// DepsConcurrency returns the configured concurrency for dependency installation.
+// Returns 0 when unset; Manager resolves 0 to its own default (min(NumCPU, 4)).
+func (c *Config) DepsConcurrency() int {
+	if c.Deps == nil {
+		return 0
+	}
+	return c.Deps.Concurrency
 }
 
 // DefaultWorktreeDir returns the conventional worktree directory path for a repo.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,9 +31,11 @@ type Config struct {
 
 // DepsConfig holds optional dependency management settings.
 type DepsConfig struct {
-	AutoDetect  *bool          `toml:"auto_detect,omitempty"`
-	Modules     []ModuleConfig `toml:"modules,omitempty"`
-	Concurrency int            `toml:"concurrency,omitempty"`
+	AutoDetect *bool          `toml:"auto_detect,omitempty"`
+	Modules    []ModuleConfig `toml:"modules,omitempty"`
+	// Concurrency caps parallel module installs.
+	// 0 or unset = auto (min(NumCPU, 4)); 1 = sequential; N >= 1 = cap at N.
+	Concurrency int `toml:"concurrency,omitempty"`
 }
 
 // ModuleConfig defines a manually configured dependency module.

--- a/internal/deps/manager.go
+++ b/internal/deps/manager.go
@@ -6,17 +6,30 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"sync/atomic"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/debug"
 	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/parallel"
 	"github.com/lugassawan/rimba/internal/progress"
 )
+
+// defaultDepsConcurrencyCap bounds the auto-selected worker pool.
+// Package-manager global stores (pnpm, npm) serialize on their own locks,
+// so going wider than this rarely helps and can starve CPU on small machines.
+const defaultDepsConcurrencyCap = 4
 
 // Manager orchestrates dependency installation for worktrees.
 type Manager struct {
 	Runner git.Runner
+
+	// Concurrency is the max number of modules installed in parallel.
+	// When <= 0, the Manager auto-picks min(runtime.NumCPU(), 4).
+	// Set to 1 to force sequential installation.
+	Concurrency int
 }
 
 // InstallResult holds the outcome of installing a single module.
@@ -88,13 +101,25 @@ func (m *Manager) install(worktreePath, sourceWT string, modules []Module, exist
 
 	existingPaths := buildExistingPaths(entries, worktreePath, sourceWT)
 
-	for i, mh := range hashed {
-		progress.Notifyf(onProgress, "%s (%d/%d)", mh.Module.Dir, i+1, len(hashed))
-		result := m.installModule(worktreePath, mh, existingPaths)
-		results = append(results, result)
-	}
+	concurrency := m.resolveConcurrency()
+	var done atomic.Int32
+	total := len(hashed)
+
+	results = parallel.Collect(total, concurrency, func(i int) InstallResult {
+		res := m.installModule(worktreePath, hashed[i], existingPaths)
+		completed := done.Add(1)
+		progress.Notifyf(onProgress, "%d/%d complete", completed, total)
+		return res
+	})
 
 	return results
+}
+
+func (m *Manager) resolveConcurrency() int {
+	if m.Concurrency >= 1 {
+		return m.Concurrency
+	}
+	return max(1, min(runtime.NumCPU(), defaultDepsConcurrencyCap))
 }
 
 func buildExistingPaths(entries []git.WorktreeEntry, exclude, preferred string) []string {

--- a/internal/deps/manager.go
+++ b/internal/deps/manager.go
@@ -26,9 +26,7 @@ const defaultDepsConcurrencyCap = 4
 type Manager struct {
 	Runner git.Runner
 
-	// Concurrency is the max number of modules installed in parallel.
-	// When <= 0, the Manager auto-picks min(runtime.NumCPU(), 4).
-	// Set to 1 to force sequential installation.
+	// Concurrency caps parallel module installs. <= 0 auto-picks a default.
 	Concurrency int
 }
 

--- a/internal/deps/manager_test.go
+++ b/internal/deps/manager_test.go
@@ -2,9 +2,12 @@ package deps
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/config"
@@ -747,14 +750,18 @@ func TestInstallProgressCallback(t *testing.T) {
 	writeFile(t, newWT, LockfilePnpm, "lock-content")
 
 	runner := &mockRunner{worktreeOutput: mockWorktreeList(newWT)}
-	mgr := &Manager{Runner: runner}
+	// Force sequential so progress messages appear in a predictable order.
+	mgr := &Manager{Runner: runner, Concurrency: 1}
 	modules := []Module{
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm, InstallCmd: "echo ok"},
 		{Dir: DirVendor, Lockfile: LockfileGo},
 	}
 
+	var mu sync.Mutex
 	var calls []progressCall
 	onProgress := func(msg string) {
+		mu.Lock()
+		defer mu.Unlock()
 		calls = append(calls, progressCall{msg})
 	}
 
@@ -763,11 +770,104 @@ func TestInstallProgressCallback(t *testing.T) {
 	if len(calls) != 2 {
 		t.Fatalf("expected 2 progress calls, got %d", len(calls))
 	}
-	if want := DirNodeModules + " (1/2)"; calls[0].message != want {
+	if want := "1/2 complete"; calls[0].message != want {
 		t.Errorf("calls[0] = %q, want %q", calls[0].message, want)
 	}
-	if want := DirVendor + " (2/2)"; calls[1].message != want {
+	if want := "2/2 complete"; calls[1].message != want {
 		t.Errorf("calls[1] = %q, want %q", calls[1].message, want)
+	}
+}
+
+func TestInstallPreservesOrderWhenParallel(t *testing.T) {
+	// Use distinct InstallCmds with different sleep durations so completion
+	// order differs from input order. Results must still match input order.
+	newWT := t.TempDir()
+	writeFile(t, newWT, LockfilePnpm, "lock")
+
+	runner := &mockRunner{worktreeOutput: mockWorktreeList(newWT)}
+	mgr := &Manager{Runner: runner, Concurrency: 4}
+
+	// Create unique WorkDir subdirectories so each module runs in its own dir.
+	modules := make([]Module, 5)
+	for i := range modules {
+		sub := fmt.Sprintf("m%d", i)
+		if err := os.MkdirAll(filepath.Join(newWT, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Earlier modules sleep longer so they complete last.
+		sleep := strconv.Itoa(5 - i) // module 0 sleeps 5cs, module 4 sleeps 1cs
+		modules[i] = Module{
+			Dir:        sub,
+			Lockfile:   LockfilePnpm,
+			InstallCmd: fmt.Sprintf("sleep 0.0%s && echo %s", sleep, sub),
+			WorkDir:    sub,
+		}
+	}
+
+	results := mgr.Install(newWT, modules, nil, nil)
+
+	if len(results) != len(modules) {
+		t.Fatalf("expected %d results, got %d", len(modules), len(results))
+	}
+	for i, r := range results {
+		if r.Module.Dir != modules[i].Dir {
+			t.Errorf("results[%d].Module.Dir = %q, want %q (order not preserved)",
+				i, r.Module.Dir, modules[i].Dir)
+		}
+		if r.Error != nil {
+			t.Errorf("results[%d] unexpected error: %v", i, r.Error)
+		}
+	}
+}
+
+func TestInstallParallelErrorIsolation(t *testing.T) {
+	// One failing module must not prevent others from running.
+	newWT := t.TempDir()
+	writeFile(t, newWT, LockfilePnpm, "lock")
+
+	runner := &mockRunner{worktreeOutput: mockWorktreeList(newWT)}
+	mgr := &Manager{Runner: runner, Concurrency: 3}
+
+	for _, sub := range []string{"a", "b", "c"} {
+		if err := os.MkdirAll(filepath.Join(newWT, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	modules := []Module{
+		{Dir: "a", Lockfile: LockfilePnpm, InstallCmd: "echo ok-a", WorkDir: "a"},
+		{Dir: "b", Lockfile: LockfilePnpm, InstallCmd: "/nonexistent-xyz-command", WorkDir: "b"},
+		{Dir: "c", Lockfile: LockfilePnpm, InstallCmd: "echo ok-c", WorkDir: "c"},
+	}
+
+	results := mgr.Install(newWT, modules, nil, nil)
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+	if results[0].Error != nil {
+		t.Errorf("module a: unexpected error %v", results[0].Error)
+	}
+	if results[1].Error == nil {
+		t.Error("module b: expected error for nonexistent command, got nil")
+	}
+	if results[2].Error != nil {
+		t.Errorf("module c: unexpected error %v", results[2].Error)
+	}
+}
+
+func TestManagerResolveConcurrencyExplicit(t *testing.T) {
+	m := &Manager{Concurrency: 7}
+	if got := m.resolveConcurrency(); got != 7 {
+		t.Errorf("resolveConcurrency() = %d, want 7", got)
+	}
+}
+
+func TestManagerResolveConcurrencyAuto(t *testing.T) {
+	m := &Manager{} // Concurrency == 0
+	got := m.resolveConcurrency()
+	if got < 1 || got > defaultDepsConcurrencyCap {
+		t.Errorf("resolveConcurrency() = %d, want in [1, %d]", got, defaultDepsConcurrencyCap)
 	}
 }
 

--- a/internal/mcp/tool_add.go
+++ b/internal/mcp/tool_add.go
@@ -81,6 +81,7 @@ func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 			ConfigModules: configModules,
 			SkipHooks:     req.GetBool("skip_hooks", false),
 			PostCreate:    cfg.PostCreate,
+			Concurrency:   cfg.DepsConcurrency(),
 		}, nil)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil

--- a/internal/operations/add.go
+++ b/internal/operations/add.go
@@ -25,6 +25,7 @@ type AddParams struct {
 	ConfigModules []config.ModuleConfig
 	SkipHooks     bool
 	PostCreate    []string // hook commands
+	Concurrency   int      // max parallel module installs; 0 = Manager default
 }
 
 // AddResult holds the outcome of creating a worktree.
@@ -79,6 +80,7 @@ func AddWorktree(r git.Runner, params AddParams, onProgress progress.Func) (AddR
 		ConfigModules: params.ConfigModules,
 		SkipHooks:     params.SkipHooks,
 		PostCreate:    params.PostCreate,
+		Concurrency:   params.Concurrency,
 	}, onProgress)
 	if err != nil {
 		return result, err

--- a/internal/operations/deps_install.go
+++ b/internal/operations/deps_install.go
@@ -14,6 +14,7 @@ type DepsParams struct {
 	AutoDetect    bool
 	ConfigModules []config.ModuleConfig
 	Entries       []git.WorktreeEntry
+	Concurrency   int
 }
 
 // InstallDeps detects modules and installs dependencies.
@@ -25,7 +26,7 @@ func InstallDeps(r git.Runner, p DepsParams, onProgress progress.Func) []deps.In
 		return nil
 	}
 
-	mgr := &deps.Manager{Runner: r}
+	mgr := &deps.Manager{Runner: r, Concurrency: p.Concurrency}
 	return mgr.Install(p.WtPath, modules, p.Entries, onProgress)
 }
 
@@ -38,7 +39,7 @@ func InstallDepsPreferSource(r git.Runner, sourceWT string, p DepsParams, onProg
 		return nil
 	}
 
-	mgr := &deps.Manager{Runner: r}
+	mgr := &deps.Manager{Runner: r, Concurrency: p.Concurrency}
 	return mgr.InstallPreferSource(p.WtPath, sourceWT, modules, p.Entries, onProgress)
 }
 

--- a/internal/operations/post_create.go
+++ b/internal/operations/post_create.go
@@ -24,6 +24,7 @@ type PostCreateParams struct {
 	SkipHooks     bool
 	PostCreate    []string // hook commands
 	SourcePath    string   // if non-empty, prefer copying deps from this worktree
+	Concurrency   int      // max parallel module installs; 0 = Manager default
 }
 
 // PostCreateResult holds the outcome of the post-create setup sequence.
@@ -62,6 +63,7 @@ func PostCreateSetup(r git.Runner, params PostCreateParams, onProgress progress.
 			AutoDetect:    params.AutoDetect,
 			ConfigModules: params.ConfigModules,
 			Entries:       wtEntries,
+			Concurrency:   params.Concurrency,
 		}
 		if params.SourcePath != "" {
 			result.DepsResults = InstallDepsPreferSource(r, params.SourcePath, dp, onProgress)

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -4,6 +4,8 @@ import "fmt"
 
 // Func is called to report operation progress.
 // CLI wires this to spinner updates; MCP passes nil.
+// Implementations must be safe to call from multiple goroutines concurrently —
+// some callers (e.g. parallel dependency installs) invoke Func from worker pools.
 type Func func(message string)
 
 // Notify safely invokes fn if non-nil.

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -4,8 +4,7 @@ import "fmt"
 
 // Func is called to report operation progress.
 // CLI wires this to spinner updates; MCP passes nil.
-// Implementations must be safe to call from multiple goroutines concurrently —
-// some callers (e.g. parallel dependency installs) invoke Func from worker pools.
+// Implementations must be goroutine-safe.
 type Func func(message string)
 
 // Notify safely invokes fn if non-nil.

--- a/internal/spinner/spinner.go
+++ b/internal/spinner/spinner.go
@@ -113,7 +113,7 @@ func (s *Spinner) animate() {
 		msg := s.msg
 		s.mu.Unlock()
 
-		fmt.Fprintf(s.w, "\r%s %s", frames[i%len(frames)], msg)
+		fmt.Fprintf(s.w, "\r%s %s\033[K", frames[i%len(frames)], msg)
 
 		select {
 		case <-s.stopCh:


### PR DESCRIPTION
## Summary

- Fix garbled spinner output during `Installing dependencies...` (e.g. `node modules (1/7)encies...`) by appending ANSI erase-to-EOL to every frame. `\r` alone doesn't erase, so residue from longer previous messages stayed visible.
- Install dependency modules in parallel instead of sequentially. For multi-module monorepos this cuts `Installing dependencies...` wall-clock time from minutes to seconds on slower machines. Workers default to `min(NumCPU, 4)`; input order is preserved in the result summary; one failing module doesn't block others.
- Add `[deps].concurrency` TOML setting: `0` or unset = auto, `1` = sequential, `N` = cap at N. Threaded through `rimba add`, `rimba deps`, `rimba duplicate`, `rimba restore`, and the MCP add tool.
- Progress callback format now reads `N/M complete` (atomic counter) since naming "the current module" stops being meaningful when multiple installs are in-flight.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] `go test -race ./internal/deps/... ./internal/spinner/...` clean; new tests cover parallel ordering, error isolation, and concurrency resolution

N/A