### PR TITLE
[feat] Add --debug persistent flag for runtime diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [Quick Start](#quick-start)
 - [Commands](#commands)
 - [Configuration](#configuration)
+- [Troubleshooting](#troubleshooting)
 - [Contributing](CONTRIBUTING.md)
 - [License](#license)
 
@@ -137,6 +138,14 @@ agent = 'claude'
 ```
 
 > See [docs/configuration.md](docs/configuration.md) for the full field reference, dependency management, and environment variables.
+
+## Troubleshooting
+
+Pass `--debug` to any command (or set `RIMBA_DEBUG=1`) to log git commands and their timings to stderr:
+
+```sh
+rimba list --debug
+```
 
 ## License
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -12,6 +13,7 @@ import (
 )
 
 const (
+	flagDebug        = "debug"
 	flagForce        = "force"
 	flagJSON         = "json"
 	flagNoColor      = "no-color"
@@ -34,6 +36,10 @@ var rootCmd = &cobra.Command{
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		commandName = strings.TrimPrefix(cmd.CommandPath(), "rimba ")
+
+		if debug, _ := cmd.Flags().GetBool(flagDebug); debug {
+			_ = os.Setenv("RIMBA_DEBUG", "1")
+		}
 
 		// Skip config for Cobra internals (completion, __complete)
 		if cmd.Name() == "completion" || cmd.Name() == "__complete" {
@@ -77,6 +83,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().Bool(flagJSON, false, "output in JSON format")
 	rootCmd.PersistentFlags().Bool(flagNoColor, false, "disable colored output")
+	rootCmd.PersistentFlags().Bool(flagDebug, false, "Log git commands and timings to stderr")
 
 	originalHelp := rootCmd.HelpFunc()
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -152,6 +152,32 @@ func TestPersistentPreRunESuccessWithDirConfig(t *testing.T) {
 	}
 }
 
+func TestPersistentPreRunESetsDebugEnv(t *testing.T) {
+	// Ensure RIMBA_DEBUG starts unset and is cleaned up after the test.
+	t.Setenv("RIMBA_DEBUG", "")
+	os.Unsetenv("RIMBA_DEBUG")
+	t.Cleanup(func() { os.Unsetenv("RIMBA_DEBUG") })
+
+	preRunE := rootCmd.PersistentPreRunE
+
+	cmd := &cobra.Command{
+		Use:         "debug-test",
+		Annotations: map[string]string{"skipConfig": "true"},
+	}
+	cmd.Flags().Bool(flagDebug, false, "")
+	if err := cmd.Flags().Set(flagDebug, "true"); err != nil {
+		t.Fatalf("set debug flag: %v", err)
+	}
+
+	if err := preRunE(cmd, nil); err != nil {
+		t.Fatalf("PreRunE: %v", err)
+	}
+
+	if os.Getenv("RIMBA_DEBUG") == "" {
+		t.Error("expected RIMBA_DEBUG to be set after --debug flag")
+	}
+}
+
 func TestRootHelpFunctionSubcommand(t *testing.T) {
 	sub := &cobra.Command{Use: "sub", Short: "a subcommand"}
 	rootCmd.AddCommand(sub)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,6 +98,6 @@ When `auto_detect` is enabled (default), rimba recognizes these lockfiles automa
 
 | Variable | Description |
 |----------|-------------|
-| `RIMBA_DEBUG` | Log git command timing to stderr (set to any value, e.g. `RIMBA_DEBUG=1`) |
+| `RIMBA_DEBUG` | Log git command timing to stderr (set to any value, e.g. `RIMBA_DEBUG=1`). The `--debug` flag on any command has the same effect. |
 | `RIMBA_QUIET` | Suppress pre-execution hints (set to any value, e.g. `RIMBA_QUIET=1`) |
 | `NO_COLOR` | Disable colored output globally (per [no-color.org](https://no-color.org)) |


### PR DESCRIPTION
## Summary
- Adds --debug as a persistent flag on the rimba root command
- Sets RIMBA_DEBUG=1 in PersistentPreRunE so existing timing instrumentation activates
- Documents the flag in README alongside the existing RIMBA_DEBUG env var

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] `./bin/rimba list --debug` prints `[debug] git ...: Nms` lines to stderr
- [x] `./bin/rimba --help` shows `--debug` under global flags

N/A