### PR TITLE
[feat] Add errhint.WithFix helper and apply to user-facing errors

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lugassawan/rimba/internal/agentfile"
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/fileutil"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/spf13/cobra"
@@ -57,7 +58,10 @@ directory is already personal.`,
 		case fileExists(legacyPath):
 			// Migrate from legacy .rimba.toml → .rimba/ directory
 			if err := os.MkdirAll(dirPath, 0750); err != nil {
-				return fmt.Errorf("failed to create config directory: %w", err)
+				return errhint.WithFix(
+					fmt.Errorf("failed to create config directory: %w", err),
+					"check directory permissions for .rimba/ in the repo root",
+				)
 			}
 
 			if err := os.Rename(legacyPath, filepath.Join(dirPath, config.TeamFile)); err != nil {
@@ -101,7 +105,10 @@ directory is already personal.`,
 			}
 
 			if err := os.MkdirAll(dirPath, 0750); err != nil {
-				return fmt.Errorf("failed to create config directory: %w", err)
+				return errhint.WithFix(
+					fmt.Errorf("failed to create config directory: %w", err),
+					"check directory permissions for .rimba/ in the repo root",
+				)
 			}
 
 			if err := config.Save(filepath.Join(dirPath, config.TeamFile), cfg); err != nil {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/hint"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/spinner"
@@ -52,6 +53,9 @@ var removeCmd = &cobra.Command{
 			s.Update(msg)
 		})
 		if err != nil {
+			if !force {
+				return errhint.WithFix(err, "commit or stash changes, or use --force to discard")
+			}
 			return err
 		}
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/hint"
 	"github.com/lugassawan/rimba/internal/operations"
@@ -127,7 +128,10 @@ func syncOne(sc *syncContext, input string, worktrees []resolver.WorktreeInfo, p
 		return err
 	}
 	if dirty {
-		return fmt.Errorf("worktree %q has uncommitted changes\nCommit or stash changes before syncing: cd %s", task, wt.Path)
+		return errhint.WithFix(
+			fmt.Errorf("worktree %q has uncommitted changes", task),
+			"Commit or stash changes before syncing: cd "+wt.Path,
+		)
 	}
 
 	verb := "Rebasing"
@@ -151,7 +155,10 @@ func syncOne(sc *syncContext, input string, worktrees []resolver.WorktreeInfo, p
 			if useMerge {
 				pushHint = fmt.Sprintf("cd %s && git push", wt.Path)
 			}
-			return fmt.Errorf("push failed for %s: %w\nTo resolve: %s", wt.Branch, pushErr, pushHint)
+			return errhint.WithFix(
+				fmt.Errorf("push failed for %s: %w", wt.Branch, pushErr),
+				pushHint,
+			)
 		}
 		if pushed {
 			fmt.Fprintf(sc.cmd.OutOrStdout(), "Pushed %s to origin\n", wt.Branch)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 
 	toml "github.com/pelletier/go-toml/v2"
+
+	"github.com/lugassawan/rimba/internal/errhint"
 )
 
 // FileName is the legacy config file name used by rimba.
@@ -97,12 +99,18 @@ func DefaultConfig(repoName, defaultBranch string) *Config {
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("config not found: %w (run 'rimba init' first)", err)
+		return nil, errhint.WithFix(
+			fmt.Errorf("config not found: %w", err),
+			"run 'rimba init' to create a default .rimba/settings.toml",
+		)
 	}
 
 	var cfg Config
 	if err := toml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("invalid config: %w", err)
+		return nil, errhint.WithFix(
+			fmt.Errorf("invalid config: %w", err),
+			"fix the TOML syntax in "+path,
+		)
 	}
 	return &cfg, nil
 }
@@ -154,7 +162,10 @@ func LoadDir(dirPath string) (*Config, error) {
 		return nil, fmt.Errorf("failed to read team config: %w", err)
 	}
 	if team == nil {
-		return nil, fmt.Errorf("config not found: %s does not exist (run 'rimba init' first)", filepath.Join(dirPath, TeamFile))
+		return nil, errhint.WithFix(
+			fmt.Errorf("config not found: %s does not exist", filepath.Join(dirPath, TeamFile)),
+			"run 'rimba init' to create a default .rimba/settings.toml",
+		)
 	}
 
 	local, err := loadRaw(filepath.Join(dirPath, LocalFile))
@@ -198,7 +209,10 @@ func loadRaw(path string) (*Config, error) {
 
 	var cfg Config
 	if err := toml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("invalid config %s: %w", filepath.Base(path), err)
+		return nil, errhint.WithFix(
+			fmt.Errorf("invalid config %s: %w", filepath.Base(path), err),
+			"fix the TOML syntax in "+path,
+		)
 	}
 	return &cfg, nil
 }

--- a/internal/deps/manager.go
+++ b/internal/deps/manager.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/debug"
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/parallel"
 	"github.com/lugassawan/rimba/internal/progress"
@@ -197,8 +198,9 @@ func runInstall(worktreePath string, mod Module) error {
 	cmd.Stderr = &buf
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("install %q in %s: %w\n%s\nTo fix: cd %s && %s",
-			mod.Dir, dir, err, strings.TrimSpace(buf.String()), dir, mod.InstallCmd)
+		wrapped := fmt.Errorf("install %q in %s: %w\n%s",
+			mod.Dir, dir, err, strings.TrimSpace(buf.String()))
+		return errhint.WithFix(wrapped, fmt.Sprintf("cd %s && %s", dir, mod.InstallCmd))
 	}
 	return nil
 }

--- a/internal/errhint/errhint.go
+++ b/internal/errhint/errhint.go
@@ -1,0 +1,12 @@
+// Package errhint wraps errors with actionable "To fix:" hints.
+package errhint
+
+import "fmt"
+
+// WithFix wraps err with a "To fix:" hint. Returns nil if err is nil.
+func WithFix(err error, fix string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w\nTo fix: %s", err, fix)
+}

--- a/internal/errhint/errhint_test.go
+++ b/internal/errhint/errhint_test.go
@@ -1,0 +1,83 @@
+package errhint_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/errhint"
+)
+
+var errSentinel = errors.New("sentinel boom")
+
+func TestWithFix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		fix        string
+		wantNil    bool
+		wantSubstr []string
+	}{
+		{
+			name:    "nil error returns nil",
+			err:     nil,
+			fix:     "do the thing",
+			wantNil: true,
+		},
+		{
+			name: "wraps error message with fix hint",
+			err:  errors.New("something failed"),
+			fix:  "run rimba init",
+			wantSubstr: []string{
+				"something failed",
+				"To fix: run rimba init",
+			},
+		},
+		{
+			name: "preserves sentinel for errors.Is",
+			err:  errSentinel,
+			fix:  "retry",
+			wantSubstr: []string{
+				"sentinel boom",
+				"To fix: retry",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := errhint.WithFix(tc.err, tc.fix)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil error, got nil")
+			}
+			msg := got.Error()
+			for _, sub := range tc.wantSubstr {
+				if !strings.Contains(msg, sub) {
+					t.Errorf("error %q missing substring %q", msg, sub)
+				}
+			}
+		})
+	}
+}
+
+func TestWithFixPreservesSentinel(t *testing.T) {
+	t.Parallel()
+
+	wrapped := errhint.WithFix(errSentinel, "try again")
+	if !errors.Is(wrapped, errSentinel) {
+		t.Fatalf("errors.Is failed to match sentinel through wrap: %v", wrapped)
+	}
+	if unwrapped := errors.Unwrap(wrapped); !errors.Is(unwrapped, errSentinel) {
+		t.Fatalf("errors.Unwrap = %v, want %v", unwrapped, errSentinel)
+	}
+}

--- a/internal/operations/add.go
+++ b/internal/operations/add.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/deps"
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/progress"
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -56,10 +57,16 @@ func AddWorktree(r git.Runner, params AddParams, onProgress progress.Func) (AddR
 
 	// Validate
 	if git.BranchExists(r, branch) {
-		return result, fmt.Errorf("branch %q already exists", branch)
+		return result, errhint.WithFix(
+			fmt.Errorf("branch %q already exists", branch),
+			"run 'rimba list' to see existing tasks, or use a different task name",
+		)
 	}
 	if _, err := os.Stat(wtPath); err == nil {
-		return result, fmt.Errorf("worktree path already exists: %s", wtPath)
+		return result, errhint.WithFix(
+			fmt.Errorf("worktree path already exists: %s", wtPath),
+			"run 'rimba list' to see existing tasks, or use a different task name",
+		)
 	}
 
 	// Create worktree

--- a/internal/operations/merge.go
+++ b/internal/operations/merge.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/progress"
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -87,7 +88,10 @@ func MergeWorktree(r git.Runner, params MergeParams, onProgress progress.Func) (
 	// Execute merge
 	progress.Notify(onProgress, "Merging...")
 	if err := git.Merge(r, targetDir, source.Branch, params.NoFF); err != nil {
-		return result, fmt.Errorf("merge failed: %w\nTo resolve conflicts: cd %s", err, targetDir)
+		return result, errhint.WithFix(
+			fmt.Errorf("merge failed: %w", err),
+			fmt.Sprintf("resolve conflicts in %s, commit, then re-run rimba merge", targetDir),
+		)
 	}
 
 	// Auto-cleanup
@@ -125,7 +129,10 @@ func checkDirty(r git.Runner, sourcePath, targetDir, sourceTask, intoTask string
 		return srcCheck.err
 	}
 	if srcCheck.dirty {
-		return fmt.Errorf("source worktree %q has uncommitted changes\nCommit or stash changes before merging: cd %s", sourceTask, sourcePath)
+		return errhint.WithFix(
+			fmt.Errorf("source worktree %q has uncommitted changes", sourceTask),
+			"Commit or stash changes before merging: cd "+sourcePath,
+		)
 	}
 	if tgtCheck.err != nil {
 		return tgtCheck.err
@@ -135,7 +142,10 @@ func checkDirty(r git.Runner, sourcePath, targetDir, sourceTask, intoTask string
 		if !mergingToMain {
 			label = intoTask
 		}
-		return fmt.Errorf("target %q has uncommitted changes\nCommit or stash changes before merging: cd %s", label, targetDir)
+		return errhint.WithFix(
+			fmt.Errorf("target %q has uncommitted changes", label),
+			"Commit or stash changes before merging: cd "+targetDir,
+		)
 	}
 	return nil
 }

--- a/internal/operations/remove.go
+++ b/internal/operations/remove.go
@@ -3,6 +3,7 @@ package operations
 import (
 	"fmt"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/progress"
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -35,7 +36,10 @@ func RemoveWorktree(r git.Runner, wt resolver.WorktreeInfo, task string, keepBra
 	if !keepBranch {
 		progress.Notify(onProgress, "Deleting branch...")
 		if err := git.DeleteBranch(r, wt.Branch, true); err != nil {
-			result.BranchError = fmt.Errorf("worktree removed but failed to delete branch: %w\nTo delete manually: git branch -D %s", err, wt.Branch)
+			result.BranchError = errhint.WithFix(
+				fmt.Errorf("worktree removed but failed to delete branch: %w", err),
+				"delete manually: git branch -D "+wt.Branch,
+			)
 			return result, nil
 		}
 		result.BranchDeleted = true


### PR DESCRIPTION
## Summary
- New internal/errhint package with WithFix helper for "To fix: <hint>" error wrapping
- Migrates internal/deps/manager.go to use the helper (single source of truth)
- Applies actionable hints to ~11 user-facing error sites across cmd/*.go, internal/config, and internal/operations

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New errhint unit tests cover nil, formatting, errors.Is preservation
- [x] Manual: triggering wrapped errors shows the "To fix:" line

N/A