### PR TITLE
[refactor] Split long cmd/list, clean, exec into helpers

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -104,52 +104,55 @@ func cleanMerged(cmd *cobra.Command, r git.Runner) error {
 	s := spinner.New(spinnerOpts(cmd))
 	defer s.Stop()
 
-	// Fetch latest (non-fatal)
-	mergeRef := mainBranch
-	s.Start("Fetching from origin...")
-	if err := git.Fetch(r, "origin"); err != nil {
-		s.Stop()
-		fmt.Fprintf(cmd.OutOrStdout(), "Warning: fetch failed (no remote?): continuing with local state\n")
-	} else {
-		mergeRef = "origin/" + mainBranch
-	}
+	mergeRef := cleanFetchMergeRef(cmd, r, s, mainBranch)
 
 	s.Update("Analyzing branches...")
 	mergedResult, err := operations.FindMergedCandidates(r, mergeRef, mainBranch)
 	if err != nil {
 		return err
 	}
-
 	s.Stop()
 
 	printWarnings(cmd, mergedResult.Warnings)
-
 	if len(mergedResult.Candidates) == 0 {
 		fmt.Fprintln(cmd.OutOrStdout(), "No merged worktrees found.")
 		return nil
 	}
 
 	printMergedCandidates(cmd, mergedResult.Candidates)
-
 	if dryRun {
 		return nil
 	}
-
 	if !force && !confirmRemoval(cmd, len(mergedResult.Candidates), "merged") {
 		fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
 		return nil
 	}
 
+	removed := cleanRemoveCandidates(cmd, r, s, mergedResult.Candidates)
+	fmt.Fprintf(cmd.OutOrStdout(), "Cleaned %d merged worktree(s).\n", removed)
+	return nil
+}
+
+// cleanFetchMergeRef fetches from origin and returns the ref to diff against.
+// Falls back to local mainBranch (with a warning) when fetch fails.
+func cleanFetchMergeRef(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, mainBranch string) string {
+	s.Start("Fetching from origin...")
+	if err := git.Fetch(r, "origin"); err != nil {
+		s.Stop()
+		fmt.Fprintf(cmd.OutOrStdout(), "Warning: fetch failed (no remote?): continuing with local state\n")
+		return mainBranch
+	}
+	return "origin/" + mainBranch
+}
+
+func cleanRemoveCandidates(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, candidates []operations.CleanCandidate) int {
 	s.Start("Removing worktrees...")
-	items := operations.RemoveCandidates(r, mergedResult.Candidates, func(msg string) {
+	items := operations.RemoveCandidates(r, candidates, func(msg string) {
 		s.Update(msg)
 	})
 	s.Stop()
 	printCleanedItems(cmd, items)
-
-	removed := countRemoved(items)
-	fmt.Fprintf(cmd.OutOrStdout(), "Cleaned %d merged worktree(s).\n", removed)
-	return nil
+	return countRemoved(items)
 }
 
 func cleanStale(cmd *cobra.Command, r git.Runner) error {
@@ -179,38 +182,32 @@ func cleanStale(cmd *cobra.Command, r git.Runner) error {
 	s.Stop()
 
 	printWarnings(cmd, staleResult.Warnings)
-
 	if len(staleResult.Candidates) == 0 {
 		fmt.Fprintln(cmd.OutOrStdout(), "No stale worktrees found.")
 		return nil
 	}
 
 	printStaleCandidates(cmd, staleResult.Candidates)
-
 	if dryRun {
 		return nil
 	}
-
 	if !force && !confirmRemoval(cmd, len(staleResult.Candidates), "stale") {
 		fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
 		return nil
 	}
 
-	toRemove := make([]operations.CleanCandidate, len(staleResult.Candidates))
-	for i, c := range staleResult.Candidates {
-		toRemove[i] = c.CleanCandidate
-	}
-
-	s.Start("Removing worktrees...")
-	items := operations.RemoveCandidates(r, toRemove, func(msg string) {
-		s.Update(msg)
-	})
-	s.Stop()
-	printCleanedItems(cmd, items)
-
-	removed := countRemoved(items)
+	toRemove := flattenStaleCandidates(staleResult.Candidates)
+	removed := cleanRemoveCandidates(cmd, r, s, toRemove)
 	fmt.Fprintf(cmd.OutOrStdout(), "Cleaned %d stale worktree(s).\n", removed)
 	return nil
+}
+
+func flattenStaleCandidates(candidates []operations.StaleCandidate) []operations.CleanCandidate {
+	out := make([]operations.CleanCandidate, len(candidates))
+	for i, c := range candidates {
+		out[i] = c.CleanCandidate
+	}
+	return out
 }
 
 func printMergedCandidates(cmd *cobra.Command, candidates []operations.CleanCandidate) {

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -566,3 +566,49 @@ func TestCleanStaleForce(t *testing.T) {
 		t.Errorf("output = %q, want 'Cleaned'", out)
 	}
 }
+
+func TestPrintWarnings(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	printWarnings(cmd, []string{"first", "second"})
+	out := buf.String()
+	if !strings.Contains(out, "Warning: first") || !strings.Contains(out, "Warning: second") {
+		t.Errorf("got %q", out)
+	}
+
+	buf.Reset()
+	printWarnings(cmd, nil)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for empty warnings, got %q", buf.String())
+	}
+}
+
+func TestPrintCleanedItemsAllBranches(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	items := []operations.CleanedItem{
+		// Success: worktree removed + branch deleted
+		{Branch: "feature/ok", Path: "/wt/ok", WorktreeRemoved: true, BranchDeleted: true},
+		// Partial: worktree removed but branch delete failed
+		{Branch: "feature/partial", Path: "/wt/partial", WorktreeRemoved: true, BranchDeleted: false},
+		// Failure: worktree removal failed
+		{Branch: "feature/fail", Path: "/wt/fail", WorktreeRemoved: false, BranchDeleted: false},
+	}
+	printCleanedItems(cmd, items)
+	out := buf.String()
+	for _, want := range []string{
+		"Removed worktree: /wt/ok",
+		"Deleted branch: feature/ok",
+		"Removed worktree: /wt/partial",
+		"failed to delete branch",
+		"git branch -D feature/partial",
+		"Failed to remove worktree feature/fail",
+		"rimba remove feature/fail",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output: %s", want, out)
+		}
+	}
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -36,58 +36,22 @@ var execCmd = &cobra.Command{
 	Long:  "Executes a shell command in parallel across matching worktrees. Use --all to target all worktrees, or --type to filter by prefix type.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg := config.FromContext(cmd.Context())
+		opts := execReadFlags(cmd)
+		if err := execValidateFlags(opts); err != nil {
+			return err
+		}
+
+		execShowHints(cmd)
 
 		r := newRunner()
-		all, _ := cmd.Flags().GetBool(flagAll)
-		typeFilter, _ := cmd.Flags().GetString(flagType)
-		dirty, _ := cmd.Flags().GetBool(flagDirty)
-		failFast, _ := cmd.Flags().GetBool(flagFailFast)
-		concurrency, _ := cmd.Flags().GetInt(flagConcurrency)
-
-		if !all && typeFilter == "" {
-			return errors.New("provide --all or --type to select worktrees")
-		}
-
-		if typeFilter != "" && !resolver.ValidPrefixType(typeFilter) {
-			valid := make([]string, 0, len(resolver.AllPrefixes()))
-			for _, p := range resolver.AllPrefixes() {
-				valid = append(valid, strings.TrimSuffix(p, "/"))
-			}
-			return fmt.Errorf("invalid type %q; valid types: %s", typeFilter, strings.Join(valid, ", "))
-		}
-
-		if !isJSON(cmd) {
-			hint.New(cmd, hintPainter(cmd)).
-				Add(flagAll, hintExecAll).
-				Add(flagType, hintExecType).
-				Add(flagDirty, hintExecDirty).
-				Add(flagFailFast, hintFailFast).
-				Add(flagConcurrency, hintConcurrency).
-				Show()
-		}
-
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
 		s.Start("Collecting worktrees...")
 
-		worktrees, err := listWorktreeInfos(r)
+		prefixes := resolver.AllPrefixes()
+		filtered, err := execSelectWorktrees(cmd, r, s, opts, prefixes)
 		if err != nil {
 			return err
-		}
-
-		prefixes := resolver.AllPrefixes()
-
-		var filtered []resolver.WorktreeInfo
-		if typeFilter != "" {
-			filtered = operations.FilterByType(worktrees, prefixes, typeFilter)
-		} else {
-			allTasks := operations.CollectTasks(worktrees, prefixes)
-			filtered = operations.FilterEligible(worktrees, prefixes, cfg.DefaultSource, allTasks, true)
-		}
-
-		if dirty {
-			filtered = filterDirtyWorktrees(r, s, filtered)
 		}
 
 		if len(filtered) == 0 {
@@ -96,67 +60,148 @@ var execCmd = &cobra.Command{
 			return nil
 		}
 
-		targets := make([]executor.Target, len(filtered))
-		for i, wt := range filtered {
-			task, _ := resolver.TaskFromBranch(wt.Branch, prefixes)
-			targets[i] = executor.Target{
-				Path:   wt.Path,
-				Branch: wt.Branch,
-				Task:   task,
-			}
-		}
-
+		targets := execBuildTargets(filtered, prefixes)
 		s.Update(fmt.Sprintf("Running in %d worktree(s)...", len(targets)))
 
 		results := executor.Run(cmd.Context(), executor.Config{
 			Targets:     targets,
 			Command:     args[0],
-			Concurrency: concurrency,
-			FailFast:    failFast,
+			Concurrency: opts.concurrency,
+			FailFast:    opts.failFast,
 			Runner:      executor.ShellRunner(),
 		})
 
 		s.Stop()
 
 		if isJSON(cmd) {
-			jsonResults := make([]output.ExecResult, len(results))
-			for i, r := range results {
-				jr := output.ExecResult{
-					Task:      r.Target.Task,
-					Branch:    r.Target.Branch,
-					Path:      r.Target.Path,
-					ExitCode:  r.ExitCode,
-					Stdout:    string(r.Stdout),
-					Stderr:    string(r.Stderr),
-					Cancelled: r.Cancelled,
-				}
-				if r.Err != nil {
-					jr.Error = r.Err.Error()
-				}
-				jsonResults[i] = jr
-			}
-			data := output.ExecData{
-				Command: args[0],
-				Results: jsonResults,
-				Success: !hasFailure(results),
-			}
-			_ = output.WriteJSON(cmd.OutOrStdout(), version, "exec", data)
-			if hasFailure(results) {
-				return &output.SilentError{ExitCode: 1}
-			}
-			return nil
+			return execRenderJSON(cmd, args[0], results)
 		}
-
-		noColor, _ := cmd.Flags().GetBool(flagNoColor)
-		p := termcolor.NewPainter(noColor)
-
-		printExecResults(cmd, p, results, prefixes)
-
-		if hasFailure(results) {
-			return errors.New("one or more commands failed")
-		}
-		return nil
+		return execRenderText(cmd, results, prefixes)
 	},
+}
+
+// execOpts holds parsed exec flags.
+type execOpts struct {
+	all         bool
+	typeFilter  string
+	dirty       bool
+	failFast    bool
+	concurrency int
+}
+
+func execReadFlags(cmd *cobra.Command) execOpts {
+	all, _ := cmd.Flags().GetBool(flagAll)
+	typeFilter, _ := cmd.Flags().GetString(flagType)
+	dirty, _ := cmd.Flags().GetBool(flagDirty)
+	failFast, _ := cmd.Flags().GetBool(flagFailFast)
+	concurrency, _ := cmd.Flags().GetInt(flagConcurrency)
+	return execOpts{
+		all:         all,
+		typeFilter:  typeFilter,
+		dirty:       dirty,
+		failFast:    failFast,
+		concurrency: concurrency,
+	}
+}
+
+func execValidateFlags(opts execOpts) error {
+	if !opts.all && opts.typeFilter == "" {
+		return errors.New("provide --all or --type to select worktrees")
+	}
+	if opts.typeFilter != "" && !resolver.ValidPrefixType(opts.typeFilter) {
+		valid := make([]string, 0, len(resolver.AllPrefixes()))
+		for _, p := range resolver.AllPrefixes() {
+			valid = append(valid, strings.TrimSuffix(p, "/"))
+		}
+		return fmt.Errorf("invalid type %q; valid types: %s", opts.typeFilter, strings.Join(valid, ", "))
+	}
+	return nil
+}
+
+func execShowHints(cmd *cobra.Command) {
+	if isJSON(cmd) {
+		return
+	}
+	hint.New(cmd, hintPainter(cmd)).
+		Add(flagAll, hintExecAll).
+		Add(flagType, hintExecType).
+		Add(flagDirty, hintExecDirty).
+		Add(flagFailFast, hintFailFast).
+		Add(flagConcurrency, hintConcurrency).
+		Show()
+}
+
+func execSelectWorktrees(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, opts execOpts, prefixes []string) ([]resolver.WorktreeInfo, error) {
+	cfg := config.FromContext(cmd.Context())
+	worktrees, err := listWorktreeInfos(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []resolver.WorktreeInfo
+	if opts.typeFilter != "" {
+		filtered = operations.FilterByType(worktrees, prefixes, opts.typeFilter)
+	} else {
+		allTasks := operations.CollectTasks(worktrees, prefixes)
+		filtered = operations.FilterEligible(worktrees, prefixes, cfg.DefaultSource, allTasks, true)
+	}
+
+	if opts.dirty {
+		filtered = filterDirtyWorktrees(r, s, filtered)
+	}
+	return filtered, nil
+}
+
+func execBuildTargets(filtered []resolver.WorktreeInfo, prefixes []string) []executor.Target {
+	targets := make([]executor.Target, len(filtered))
+	for i, wt := range filtered {
+		task, _ := resolver.TaskFromBranch(wt.Branch, prefixes)
+		targets[i] = executor.Target{
+			Path:   wt.Path,
+			Branch: wt.Branch,
+			Task:   task,
+		}
+	}
+	return targets
+}
+
+func execRenderJSON(cmd *cobra.Command, command string, results []executor.Result) error {
+	jsonResults := make([]output.ExecResult, len(results))
+	for i, r := range results {
+		jr := output.ExecResult{
+			Task:      r.Target.Task,
+			Branch:    r.Target.Branch,
+			Path:      r.Target.Path,
+			ExitCode:  r.ExitCode,
+			Stdout:    string(r.Stdout),
+			Stderr:    string(r.Stderr),
+			Cancelled: r.Cancelled,
+		}
+		if r.Err != nil {
+			jr.Error = r.Err.Error()
+		}
+		jsonResults[i] = jr
+	}
+	data := output.ExecData{
+		Command: command,
+		Results: jsonResults,
+		Success: !hasFailure(results),
+	}
+	_ = output.WriteJSON(cmd.OutOrStdout(), version, "exec", data)
+	if hasFailure(results) {
+		return &output.SilentError{ExitCode: 1}
+	}
+	return nil
+}
+
+func execRenderText(cmd *cobra.Command, results []executor.Result, prefixes []string) error {
+	noColor, _ := cmd.Flags().GetBool(flagNoColor)
+	p := termcolor.NewPainter(noColor)
+	printExecResults(cmd, p, results, prefixes)
+	if hasFailure(results) {
+		return errors.New("one or more commands failed")
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/executor"
 	"github.com/lugassawan/rimba/internal/output"
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -275,4 +278,204 @@ func TestExecTypeFlagCompletion(t *testing.T) {
 
 func testExecSpinner(cmd *cobra.Command) *spinner.Spinner {
 	return spinner.New(spinnerOpts(cmd))
+}
+
+func TestExecReadFlags(t *testing.T) {
+	const typeFeature = "feature"
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool(flagAll, false, "")
+	cmd.Flags().String(flagType, "", "")
+	cmd.Flags().Bool(flagDirty, false, "")
+	cmd.Flags().Bool(flagFailFast, false, "")
+	cmd.Flags().Int(flagConcurrency, 0, "")
+	if err := cmd.ParseFlags([]string{"--all", "--type", typeFeature, "--dirty", "--fail-fast", "--concurrency", "4"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	opts := execReadFlags(cmd)
+	if !opts.all || opts.typeFilter != typeFeature || !opts.dirty || !opts.failFast || opts.concurrency != 4 {
+		t.Errorf("unexpected opts: %+v", opts)
+	}
+}
+
+func TestExecValidateFlagsNeedsAllOrType(t *testing.T) {
+	if err := execValidateFlags(execOpts{}); err == nil {
+		t.Error("expected error when neither --all nor --type set")
+	}
+}
+
+func TestExecValidateFlagsInvalidType(t *testing.T) {
+	err := execValidateFlags(execOpts{typeFilter: "nope"})
+	if err == nil || !strings.Contains(err.Error(), "invalid type") {
+		t.Errorf("expected invalid type error, got %v", err)
+	}
+}
+
+func TestExecValidateFlagsOK(t *testing.T) {
+	if err := execValidateFlags(execOpts{all: true}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := execValidateFlags(execOpts{typeFilter: "feature"}); err != nil {
+		t.Errorf("unexpected error for valid type: %v", err)
+	}
+}
+
+func TestExecBuildTargets(t *testing.T) {
+	wts := []resolver.WorktreeInfo{
+		{Branch: "feature/foo", Path: "/tmp/foo"},
+		{Branch: "bugfix/bar", Path: "/tmp/bar"},
+	}
+	targets := execBuildTargets(wts, resolver.AllPrefixes())
+	if len(targets) != 2 {
+		t.Fatalf("got %d targets, want 2", len(targets))
+	}
+	if targets[0].Task != "foo" || targets[0].Path != "/tmp/foo" {
+		t.Errorf("target[0] = %+v", targets[0])
+	}
+	if targets[1].Task != "bar" {
+		t.Errorf("target[1].Task = %q, want bar", targets[1].Task)
+	}
+}
+
+func TestExecRenderJSONSuccess(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	results := []executor.Result{
+		{Target: executor.Target{Task: "foo", Branch: "feature/foo", Path: "/tmp/foo"}, ExitCode: 0, Stdout: []byte("hi")},
+	}
+	if err := execRenderJSON(cmd, "echo hi", results); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal([]byte(buf.String()), &data); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+}
+
+func TestExecRenderJSONFailureReturnsSilentError(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	results := []executor.Result{
+		{Target: executor.Target{Task: "foo", Branch: "feature/foo"}, ExitCode: 1},
+	}
+	err := execRenderJSON(cmd, "false", results)
+	if err == nil {
+		t.Fatal("expected SilentError on failure")
+	}
+	var se *output.SilentError
+	if !errors.As(err, &se) || se.ExitCode != 1 {
+		t.Errorf("expected SilentError exit=1, got %#v", err)
+	}
+}
+
+func TestExecRenderTextFailureReturnsError(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool(flagNoColor, true, "")
+	_ = cmd.ParseFlags([]string{"--no-color"})
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	results := []executor.Result{
+		{Target: executor.Target{Task: "foo", Branch: "feature/foo"}, ExitCode: 1},
+	}
+	if err := execRenderText(cmd, results, resolver.AllPrefixes()); err == nil {
+		t.Error("expected error on non-zero exit")
+	}
+}
+
+func TestExecRenderTextSuccess(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool(flagNoColor, true, "")
+	_ = cmd.ParseFlags([]string{"--no-color"})
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	results := []executor.Result{
+		{Target: executor.Target{Task: "foo", Branch: "feature/foo"}, ExitCode: 0},
+	}
+	if err := execRenderText(cmd, results, resolver.AllPrefixes()); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestExecSelectWorktreesListError(t *testing.T) {
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", errGitFailed },
+		runInDir: noopRunInDir,
+	}
+	cmd, _ := newTestCmd()
+	cmd.SetContext(config.WithConfig(context.Background(), &config.Config{DefaultSource: "main"}))
+	s := spinner.New(spinnerOpts(cmd))
+	_, err := execSelectWorktrees(cmd, r, s, execOpts{all: true}, resolver.AllPrefixes())
+	if err == nil {
+		t.Fatal("expected error from listWorktreeInfos")
+	}
+}
+
+func TestExecSelectWorktreesTypeFilter(t *testing.T) {
+	porcelain := strings.Join([]string{
+		"worktree /repo",
+		"HEAD abc",
+		"branch refs/heads/main",
+		"",
+		"worktree /wt/foo",
+		"HEAD def",
+		"branch refs/heads/feature/foo",
+		"",
+		"worktree /wt/bar",
+		"HEAD ghi",
+		"branch refs/heads/bugfix/bar",
+		"",
+	}, "\n")
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return porcelain, nil },
+		runInDir: noopRunInDir,
+	}
+	cmd, _ := newTestCmd()
+	cmd.SetContext(config.WithConfig(context.Background(), &config.Config{DefaultSource: "main"}))
+	s := spinner.New(spinnerOpts(cmd))
+	got, err := execSelectWorktrees(cmd, r, s, execOpts{typeFilter: "feature"}, resolver.AllPrefixes())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(got) != 1 || got[0].Branch != "feature/foo" {
+		t.Errorf("got %+v, want one feature worktree", got)
+	}
+}
+
+func TestExecSelectWorktreesAllEligible(t *testing.T) {
+	porcelain := strings.Join([]string{
+		"worktree /repo",
+		"HEAD abc",
+		"branch refs/heads/main",
+		"",
+		"worktree /wt/foo",
+		"HEAD def",
+		"branch refs/heads/feature/foo",
+		"",
+	}, "\n")
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return porcelain, nil },
+		runInDir: noopRunInDir,
+	}
+	cmd, _ := newTestCmd()
+	cmd.SetContext(config.WithConfig(context.Background(), &config.Config{DefaultSource: "main"}))
+	s := spinner.New(spinnerOpts(cmd))
+	got, err := execSelectWorktrees(cmd, r, s, execOpts{all: true}, resolver.AllPrefixes())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(got) == 0 {
+		t.Error("expected at least one eligible worktree")
+	}
+}
+
+func TestExecShowHintsNoJSON(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool(flagJSON, false, "")
+	cmd.Flags().Bool(flagNoColor, true, "")
+	_ = cmd.ParseFlags([]string{"--no-color"})
+	var buf strings.Builder
+	cmd.SetErr(&buf)
+	cmd.SetOut(&buf)
+	execShowHints(cmd) // should not panic; output goes to stderr for hint pkg
 }

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -479,3 +479,17 @@ func TestExecShowHintsNoJSON(t *testing.T) {
 	cmd.SetOut(&buf)
 	execShowHints(cmd) // should not panic; output goes to stderr for hint pkg
 }
+
+func TestExecShowHintsJSONEarlyReturn(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool(flagJSON, true, "")
+	cmd.Flags().Bool(flagNoColor, true, "")
+	_ = cmd.ParseFlags([]string{"--json", "--no-color"})
+	var buf strings.Builder
+	cmd.SetErr(&buf)
+	cmd.SetOut(&buf)
+	execShowHints(cmd)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output in JSON mode, got %q", buf.String())
+	}
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -45,14 +45,9 @@ var listCmd = &cobra.Command{
 	Short: "List all worktrees",
 	Long:  "Lists all git worktrees with task, type, and status. Use --full to show all columns including branch and path.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		listType, _ := cmd.Flags().GetString(flagType)
-		listDirty, _ := cmd.Flags().GetBool(flagDirty)
-		listBehind, _ := cmd.Flags().GetBool(flagBehind)
-		listArchived, _ := cmd.Flags().GetBool(flagArchived)
-		listFull, _ := cmd.Flags().GetBool(flagFull)
-		listService, _ := cmd.Flags().GetString(flagService)
+		opts := listReadFlags(cmd)
 
-		if listArchived {
+		if opts.archived {
 			r := newRunner()
 			mainBranch, err := resolveMainBranch(r)
 			if err != nil {
@@ -61,148 +56,202 @@ var listCmd = &cobra.Command{
 			return listArchivedBranches(cmd, r, mainBranch)
 		}
 
-		cfg := config.FromContext(cmd.Context())
-
-		if listType != "" && !resolver.ValidPrefixType(listType) {
-			valid := make([]string, 0, len(resolver.AllPrefixes()))
-			for _, p := range resolver.AllPrefixes() {
-				valid = append(valid, strings.TrimSuffix(p, "/"))
-			}
-			return fmt.Errorf("invalid type %q; valid types: %s", listType, strings.Join(valid, ", "))
-		}
-
-		r := newRunner()
-
-		repoRoot, err := git.MainRepoRoot(r)
-		if err != nil {
+		if err := listValidateType(opts.typeFilter); err != nil {
 			return err
 		}
 
-		entries, err := git.ListWorktrees(r)
+		r := newRunner()
+		entries, wtDir, err := listLoadEntries(r, cmd)
 		if err != nil {
 			return err
 		}
 
 		if len(entries) == 0 {
-			if isJSON(cmd) {
-				return output.WriteJSON(cmd.OutOrStdout(), version, "list", make([]output.ListItem, 0))
-			}
-			fmt.Fprintln(cmd.OutOrStdout(), "No worktrees found.")
-			return nil
+			return listRenderEmpty(cmd, "No worktrees found.")
 		}
 
-		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
-		prefixes := resolver.AllPrefixes()
-
-		// Detect current worktree
-		cwd, _ := os.Getwd()
-		cwdResolved, _ := filepath.EvalSymlinks(cwd)
-		cwdResolved = filepath.Clean(cwdResolved)
-
-		if !isJSON(cmd) {
-			hint.New(cmd, hintPainter(cmd)).
-				Add(flagFull, hintFull).
-				Add(flagType, hintType).
-				Add(flagService, hintService).
-				Add(flagDirty, hintDirty).
-				Add(flagBehind, hintBehind).
-				Show()
-		}
+		listShowHints(cmd)
 
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
 		s.Start("Loading worktrees...")
 
-		var candidates []candidate
-		for _, e := range entries {
-			if e.Bare {
-				continue
-			}
-
-			if listType != "" {
-				_, matchedPrefix := resolver.TaskFromBranch(e.Branch, prefixes)
-				entryType := strings.TrimSuffix(matchedPrefix, "/")
-				if entryType != listType {
-					continue
-				}
-			}
-
-			displayPath := e.Path
-			if rel, err := filepath.Rel(wtDir, e.Path); err == nil && len(rel) < len(displayPath) {
-				displayPath = rel
-			}
-
-			entryResolved, _ := filepath.EvalSymlinks(e.Path)
-			entryResolved = filepath.Clean(entryResolved)
-			isCurrent := cwdResolved == entryResolved
-
-			candidates = append(candidates, candidate{entry: e, displayPath: displayPath, isCurrent: isCurrent})
-		}
-
-		rows := parallel.Collect(len(candidates), 8, func(i int) resolver.WorktreeDetail {
-			c := candidates[i]
-			status := operations.CollectWorktreeStatus(r, c.entry.Path)
-			return resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)
-		})
-
-		rows = operations.FilterDetailsByStatus(rows, listDirty, listBehind)
-		rows = resolver.FilterByService(rows, listService)
+		prefixes := resolver.AllPrefixes()
+		candidates := listBuildCandidates(entries, wtDir, prefixes, opts.typeFilter)
+		rows := listCollectRows(r, candidates, prefixes)
+		rows = operations.FilterDetailsByStatus(rows, opts.dirty, opts.behind)
+		rows = resolver.FilterByService(rows, opts.service)
 
 		s.Stop()
 
 		if len(rows) == 0 {
-			if isJSON(cmd) {
-				return output.WriteJSON(cmd.OutOrStdout(), version, "list", make([]output.ListItem, 0))
-			}
-			fmt.Fprintln(cmd.OutOrStdout(), "No worktrees match the given filters.")
-			return nil
+			return listRenderEmpty(cmd, "No worktrees match the given filters.")
 		}
 
 		resolver.SortDetailsByTask(rows)
 
 		if isJSON(cmd) {
-			items := make([]output.ListItem, len(rows))
-			for i, r := range rows {
-				items[i] = output.ListItem{
-					Task:      r.Task,
-					Service:   r.Service,
-					Type:      r.Type,
-					Branch:    r.Branch,
-					Path:      r.Path,
-					IsCurrent: r.IsCurrent,
-					Status:    r.Status,
-				}
-			}
-			return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
+			return listRenderJSON(cmd, rows)
 		}
-
-		hasService := resolver.HasService(rows)
-
-		noColor, _ := cmd.Flags().GetBool(flagNoColor)
-		p := termcolor.NewPainter(noColor)
-
-		tbl := termcolor.NewTable(2)
-		tbl.AddRow(listHeader(p, hasService, listFull)...)
-
-		for _, row := range rows {
-			taskCell := "  " + row.Task
-			if row.IsCurrent {
-				taskCell = "* " + row.Task
-				taskCell = p.Paint(taskCell, termcolor.Green, termcolor.Bold)
-			}
-
-			typeCell := row.Type
-			if c := typeColor(row.Type); c != "" {
-				typeCell = p.Paint(typeCell, c)
-			}
-
-			statusCell := colorStatus(p, row.Status)
-			tbl.AddRow(listRow(taskCell, row, typeCell, statusCell, hasService, listFull)...)
-		}
-
-		tbl.Render(cmd.OutOrStdout())
+		listRenderTable(cmd, rows, opts.full)
 		return nil
 	},
+}
+
+// listOpts holds parsed list flags.
+type listOpts struct {
+	typeFilter string
+	dirty      bool
+	behind     bool
+	archived   bool
+	full       bool
+	service    string
+}
+
+func listReadFlags(cmd *cobra.Command) listOpts {
+	typeFilter, _ := cmd.Flags().GetString(flagType)
+	dirty, _ := cmd.Flags().GetBool(flagDirty)
+	behind, _ := cmd.Flags().GetBool(flagBehind)
+	archived, _ := cmd.Flags().GetBool(flagArchived)
+	full, _ := cmd.Flags().GetBool(flagFull)
+	service, _ := cmd.Flags().GetString(flagService)
+	return listOpts{
+		typeFilter: typeFilter,
+		dirty:      dirty,
+		behind:     behind,
+		archived:   archived,
+		full:       full,
+		service:    service,
+	}
+}
+
+func listValidateType(typeFilter string) error {
+	if typeFilter == "" || resolver.ValidPrefixType(typeFilter) {
+		return nil
+	}
+	valid := make([]string, 0, len(resolver.AllPrefixes()))
+	for _, p := range resolver.AllPrefixes() {
+		valid = append(valid, strings.TrimSuffix(p, "/"))
+	}
+	return fmt.Errorf("invalid type %q; valid types: %s", typeFilter, strings.Join(valid, ", "))
+}
+
+func listLoadEntries(r git.Runner, cmd *cobra.Command) ([]git.WorktreeEntry, string, error) {
+	cfg := config.FromContext(cmd.Context())
+	repoRoot, err := git.MainRepoRoot(r)
+	if err != nil {
+		return nil, "", err
+	}
+	entries, err := git.ListWorktrees(r)
+	if err != nil {
+		return nil, "", err
+	}
+	return entries, filepath.Join(repoRoot, cfg.WorktreeDir), nil
+}
+
+func listShowHints(cmd *cobra.Command) {
+	if isJSON(cmd) {
+		return
+	}
+	hint.New(cmd, hintPainter(cmd)).
+		Add(flagFull, hintFull).
+		Add(flagType, hintType).
+		Add(flagService, hintService).
+		Add(flagDirty, hintDirty).
+		Add(flagBehind, hintBehind).
+		Show()
+}
+
+func listRenderEmpty(cmd *cobra.Command, msg string) error {
+	if isJSON(cmd) {
+		return output.WriteJSON(cmd.OutOrStdout(), version, "list", make([]output.ListItem, 0))
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), msg)
+	return nil
+}
+
+func listBuildCandidates(entries []git.WorktreeEntry, wtDir string, prefixes []string, typeFilter string) []candidate {
+	cwd, _ := os.Getwd()
+	cwdResolved, _ := filepath.EvalSymlinks(cwd)
+	cwdResolved = filepath.Clean(cwdResolved)
+
+	var candidates []candidate
+	for _, e := range entries {
+		if e.Bare {
+			continue
+		}
+
+		if typeFilter != "" {
+			_, matchedPrefix := resolver.TaskFromBranch(e.Branch, prefixes)
+			entryType := strings.TrimSuffix(matchedPrefix, "/")
+			if entryType != typeFilter {
+				continue
+			}
+		}
+
+		displayPath := e.Path
+		if rel, err := filepath.Rel(wtDir, e.Path); err == nil && len(rel) < len(displayPath) {
+			displayPath = rel
+		}
+
+		entryResolved, _ := filepath.EvalSymlinks(e.Path)
+		entryResolved = filepath.Clean(entryResolved)
+		isCurrent := cwdResolved == entryResolved
+
+		candidates = append(candidates, candidate{entry: e, displayPath: displayPath, isCurrent: isCurrent})
+	}
+	return candidates
+}
+
+func listCollectRows(r git.Runner, candidates []candidate, prefixes []string) []resolver.WorktreeDetail {
+	return parallel.Collect(len(candidates), 8, func(i int) resolver.WorktreeDetail {
+		c := candidates[i]
+		status := operations.CollectWorktreeStatus(r, c.entry.Path)
+		return resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)
+	})
+}
+
+func listRenderJSON(cmd *cobra.Command, rows []resolver.WorktreeDetail) error {
+	items := make([]output.ListItem, len(rows))
+	for i, r := range rows {
+		items[i] = output.ListItem{
+			Task:      r.Task,
+			Service:   r.Service,
+			Type:      r.Type,
+			Branch:    r.Branch,
+			Path:      r.Path,
+			IsCurrent: r.IsCurrent,
+			Status:    r.Status,
+		}
+	}
+	return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
+}
+
+func listRenderTable(cmd *cobra.Command, rows []resolver.WorktreeDetail, full bool) {
+	hasService := resolver.HasService(rows)
+	noColor, _ := cmd.Flags().GetBool(flagNoColor)
+	p := termcolor.NewPainter(noColor)
+
+	tbl := termcolor.NewTable(2)
+	tbl.AddRow(listHeader(p, hasService, full)...)
+
+	for _, row := range rows {
+		taskCell := "  " + row.Task
+		if row.IsCurrent {
+			taskCell = "* " + row.Task
+			taskCell = p.Paint(taskCell, termcolor.Green, termcolor.Bold)
+		}
+
+		typeCell := row.Type
+		if c := typeColor(row.Type); c != "" {
+			typeCell = p.Paint(typeCell, c)
+		}
+
+		statusCell := colorStatus(p, row.Status)
+		tbl.AddRow(listRow(taskCell, row, typeCell, statusCell, hasService, full)...)
+	}
+
+	tbl.Render(cmd.OutOrStdout())
 }
 
 func init() {

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -762,3 +762,97 @@ func TestListBehindFilterWithMatch(t *testing.T) {
 		t.Errorf("output = %q, want 'login' in filtered table", out)
 	}
 }
+
+func TestListLoadEntriesRepoRootError(t *testing.T) {
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", errGitFailed },
+		runInDir: noopRunInDir,
+	}
+	cmd, _ := newListTestCmd()
+	cmd.SetContext(config.WithConfig(context.Background(), &config.Config{WorktreeDir: "worktrees"}))
+	if _, _, err := listLoadEntries(r, cmd); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestListLoadEntriesListError(t *testing.T) {
+	calls := 0
+	r := &mockRunner{
+		run: func(_ ...string) (string, error) {
+			calls++
+			if calls == 1 {
+				return "/repo", nil // MainRepoRoot succeeds
+			}
+			return "", errGitFailed
+		},
+		runInDir: noopRunInDir,
+	}
+	cmd, _ := newListTestCmd()
+	cmd.SetContext(config.WithConfig(context.Background(), &config.Config{WorktreeDir: "worktrees"}))
+	if _, _, err := listLoadEntries(r, cmd); err == nil {
+		t.Fatal("expected list error")
+	}
+}
+
+func TestListValidateTypeEmpty(t *testing.T) {
+	if err := listValidateType(""); err != nil {
+		t.Errorf("expected nil for empty type, got %v", err)
+	}
+}
+
+func TestListValidateTypeValid(t *testing.T) {
+	if err := listValidateType("feature"); err != nil {
+		t.Errorf("expected nil for valid type, got %v", err)
+	}
+}
+
+func TestListReadFlags(t *testing.T) {
+	cmd, _ := newListTestCmd()
+	_ = cmd.Flags().Set(flagType, "feature")
+	_ = cmd.Flags().Set(flagService, "web")
+	_ = cmd.Flags().Set(flagDirty, "true")
+	_ = cmd.Flags().Set(flagBehind, "true")
+	_ = cmd.Flags().Set(flagArchived, "true")
+	_ = cmd.Flags().Set(flagFull, "true")
+	opts := listReadFlags(cmd)
+	if opts.typeFilter != "feature" || opts.service != "web" || !opts.dirty || !opts.behind || !opts.archived || !opts.full {
+		t.Errorf("unexpected opts: %+v", opts)
+	}
+}
+
+func TestListRenderEmptyJSON(t *testing.T) {
+	cmd, buf := newListTestCmd()
+	_ = cmd.Flags().Set(flagJSON, "true")
+	if err := listRenderEmpty(cmd, "none"); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &data); err != nil {
+		t.Errorf("output not JSON: %v", err)
+	}
+}
+
+func TestListRenderEmptyText(t *testing.T) {
+	cmd, buf := newListTestCmd()
+	if err := listRenderEmpty(cmd, "none here"); err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if !strings.Contains(buf.String(), "none here") {
+		t.Errorf("expected 'none here' in %q", buf.String())
+	}
+}
+
+func TestListRenderTableWithFullAndService(t *testing.T) {
+	cmd, buf := newListTestCmd()
+	rows := []resolver.WorktreeDetail{
+		{Task: "foo", Branch: "feature/foo", Type: "feature", Path: "/wt/foo", Service: "web", IsCurrent: true, Status: resolver.WorktreeStatus{}},
+		{Task: "bar", Branch: "bugfix/bar", Type: "bugfix", Path: "/wt/bar", Status: resolver.WorktreeStatus{Dirty: true}},
+	}
+	listRenderTable(cmd, rows, true)
+	out := buf.String()
+	for _, want := range []string{"foo", "bar", "feature/foo", "bugfix/bar", "SERVICE", "BRANCH", "PATH"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("want %q in output: %s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Splits RunE closures in cmd/list.go, cmd/clean.go, cmd/exec.go into named helpers
- Each helper now does one thing; RunE becomes orchestration only
- No behavior change; all existing tests pass unchanged

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] `./bin/rimba list`, `clean --help`, `exec --help` produce identical output to main

N/A