### PR TITLE
[feat] Validate config invariants early via Config.Validate()

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,6 +75,10 @@ var rootCmd = &cobra.Command{
 		}
 		cfg.FillDefaults(repoName, defaultBranch)
 
+		if err := cfg.Validate(); err != nil {
+			return err
+		}
+
 		cmd.SetContext(config.WithConfig(cmd.Context(), cfg))
 		return nil
 	},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,10 +90,7 @@ func (c *Config) FillDefaults(repoName, defaultBranch string) {
 	}
 }
 
-// Validate checks invariants on the loaded config and returns a joined error
-// describing all issues at once, or nil if the config is valid. It performs no
-// I/O and is safe to call after Resolve and FillDefaults. Each issue names the
-// offending field or section so users can fix them in one pass.
+// Validate returns a joined error of all invariant violations, or nil if valid.
 func (c *Config) Validate() error {
 	var errs []error
 	errs = appendIf(errs, validateWorktreeDir(c.WorktreeDir)...)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -242,7 +242,10 @@ func appendIf(dst []error, src ...error) []error {
 // break resolution because worktree paths are joined against the repo root.
 func validateWorktreeDir(dir string) []error {
 	if dir != "" && filepath.IsAbs(dir) {
-		return []error{fmt.Errorf("config: worktree_dir must be relative, got %q", dir)}
+		return []error{errhint.WithFix(
+			fmt.Errorf("config: worktree_dir must be relative, got %q", dir),
+			"set worktree_dir to a path relative to the repo root in .rimba/settings.toml",
+		)}
 	}
 	return nil
 }
@@ -259,7 +262,10 @@ func validateDeps(deps *DepsConfig) []error {
 	for i, m := range deps.Modules {
 		errs = append(errs, validateModuleDir(i, m.Dir, seenDirs)...)
 		if strings.TrimSpace(m.Install) == "" {
-			errs = append(errs, fmt.Errorf("config: deps.modules[%q]: install command is empty", m.Dir))
+			errs = append(errs, errhint.WithFix(
+				fmt.Errorf("config: deps.modules[%q]: install command is empty", m.Dir),
+				"set install = \"<command>\" for the module in .rimba/settings.toml",
+			))
 		}
 	}
 	return errs
@@ -270,9 +276,15 @@ func validateDeps(deps *DepsConfig) []error {
 func validateModuleDir(index int, dir string, seen map[string]bool) []error {
 	switch {
 	case strings.TrimSpace(dir) == "":
-		return []error{fmt.Errorf("config: deps.modules[%d]: dir is empty", index)}
+		return []error{errhint.WithFix(
+			fmt.Errorf("config: deps.modules[%d]: dir is empty", index),
+			"set dir = \"<path>\" for the module in .rimba/settings.toml",
+		)}
 	case seen[dir]:
-		return []error{fmt.Errorf("config: deps.modules[%d]: duplicate dir %q", index, dir)}
+		return []error{errhint.WithFix(
+			fmt.Errorf("config: deps.modules[%d]: duplicate dir %q", index, dir),
+			"remove the duplicate [[deps.modules]] entry from .rimba/settings.toml",
+		)}
 	default:
 		seen[dir] = true
 		return nil
@@ -286,11 +298,17 @@ func validateOpen(open map[string]string) []error {
 	var errs []error
 	for name := range open {
 		if name == "" {
-			errs = append(errs, errors.New("config: open: shortcut name is empty"))
+			errs = append(errs, errhint.WithFix(
+				errors.New("config: open: shortcut name is empty"),
+				"remove the empty-keyed entry under [open] in .rimba/settings.toml",
+			))
 			continue
 		}
 		if strings.ContainsRune(name, '/') || strings.ContainsRune(name, filepath.Separator) {
-			errs = append(errs, fmt.Errorf("config: open[%q]: shortcut name must not contain path separators", name))
+			errs = append(errs, errhint.WithFix(
+				fmt.Errorf("config: open[%q]: shortcut name must not contain path separators", name),
+				"rename the shortcut in [open] to a name without '/' in .rimba/settings.toml",
+			))
 		}
 	}
 	return errs

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,9 +2,11 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	toml "github.com/pelletier/go-toml/v2"
 
@@ -86,6 +88,18 @@ func (c *Config) FillDefaults(repoName, defaultBranch string) {
 	if c.CopyFiles == nil {
 		c.CopyFiles = DefaultCopyFiles()
 	}
+}
+
+// Validate checks invariants on the loaded config and returns a joined error
+// describing all issues at once, or nil if the config is valid. It performs no
+// I/O and is safe to call after Resolve and FillDefaults. Each issue names the
+// offending field or section so users can fix them in one pass.
+func (c *Config) Validate() error {
+	var errs []error
+	errs = appendIf(errs, validateWorktreeDir(c.WorktreeDir)...)
+	errs = appendIf(errs, validateDeps(c.Deps)...)
+	errs = appendIf(errs, validateOpen(c.Open)...)
+	return errors.Join(errs...)
 }
 
 type ctxKey struct{}
@@ -215,4 +229,72 @@ func loadRaw(path string) (*Config, error) {
 		)
 	}
 	return &cfg, nil
+}
+
+// appendIf appends only non-nil errors. Keeps Validate concise.
+func appendIf(dst []error, src ...error) []error {
+	for _, e := range src {
+		if e != nil {
+			dst = append(dst, e)
+		}
+	}
+	return dst
+}
+
+// validateWorktreeDir enforces that WorktreeDir is relative. Absolute paths
+// break resolution because worktree paths are joined against the repo root.
+func validateWorktreeDir(dir string) []error {
+	if dir != "" && filepath.IsAbs(dir) {
+		return []error{fmt.Errorf("config: worktree_dir must be relative, got %q", dir)}
+	}
+	return nil
+}
+
+// validateDeps checks that each module has a non-empty, unique Dir and a
+// non-empty Install command. Empty Dir collides in the downstream map keyed
+// by Dir; empty Install is a silent no-op at install time.
+func validateDeps(deps *DepsConfig) []error {
+	if deps == nil {
+		return nil
+	}
+	var errs []error
+	seenDirs := make(map[string]bool, len(deps.Modules))
+	for i, m := range deps.Modules {
+		errs = append(errs, validateModuleDir(i, m.Dir, seenDirs)...)
+		if strings.TrimSpace(m.Install) == "" {
+			errs = append(errs, fmt.Errorf("config: deps.modules[%q]: install command is empty", m.Dir))
+		}
+	}
+	return errs
+}
+
+// validateModuleDir returns an error if dir is empty or a duplicate, and
+// records the dir in seen when it's valid.
+func validateModuleDir(index int, dir string, seen map[string]bool) []error {
+	switch {
+	case strings.TrimSpace(dir) == "":
+		return []error{fmt.Errorf("config: deps.modules[%d]: dir is empty", index)}
+	case seen[dir]:
+		return []error{fmt.Errorf("config: deps.modules[%d]: duplicate dir %q", index, dir)}
+	default:
+		seen[dir] = true
+		return nil
+	}
+}
+
+// validateOpen rejects shortcut names that are empty or contain path
+// separators (either `/` or the OS-specific separator) to avoid collisions
+// with file-path resolution in `rimba open`.
+func validateOpen(open map[string]string) []error {
+	var errs []error
+	for name := range open {
+		if name == "" {
+			errs = append(errs, errors.New("config: open: shortcut name is empty"))
+			continue
+		}
+		if strings.ContainsRune(name, '/') || strings.ContainsRune(name, filepath.Separator) {
+			errs = append(errs, fmt.Errorf("config: open[%q]: shortcut name must not contain path separators", name))
+		}
+	}
+	return errs
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -566,6 +566,142 @@ func TestResolveNeitherExists(t *testing.T) {
 	}
 }
 
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        *config.Config
+		wantErr    bool
+		wantSubstr []string
+	}{
+		{
+			name: "valid config",
+			cfg: &config.Config{
+				WorktreeDir:   "../myrepo-worktrees",
+				DefaultSource: testDefaultBranch,
+				CopyFiles:     []string{".env"},
+				Open:          map[string]string{"ide": "code .", "agent": "claude"},
+				Deps: &config.DepsConfig{
+					Modules: []config.ModuleConfig{
+						{Dir: "web", Lockfile: "package-lock.json", Install: "npm ci"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "absolute worktree_dir",
+			cfg: &config.Config{
+				WorktreeDir:   "/abs/path/bad",
+				DefaultSource: testDefaultBranch,
+			},
+			wantErr:    true,
+			wantSubstr: []string{"worktree_dir", "/abs/path/bad"},
+		},
+		{
+			name: "deps module with empty install",
+			cfg: &config.Config{
+				WorktreeDir:   "../wt",
+				DefaultSource: testDefaultBranch,
+				Deps: &config.DepsConfig{
+					Modules: []config.ModuleConfig{
+						{Dir: "web", Install: ""},
+					},
+				},
+			},
+			wantErr:    true,
+			wantSubstr: []string{"deps", "web", "install"},
+		},
+		{
+			name: "deps module with empty dir",
+			cfg: &config.Config{
+				WorktreeDir:   "../wt",
+				DefaultSource: testDefaultBranch,
+				Deps: &config.DepsConfig{
+					Modules: []config.ModuleConfig{
+						{Dir: "", Install: "npm ci"},
+					},
+				},
+			},
+			wantErr:    true,
+			wantSubstr: []string{"deps", "dir is empty"},
+		},
+		{
+			name: "deps modules with duplicate dir",
+			cfg: &config.Config{
+				WorktreeDir:   "../wt",
+				DefaultSource: testDefaultBranch,
+				Deps: &config.DepsConfig{
+					Modules: []config.ModuleConfig{
+						{Dir: "web", Install: "npm ci"},
+						{Dir: "web", Install: "npm install"},
+					},
+				},
+			},
+			wantErr:    true,
+			wantSubstr: []string{"duplicate dir", "web"},
+		},
+		{
+			name: "open shortcut with slash",
+			cfg: &config.Config{
+				WorktreeDir:   "../wt",
+				DefaultSource: testDefaultBranch,
+				Open:          map[string]string{"bad/key": "echo hi"},
+			},
+			wantErr:    true,
+			wantSubstr: []string{"open", "bad/key"},
+		},
+		{
+			name: "open shortcut with empty name",
+			cfg: &config.Config{
+				WorktreeDir:   "../wt",
+				DefaultSource: testDefaultBranch,
+				Open:          map[string]string{"": "echo hi"},
+			},
+			wantErr:    true,
+			wantSubstr: []string{"open", "empty"},
+		},
+		{
+			name: "multiple issues aggregated",
+			cfg: &config.Config{
+				WorktreeDir:   "/abs/bad",
+				DefaultSource: testDefaultBranch,
+				Open:          map[string]string{"bad/key": "echo hi"},
+				Deps: &config.DepsConfig{
+					Modules: []config.ModuleConfig{
+						{Dir: "web", Install: ""},
+					},
+				},
+			},
+			wantErr:    true,
+			wantSubstr: []string{"worktree_dir", "/abs/bad", "bad/key", "web", "install"},
+		},
+		{
+			name:    "empty config passes",
+			cfg:     &config.Config{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Validate() returned nil, want error containing %v", tt.wantSubstr)
+				}
+				msg := err.Error()
+				for _, sub := range tt.wantSubstr {
+					if !strings.Contains(msg, sub) {
+						t.Errorf("Validate() error = %q, want substring %q", msg, sub)
+					}
+				}
+			} else if err != nil {
+				t.Errorf("Validate() returned unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestIsAutoDetectDeps(t *testing.T) {
 	boolPtr := func(b bool) *bool { return &b }
 


### PR DESCRIPTION
## Summary
- Adds Config.Validate() method that aggregates invariant checks via errors.Join
- Validates WorktreeDir is relative, deps module Dir non-empty/unique, deps install commands non-empty, open shortcuts free of path separators
- Called in PersistentPreRunE so misconfiguration fails fast with all issues reported at once

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Table-driven TestConfigValidate covers valid, single-issue, and multi-issue cases
- [x] Manual: a config with multiple invalid fields surfaces ALL issues in one error

N/A