### PR TITLE
[fix] Use PureTaskFromBranch for monorepo-aware task display

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -214,7 +214,7 @@ func printMergedCandidates(cmd *cobra.Command, candidates []operations.CleanCand
 	prefixes := resolver.AllPrefixes()
 	fmt.Fprintln(cmd.OutOrStdout(), "Merged worktrees:")
 	for _, c := range candidates {
-		task, _ := resolver.TaskFromBranch(c.Branch, prefixes)
+		task, _ := resolver.PureTaskFromBranch(c.Branch, prefixes)
 		fmt.Fprintf(cmd.OutOrStdout(), "  %s (%s)\n", task, c.Branch)
 	}
 }
@@ -223,7 +223,7 @@ func printStaleCandidates(cmd *cobra.Command, candidates []operations.StaleCandi
 	prefixes := resolver.AllPrefixes()
 	fmt.Fprintln(cmd.OutOrStdout(), "Stale worktrees:")
 	for _, c := range candidates {
-		task, _ := resolver.TaskFromBranch(c.Branch, prefixes)
+		task, _ := resolver.PureTaskFromBranch(c.Branch, prefixes)
 		age := resolver.FormatAge(c.LastCommit)
 		fmt.Fprintf(cmd.OutOrStdout(), "  %s (%s) — last commit: %s\n", task, c.Branch, age)
 	}

--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -25,7 +25,7 @@ func completeWorktreeTasks(_ *cobra.Command, toComplete string) []string {
 		if e.Bare || e.Branch == "" {
 			continue
 		}
-		task, _ := resolver.TaskFromBranch(e.Branch, prefixes)
+		task, _ := resolver.PureTaskFromBranch(e.Branch, prefixes)
 		if strings.HasPrefix(task, toComplete) {
 			tasks = append(tasks, task)
 		}
@@ -64,7 +64,7 @@ func completeArchivedTasks(_ *cobra.Command, toComplete string) []string {
 	prefixes := resolver.AllPrefixes()
 	var tasks []string
 	for _, b := range archived {
-		task, _ := resolver.TaskFromBranch(b, prefixes)
+		task, _ := resolver.PureTaskFromBranch(b, prefixes)
 		if strings.HasPrefix(task, toComplete) {
 			tasks = append(tasks, task)
 		}

--- a/cmd/conflict_check.go
+++ b/cmd/conflict_check.go
@@ -140,7 +140,7 @@ func renderOverlapTable(cmd *cobra.Command, p *termcolor.Painter, result *confli
 	for _, o := range result.Overlaps {
 		branchLabels := make([]string, len(o.Branches))
 		for i, b := range o.Branches {
-			task, prefix := resolver.TaskFromBranch(b, prefixes)
+			task, prefix := resolver.PureTaskFromBranch(b, prefixes)
 			if prefix != "" {
 				branchLabels[i] = task
 			} else {
@@ -189,8 +189,8 @@ func renderDryMergeResults(cmd *cobra.Command, p *termcolor.Painter, results []c
 	)
 
 	for _, r := range conflicting {
-		task1, _ := resolver.TaskFromBranch(r.Branch1, prefixes)
-		task2, _ := resolver.TaskFromBranch(r.Branch2, prefixes)
+		task1, _ := resolver.PureTaskFromBranch(r.Branch1, prefixes)
+		task2, _ := resolver.PureTaskFromBranch(r.Branch2, prefixes)
 		files := p.Paint(strings.Join(r.ConflictFiles, ", "), termcolor.Red)
 		tbl.AddRow(task1, task2, files)
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -155,7 +155,7 @@ func execSelectWorktrees(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, o
 func execBuildTargets(filtered []resolver.WorktreeInfo, prefixes []string) []executor.Target {
 	targets := make([]executor.Target, len(filtered))
 	for i, wt := range filtered {
-		task, _ := resolver.TaskFromBranch(wt.Branch, prefixes)
+		task, _ := resolver.PureTaskFromBranch(wt.Branch, prefixes)
 		targets[i] = executor.Target{
 			Path:   wt.Path,
 			Branch: wt.Branch,
@@ -260,7 +260,7 @@ func filterDirtyWorktrees(r git.Runner, s *spinner.Spinner, worktrees []resolver
 func printExecResults(cmd *cobra.Command, p *termcolor.Painter, results []executor.Result, prefixes []string) {
 	out := cmd.OutOrStdout()
 	for _, r := range results {
-		_, matchedPrefix := resolver.TaskFromBranch(r.Target.Branch, prefixes)
+		_, matchedPrefix := resolver.PureTaskFromBranch(r.Target.Branch, prefixes)
 		typeName := strings.TrimSuffix(matchedPrefix, "/")
 
 		taskLabel := r.Target.Task

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -319,7 +319,7 @@ func listArchivedBranches(cmd *cobra.Command, r git.Runner, mainBranch string) e
 	if isJSON(cmd) {
 		items := make([]output.ListArchivedItem, 0, len(archived))
 		for _, b := range archived {
-			task, matchedPrefix := resolver.TaskFromBranch(b, prefixes)
+			task, matchedPrefix := resolver.PureTaskFromBranch(b, prefixes)
 			typeName := strings.TrimSuffix(matchedPrefix, "/")
 			items = append(items, output.ListArchivedItem{Task: task, Type: typeName, Branch: b})
 		}
@@ -342,7 +342,7 @@ func listArchivedBranches(cmd *cobra.Command, r git.Runner, mainBranch string) e
 	)
 
 	for _, b := range archived {
-		task, matchedPrefix := resolver.TaskFromBranch(b, prefixes)
+		task, matchedPrefix := resolver.PureTaskFromBranch(b, prefixes)
 		typeName := strings.TrimSuffix(matchedPrefix, "/")
 
 		typeCell := typeName

--- a/cmd/merge_plan.go
+++ b/cmd/merge_plan.go
@@ -68,7 +68,7 @@ var mergePlanCmd = &cobra.Command{
 		)
 
 		for _, step := range steps {
-			task, prefix := resolver.TaskFromBranch(step.Branch, prefixes)
+			task, prefix := resolver.PureTaskFromBranch(step.Branch, prefixes)
 			typeName := strings.TrimSuffix(prefix, "/")
 
 			branchCell := task

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -183,7 +183,7 @@ func buildCLIStatusSummary(results []statusEntry, staleThreshold time.Time) cliS
 
 // buildStatusRow formats a single worktree row for the status table.
 func buildStatusRow(r statusEntry, prefixes []string, staleThreshold time.Time, p *termcolor.Painter) []string {
-	task, matchedPrefix := resolver.TaskFromBranch(r.entry.Branch, prefixes)
+	task, matchedPrefix := resolver.PureTaskFromBranch(r.entry.Branch, prefixes)
 	typeName := strings.TrimSuffix(matchedPrefix, "/")
 
 	taskCell := "  " + task
@@ -224,7 +224,7 @@ func writeStatusJSON(cmd *cobra.Command, results []statusEntry, staleDays int) e
 			summary.Behind++
 		}
 
-		task, matchedPrefix := resolver.TaskFromBranch(r.entry.Branch, prefixes)
+		task, matchedPrefix := resolver.PureTaskFromBranch(r.entry.Branch, prefixes)
 		typeName := strings.TrimSuffix(matchedPrefix, "/")
 
 		item := output.StatusItem{

--- a/internal/mcp/tool_exec.go
+++ b/internal/mcp/tool_exec.go
@@ -114,7 +114,7 @@ func runExecCommand(ctx context.Context, command string, filtered []resolver.Wor
 
 	targets := make([]executor.Target, len(filtered))
 	for i, wt := range filtered {
-		task, _ := resolver.TaskFromBranch(wt.Branch, prefixes)
+		task, _ := resolver.PureTaskFromBranch(wt.Branch, prefixes)
 		targets[i] = executor.Target{
 			Path:   wt.Path,
 			Branch: wt.Branch,

--- a/internal/mcp/tool_list.go
+++ b/internal/mcp/tool_list.go
@@ -146,7 +146,7 @@ func handleListArchived(r git.Runner, hctx *HandlerContext) (*mcp.CallToolResult
 	prefixes := resolver.AllPrefixes()
 	items := make([]listArchivedItem, 0, len(archived))
 	for _, b := range archived {
-		task, matchedPrefix := resolver.TaskFromBranch(b, prefixes)
+		task, matchedPrefix := resolver.PureTaskFromBranch(b, prefixes)
 		typeName := strings.TrimSuffix(matchedPrefix, "/")
 		items = append(items, listArchivedItem{Task: task, Type: typeName, Branch: b})
 	}

--- a/internal/mcp/tool_status.go
+++ b/internal/mcp/tool_status.go
@@ -107,7 +107,7 @@ func buildStatusResult(results []statusCollectedEntry, staleThreshold time.Time,
 
 // buildStatusItem constructs a statusItem from a collected entry.
 func buildStatusItem(r statusCollectedEntry, staleThreshold time.Time, prefixes []string) statusItem {
-	task, matchedPrefix := resolver.TaskFromBranch(r.entry.Branch, prefixes)
+	task, matchedPrefix := resolver.PureTaskFromBranch(r.entry.Branch, prefixes)
 	typeName := strings.TrimSuffix(matchedPrefix, "/")
 
 	item := statusItem{

--- a/internal/operations/archived.go
+++ b/internal/operations/archived.go
@@ -88,7 +88,7 @@ func searchByTaskExtraction(branches []string, active map[string]bool, prefixes 
 		if active[b] {
 			continue
 		}
-		t, _ := resolver.TaskFromBranch(b, prefixes)
+		t, _ := resolver.PureTaskFromBranch(b, prefixes)
 		if t == task {
 			return b, true
 		}

--- a/internal/operations/sync.go
+++ b/internal/operations/sync.go
@@ -55,7 +55,7 @@ func PushBranch(r git.Runner, dir string, useMerge bool) (bool, bool, error) {
 func CollectTasks(worktrees []resolver.WorktreeInfo, prefixes []string) []string {
 	tasks := make([]string, 0, len(worktrees))
 	for _, wt := range worktrees {
-		task, _ := resolver.TaskFromBranch(wt.Branch, prefixes)
+		task, _ := resolver.PureTaskFromBranch(wt.Branch, prefixes)
 		tasks = append(tasks, task)
 	}
 	return tasks
@@ -69,7 +69,7 @@ func FilterEligible(worktrees []resolver.WorktreeInfo, prefixes []string, mainBr
 		if wt.Branch == mainBranch || wt.Branch == "" {
 			continue
 		}
-		task, _ := resolver.TaskFromBranch(wt.Branch, prefixes)
+		task, _ := resolver.PureTaskFromBranch(wt.Branch, prefixes)
 		if !includeInherited && resolver.IsInherited(task, allTasks) {
 			continue
 		}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -79,10 +79,12 @@ func TaskFromBranch(branch string, prefixes []string) (task, matchedPrefix strin
 	return branch, ""
 }
 
-// PureTaskFromBranch returns the display-friendly task name, stripping both
-// the service component (monorepo) and the prefix (feature/, bugfix/, …).
-// Matches the Task field produced by NewWorktreeDetail. Signature mirrors
-// TaskFromBranch so callers can swap in place when they want display output.
+// PureTaskFromBranch extracts the task name from a branch, stripping both
+// the service (monorepo) and the prefix.
+// "auth-api/feature/login" → ("login", "feature/")
+// "feature/my-task"        → ("my-task", "feature/")
+// "bare-branch"            → ("bare-branch", "")
+// Return signature matches TaskFromBranch so callers can swap in place.
 func PureTaskFromBranch(branch string, prefixes []string) (task, matchedPrefix string) {
 	_, t, p := ServiceFromBranch(branch, prefixes)
 	return t, p

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -79,6 +79,15 @@ func TaskFromBranch(branch string, prefixes []string) (task, matchedPrefix strin
 	return branch, ""
 }
 
+// PureTaskFromBranch returns the display-friendly task name, stripping both
+// the service component (monorepo) and the prefix (feature/, bugfix/, …).
+// Matches the Task field produced by NewWorktreeDetail. Signature mirrors
+// TaskFromBranch so callers can swap in place when they want display output.
+func PureTaskFromBranch(branch string, prefixes []string) (task, matchedPrefix string) {
+	_, t, p := ServiceFromBranch(branch, prefixes)
+	return t, p
+}
+
 // WorktreeInfo holds parsed information about a worktree.
 type WorktreeInfo struct {
 	Path    string

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -94,6 +94,34 @@ func TestTaskFromBranch(t *testing.T) {
 	}
 }
 
+func TestPureTaskFromBranch(t *testing.T) {
+	prefixes := resolver.AllPrefixes()
+
+	const svcAuthAPI = "auth-api"
+
+	tests := []struct {
+		branch     string
+		wantTask   string
+		wantPrefix string
+	}{
+		{featurePrefix + taskMyTask, taskMyTask, featurePrefix},
+		{bugfixPrefix + taskLoginFix, taskLoginFix, bugfixPrefix},
+		{svcAuthAPI + "/" + featurePrefix + taskLogin, taskLogin, featurePrefix},
+		{svcAuthAPI + "/" + bugfixPrefix + taskCrash, taskCrash, bugfixPrefix},
+		{taskBare, taskBare, ""},
+		{"unknown/prefix", "unknown/prefix", ""},
+	}
+	for _, tt := range tests {
+		task, matched := resolver.PureTaskFromBranch(tt.branch, prefixes)
+		if task != tt.wantTask {
+			t.Errorf("PureTaskFromBranch(%q) task = %q, want %q", tt.branch, task, tt.wantTask)
+		}
+		if matched != tt.wantPrefix {
+			t.Errorf("PureTaskFromBranch(%q) prefix = %q, want %q", tt.branch, matched, tt.wantPrefix)
+		}
+	}
+}
+
 func TestFindBranchForTask(t *testing.T) {
 	worktrees := []resolver.WorktreeInfo{
 		{Path: "/wt/feature-login", Branch: featurePrefix + taskLogin},


### PR DESCRIPTION
## Summary
- Add `resolver.PureTaskFromBranch` — a display-oriented helper that composes `ServiceFromBranch` to strip both the monorepo service component and the prefix, preserving the `(task, matchedPrefix)` signature of `TaskFromBranch` for drop-in replacement.
- Migrate 20 display call sites across `cmd/` (status, clean, completions, merge_plan, exec, conflict_check, list), `internal/mcp/` (tool_status, tool_exec, tool_list), and `internal/operations/` (sync, archived) so every user-facing command reports the same pure task name that `rimba list` already shows.
- Leave four classification sites on `TaskFromBranch` (they use only `matchedPrefix` for type-filter logic): `cmd/list.go:185`, `cmd/list_bench_test.go:105`, `internal/mcp/tool_list.go:118`, `internal/operations/operations.go:71`. The type-filter gap for service-prefixed branches is called out as an out-of-scope follow-up in the issue.

Before: `rimba status` on branch `auth-api/feature/login` shows `auth-api/feature/login` in the TASK column.
After: it shows `login`, matching `rimba list`.

## Test Plan
- [x] Unit tests pass (`make test`) — 1404/1404, includes new `TestPureTaskFromBranch` covering monorepo (`auth-api/feature/login` → `("login", "feature/")`), standard, bare, and unknown-prefix cases.
- [x] Linter passes (`make lint`) — 0 issues.
- [x] Monorepo smoke check: created `auth-api/feature/login` in a scratch rimba-initialized repo; verified `rimba status`, `rimba status --json` (`.data.worktrees[].task == "login"`), `rimba exec --all 'echo hi'`, and `rimba clean --dry-run` all display `login`.

Closes #120
