### PR TITLE
[feat] Add --detail flag to rimba status for disk usage and velocity

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	flagDebug        = "debug"
+	flagDetail       = "detail"
 	flagForce        = "force"
 	flagJSON         = "json"
 	flagNoColor      = "no-color"

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/lugassawan/rimba/internal/fsutil"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
@@ -17,11 +20,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const recentWindow = 7 * 24 * time.Hour
+
 type statusEntry struct {
 	entry      git.WorktreeEntry
 	status     resolver.WorktreeStatus
 	commitTime time.Time
 	hasTime    bool
+	sizeBytes  *int64
+	recent7D   *int
+}
+
+// diskFootprint captures sizes used for the Disk: summary line and JSON
+// DiskSummary. mainErr is non-nil when main-repo size could not be computed;
+// in that case MainBytes is treated as absent in the CLI summary line.
+type diskFootprint struct {
+	mainBytes      int64
+	mainErr        error
+	worktreesBytes int64
+	total          int64
 }
 
 var statusCmd = &cobra.Command{
@@ -42,9 +59,11 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
+		mainEntry := findMainEntry(entries, mainBranch)
 		candidates := git.FilterEntries(entries, mainBranch)
 
 		staleDays, _ := cmd.Flags().GetInt(flagStaleDays)
+		detail, _ := cmd.Flags().GetBool(flagDetail)
 
 		if len(candidates) == 0 {
 			if isJSON(cmd) {
@@ -62,28 +81,61 @@ var statusCmd = &cobra.Command{
 		defer s.Stop()
 		s.Start("Collecting worktree status...")
 
-		results := collectStatuses(r, candidates, s)
+		var mainSize int64
+		var mainErr error
+		var mainWG sync.WaitGroup
+		if detail && mainEntry != nil {
+			mainWG.Add(1)
+			go func(path string) {
+				defer mainWG.Done()
+				mainSize, mainErr = fsutil.DirSize(path)
+			}(mainEntry.Path)
+		}
+
+		results := collectStatuses(r, candidates, s, detail)
+		mainWG.Wait()
 		s.Stop()
 
+		var footprint *diskFootprint
+		if detail {
+			footprint = buildFootprint(results, mainEntry, mainSize, mainErr)
+			sortBySizeDesc(results)
+		}
+
 		if isJSON(cmd) {
-			return writeStatusJSON(cmd, results, staleDays)
+			return writeStatusJSON(cmd, results, staleDays, footprint)
 		}
 
 		noColor, _ := cmd.Flags().GetBool(flagNoColor)
 		p := termcolor.NewPainter(noColor)
 
-		renderStatusDashboard(cmd.OutOrStdout(), p, results, staleDays)
+		renderStatusDashboard(cmd.OutOrStdout(), p, results, staleDays, detail, footprint)
 		return nil
 	},
 }
 
 func init() {
 	statusCmd.Flags().Int(flagStaleDays, defaultStaleDays, "Number of days after which a worktree is considered stale")
+	statusCmd.Flags().Bool(flagDetail, false, "Show per-worktree disk size and 7-day commit velocity")
 	rootCmd.AddCommand(statusCmd)
 }
 
+// findMainEntry returns the unfiltered worktree entry matching mainBranch,
+// or nil if not present. Used to compute the main-repo footprint since
+// FilterEntries strips it from the candidate set.
+func findMainEntry(entries []git.WorktreeEntry, mainBranch string) *git.WorktreeEntry {
+	for i := range entries {
+		if entries[i].Branch == mainBranch {
+			return &entries[i]
+		}
+	}
+	return nil
+}
+
 // collectStatuses gathers dirty/ahead/behind state and last commit time for each candidate.
-func collectStatuses(r git.Runner, candidates []git.WorktreeEntry, s *spinner.Spinner) []statusEntry {
+// When detail is true, it also computes per-worktree disk size and 7-day commit count;
+// per-item errors leave the corresponding pointer nil (non-fatal).
+func collectStatuses(r git.Runner, candidates []git.WorktreeEntry, s *spinner.Spinner, detail bool) []statusEntry {
 	s.Update("Collecting status...")
 	return parallel.Collect(len(candidates), 8, func(i int) statusEntry {
 		e := candidates[i]
@@ -94,38 +146,106 @@ func collectStatuses(r git.Runner, candidates []git.WorktreeEntry, s *spinner.Sp
 			ct = t
 			hasTime = true
 		}
-		return statusEntry{entry: e, status: st, commitTime: ct, hasTime: hasTime}
+		se := statusEntry{entry: e, status: st, commitTime: ct, hasTime: hasTime}
+		if detail {
+			if n, err := fsutil.DirSize(e.Path); err == nil {
+				se.sizeBytes = &n
+			}
+			if c, err := git.CommitCountSince(r, e.Branch, recentWindow); err == nil {
+				se.recent7D = &c
+			}
+		}
+		return se
+	})
+}
+
+// buildFootprint aggregates per-worktree sizes + main-repo size into a
+// diskFootprint. Order-independent: only entries with non-nil sizeBytes
+// contribute.
+func buildFootprint(results []statusEntry, mainEntry *git.WorktreeEntry, mainSize int64, mainErr error) *diskFootprint {
+	fp := &diskFootprint{}
+	if mainEntry != nil && mainErr == nil {
+		fp.mainBytes = mainSize
+	}
+	fp.mainErr = mainErr
+	for _, r := range results {
+		if r.sizeBytes != nil {
+			fp.worktreesBytes += *r.sizeBytes
+		}
+	}
+	fp.total = fp.mainBytes + fp.worktreesBytes
+	return fp
+}
+
+// sortBySizeDesc sorts results by size (nil sizes sort last, preserving
+// input order among equal values).
+func sortBySizeDesc(results []statusEntry) {
+	sort.SliceStable(results, func(i, j int) bool {
+		a, b := results[i].sizeBytes, results[j].sizeBytes
+		switch {
+		case a == nil && b == nil:
+			return false
+		case a == nil:
+			return false
+		case b == nil:
+			return true
+		default:
+			return *a > *b
+		}
 	})
 }
 
 // renderStatusDashboard prints the summary header and per-worktree table.
-func renderStatusDashboard(out io.Writer, p *termcolor.Painter, results []statusEntry, staleDays int) {
+func renderStatusDashboard(out io.Writer, p *termcolor.Painter, results []statusEntry, staleDays int, detail bool, footprint *diskFootprint) {
 	staleThreshold := time.Now().Add(-time.Duration(staleDays) * 24 * time.Hour)
 	summary := buildCLIStatusSummary(results, staleThreshold)
 	prefixes := resolver.AllPrefixes()
 
-	fmt.Fprintf(out, "Worktrees: %s  Dirty: %s  Stale: %s  Behind: %s\n\n",
+	fmt.Fprintf(out, "Worktrees: %s  Dirty: %s  Stale: %s  Behind: %s\n",
 		p.Paint(strconv.Itoa(summary.total), termcolor.Bold),
 		colorCount(p, summary.dirty, termcolor.Yellow),
 		colorCount(p, summary.stale, termcolor.Red),
 		colorCount(p, summary.behind, termcolor.Red),
 	)
+	if detail && footprint != nil {
+		fmt.Fprintln(out, formatDiskLine(p, footprint))
+	}
+	fmt.Fprintln(out)
 
 	tbl := termcolor.NewTable(2)
-	tbl.AddRow(
+	header := []string{
 		p.Paint("TASK", termcolor.Bold),
 		p.Paint("TYPE", termcolor.Bold),
 		p.Paint("BRANCH", termcolor.Bold),
 		p.Paint("STATUS", termcolor.Bold),
 		p.Paint("AGE", termcolor.Bold),
-	)
+	}
+	if detail {
+		header = append(header,
+			p.Paint("SIZE", termcolor.Bold),
+			p.Paint("7D", termcolor.Bold),
+		)
+	}
+	tbl.AddRow(header...)
 
 	for _, r := range results {
-		tbl.AddRow(buildStatusRow(r, prefixes, staleThreshold, p)...)
+		tbl.AddRow(buildStatusRow(r, prefixes, staleThreshold, p, detail)...)
 	}
 
 	tbl.Render(out)
 	renderActionHints(out, p, summary)
+}
+
+// formatDiskLine builds the "Disk: total X  (main: Y, worktrees: Z)" summary.
+// When main-size computation failed, the "main:" fragment is omitted.
+func formatDiskLine(p *termcolor.Painter, fp *diskFootprint) string {
+	total := p.Paint(resolver.FormatBytes(fp.total), termcolor.Bold)
+	worktrees := resolver.FormatBytes(fp.worktreesBytes)
+	if fp.mainErr != nil {
+		return fmt.Sprintf("Disk: total %s  (worktrees: %s)", total, worktrees)
+	}
+	main := resolver.FormatBytes(fp.mainBytes)
+	return fmt.Sprintf("Disk: total %s  (main: %s, worktrees: %s)", total, main, worktrees)
 }
 
 // renderActionHints prints one-line next-step suggestions derived from the
@@ -182,7 +302,7 @@ func buildCLIStatusSummary(results []statusEntry, staleThreshold time.Time) cliS
 }
 
 // buildStatusRow formats a single worktree row for the status table.
-func buildStatusRow(r statusEntry, prefixes []string, staleThreshold time.Time, p *termcolor.Painter) []string {
+func buildStatusRow(r statusEntry, prefixes []string, staleThreshold time.Time, p *termcolor.Painter, detail bool) []string {
 	task, matchedPrefix := resolver.PureTaskFromBranch(r.entry.Branch, prefixes)
 	typeName := strings.TrimSuffix(matchedPrefix, "/")
 
@@ -192,7 +312,27 @@ func buildStatusRow(r statusEntry, prefixes []string, staleThreshold time.Time, 
 		typeCell = p.Paint(typeCell, c)
 	}
 
-	return []string{taskCell, typeCell, r.entry.Branch, colorStatus(p, r.status), formatAgeCell(r, staleThreshold, p)}
+	row := []string{taskCell, typeCell, r.entry.Branch, colorStatus(p, r.status), formatAgeCell(r, staleThreshold, p)}
+	if detail {
+		row = append(row, formatSizeCell(r, p), formatRecentCell(r, p))
+	}
+	return row
+}
+
+// formatSizeCell renders the SIZE column. Errors render as "?" in gray.
+func formatSizeCell(r statusEntry, p *termcolor.Painter) string {
+	if r.sizeBytes == nil {
+		return p.Paint("?", termcolor.Gray)
+	}
+	return resolver.FormatBytes(*r.sizeBytes)
+}
+
+// formatRecentCell renders the 7D column. Errors render as "?" in gray.
+func formatRecentCell(r statusEntry, p *termcolor.Painter) string {
+	if r.recent7D == nil {
+		return p.Paint("?", termcolor.Gray)
+	}
+	return strconv.Itoa(*r.recent7D)
 }
 
 // formatAgeCell formats the age cell with color and stale indicator.
@@ -208,7 +348,7 @@ func formatAgeCell(r statusEntry, staleThreshold time.Time, p *termcolor.Painter
 }
 
 // writeStatusJSON builds the JSON output for the status command.
-func writeStatusJSON(cmd *cobra.Command, results []statusEntry, staleDays int) error {
+func writeStatusJSON(cmd *cobra.Command, results []statusEntry, staleDays int, footprint *diskFootprint) error {
 	staleThreshold := time.Now().Add(-time.Duration(staleDays) * 24 * time.Hour)
 	prefixes := resolver.AllPrefixes()
 
@@ -228,10 +368,12 @@ func writeStatusJSON(cmd *cobra.Command, results []statusEntry, staleDays int) e
 		typeName := strings.TrimSuffix(matchedPrefix, "/")
 
 		item := output.StatusItem{
-			Task:   task,
-			Type:   typeName,
-			Branch: r.entry.Branch,
-			Status: r.status,
+			Task:      task,
+			Type:      typeName,
+			Branch:    r.entry.Branch,
+			Status:    r.status,
+			SizeBytes: r.sizeBytes,
+			Recent7D:  r.recent7D,
 		}
 
 		if r.hasTime {
@@ -252,6 +394,17 @@ func writeStatusJSON(cmd *cobra.Command, results []statusEntry, staleDays int) e
 		Summary:   summary,
 		Worktrees: items,
 		StaleDays: staleDays,
+	}
+	if footprint != nil {
+		disk := &output.DiskSummary{
+			TotalBytes:     footprint.total,
+			WorktreesBytes: footprint.worktreesBytes,
+		}
+		if footprint.mainErr == nil {
+			main := footprint.mainBytes
+			disk.MainBytes = &main
+		}
+		data.Disk = disk
 	}
 	return output.WriteJSON(cmd.OutOrStdout(), version, "status", data)
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -31,16 +31,6 @@ type statusEntry struct {
 	recent7D   *int
 }
 
-// diskFootprint aggregates sizes for the Disk: summary line and JSON.
-// mainErr != nil means main-repo size was not computed; the CLI drops
-// the main: fragment and JSON omits MainBytes.
-type diskFootprint struct {
-	mainBytes      int64
-	mainErr        error
-	worktreesBytes int64
-	total          int64
-}
-
 var statusCmd = &cobra.Command{
 	Use:         "status",
 	Short:       "Show worktree dashboard with summary stats and age info",
@@ -96,9 +86,14 @@ var statusCmd = &cobra.Command{
 		mainWG.Wait()
 		s.Stop()
 
-		var footprint *diskFootprint
+		var footprint *operations.DiskFootprint
 		if detail {
-			footprint = buildFootprint(results, mainEntry, mainSize, mainErr)
+			sizes := make([]*int64, len(results))
+			for i, r := range results {
+				sizes[i] = r.sizeBytes
+			}
+			fp := operations.BuildDiskFootprint(sizes, mainSize, mainErr)
+			footprint = &fp
 			sortBySizeDesc(results)
 		}
 
@@ -158,23 +153,6 @@ func collectStatuses(r git.Runner, candidates []git.WorktreeEntry, s *spinner.Sp
 	})
 }
 
-// buildFootprint sums per-worktree sizes and the main-repo size.
-// Entries with nil sizeBytes (errored) are skipped.
-func buildFootprint(results []statusEntry, mainEntry *git.WorktreeEntry, mainSize int64, mainErr error) *diskFootprint {
-	fp := &diskFootprint{}
-	if mainEntry != nil && mainErr == nil {
-		fp.mainBytes = mainSize
-	}
-	fp.mainErr = mainErr
-	for _, r := range results {
-		if r.sizeBytes != nil {
-			fp.worktreesBytes += *r.sizeBytes
-		}
-	}
-	fp.total = fp.mainBytes + fp.worktreesBytes
-	return fp
-}
-
 // sortBySizeDesc sorts largest first, stable, nils last.
 func sortBySizeDesc(results []statusEntry) {
 	sort.SliceStable(results, func(i, j int) bool {
@@ -193,7 +171,7 @@ func sortBySizeDesc(results []statusEntry) {
 }
 
 // renderStatusDashboard prints the summary header and per-worktree table.
-func renderStatusDashboard(out io.Writer, p *termcolor.Painter, results []statusEntry, staleDays int, detail bool, footprint *diskFootprint) {
+func renderStatusDashboard(out io.Writer, p *termcolor.Painter, results []statusEntry, staleDays int, detail bool, footprint *operations.DiskFootprint) {
 	staleThreshold := time.Now().Add(-time.Duration(staleDays) * 24 * time.Hour)
 	summary := buildCLIStatusSummary(results, staleThreshold)
 	prefixes := resolver.AllPrefixes()
@@ -235,13 +213,13 @@ func renderStatusDashboard(out io.Writer, p *termcolor.Painter, results []status
 
 // formatDiskLine builds the "Disk: total X  (main: Y, worktrees: Z)"
 // summary. The main: fragment is dropped when main-size errored.
-func formatDiskLine(p *termcolor.Painter, fp *diskFootprint) string {
-	total := p.Paint(resolver.FormatBytes(fp.total), termcolor.Bold)
-	worktrees := resolver.FormatBytes(fp.worktreesBytes)
-	if fp.mainErr != nil {
+func formatDiskLine(p *termcolor.Painter, fp *operations.DiskFootprint) string {
+	total := p.Paint(resolver.FormatBytes(fp.TotalBytes), termcolor.Bold)
+	worktrees := resolver.FormatBytes(fp.WorktreesBytes)
+	if fp.MainErr != nil {
 		return fmt.Sprintf("Disk: total %s  (worktrees: %s)", total, worktrees)
 	}
-	main := resolver.FormatBytes(fp.mainBytes)
+	main := resolver.FormatBytes(fp.MainBytes)
 	return fmt.Sprintf("Disk: total %s  (main: %s, worktrees: %s)", total, main, worktrees)
 }
 
@@ -345,7 +323,7 @@ func formatAgeCell(r statusEntry, staleThreshold time.Time, p *termcolor.Painter
 }
 
 // writeStatusJSON builds the JSON output for the status command.
-func writeStatusJSON(cmd *cobra.Command, results []statusEntry, staleDays int, footprint *diskFootprint) error {
+func writeStatusJSON(cmd *cobra.Command, results []statusEntry, staleDays int, footprint *operations.DiskFootprint) error {
 	staleThreshold := time.Now().Add(-time.Duration(staleDays) * 24 * time.Hour)
 	prefixes := resolver.AllPrefixes()
 
@@ -394,11 +372,11 @@ func writeStatusJSON(cmd *cobra.Command, results []statusEntry, staleDays int, f
 	}
 	if footprint != nil {
 		disk := &output.DiskSummary{
-			TotalBytes:     footprint.total,
-			WorktreesBytes: footprint.worktreesBytes,
+			TotalBytes:     footprint.TotalBytes,
+			WorktreesBytes: footprint.WorktreesBytes,
 		}
-		if footprint.mainErr == nil {
-			main := footprint.mainBytes
+		if footprint.MainErr == nil {
+			main := footprint.MainBytes
 			disk.MainBytes = &main
 		}
 		data.Disk = disk

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -49,7 +49,7 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
-		mainEntry := findMainEntry(entries, mainBranch)
+		mainEntry := git.FindEntry(entries, mainBranch)
 		candidates := git.FilterEntries(entries, mainBranch)
 
 		staleDays, _ := cmd.Flags().GetInt(flagStaleDays)
@@ -113,17 +113,6 @@ func init() {
 	statusCmd.Flags().Int(flagStaleDays, defaultStaleDays, "Number of days after which a worktree is considered stale")
 	statusCmd.Flags().Bool(flagDetail, false, "Show per-worktree disk size and 7-day commit velocity")
 	rootCmd.AddCommand(statusCmd)
-}
-
-// findMainEntry returns the worktree for mainBranch, or nil if absent.
-// FilterEntries drops main from the candidate set, so we look it up here.
-func findMainEntry(entries []git.WorktreeEntry, mainBranch string) *git.WorktreeEntry {
-	for i := range entries {
-		if entries[i].Branch == mainBranch {
-			return &entries[i]
-		}
-	}
-	return nil
 }
 
 // collectStatuses gathers dirty/ahead/behind state and last commit time

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -31,9 +31,9 @@ type statusEntry struct {
 	recent7D   *int
 }
 
-// diskFootprint captures sizes used for the Disk: summary line and JSON
-// DiskSummary. mainErr is non-nil when main-repo size could not be computed;
-// in that case MainBytes is treated as absent in the CLI summary line.
+// diskFootprint aggregates sizes for the Disk: summary line and JSON.
+// mainErr != nil means main-repo size was not computed; the CLI drops
+// the main: fragment and JSON omits MainBytes.
 type diskFootprint struct {
 	mainBytes      int64
 	mainErr        error
@@ -120,9 +120,8 @@ func init() {
 	rootCmd.AddCommand(statusCmd)
 }
 
-// findMainEntry returns the unfiltered worktree entry matching mainBranch,
-// or nil if not present. Used to compute the main-repo footprint since
-// FilterEntries strips it from the candidate set.
+// findMainEntry returns the worktree for mainBranch, or nil if absent.
+// FilterEntries drops main from the candidate set, so we look it up here.
 func findMainEntry(entries []git.WorktreeEntry, mainBranch string) *git.WorktreeEntry {
 	for i := range entries {
 		if entries[i].Branch == mainBranch {
@@ -132,9 +131,9 @@ func findMainEntry(entries []git.WorktreeEntry, mainBranch string) *git.Worktree
 	return nil
 }
 
-// collectStatuses gathers dirty/ahead/behind state and last commit time for each candidate.
-// When detail is true, it also computes per-worktree disk size and 7-day commit count;
-// per-item errors leave the corresponding pointer nil (non-fatal).
+// collectStatuses gathers dirty/ahead/behind state and last commit time
+// per candidate. Under detail it also computes size and 7-day velocity;
+// per-item errors leave the pointer nil (non-fatal).
 func collectStatuses(r git.Runner, candidates []git.WorktreeEntry, s *spinner.Spinner, detail bool) []statusEntry {
 	s.Update("Collecting status...")
 	return parallel.Collect(len(candidates), 8, func(i int) statusEntry {
@@ -159,9 +158,8 @@ func collectStatuses(r git.Runner, candidates []git.WorktreeEntry, s *spinner.Sp
 	})
 }
 
-// buildFootprint aggregates per-worktree sizes + main-repo size into a
-// diskFootprint. Order-independent: only entries with non-nil sizeBytes
-// contribute.
+// buildFootprint sums per-worktree sizes and the main-repo size.
+// Entries with nil sizeBytes (errored) are skipped.
 func buildFootprint(results []statusEntry, mainEntry *git.WorktreeEntry, mainSize int64, mainErr error) *diskFootprint {
 	fp := &diskFootprint{}
 	if mainEntry != nil && mainErr == nil {
@@ -177,8 +175,7 @@ func buildFootprint(results []statusEntry, mainEntry *git.WorktreeEntry, mainSiz
 	return fp
 }
 
-// sortBySizeDesc sorts results by size (nil sizes sort last, preserving
-// input order among equal values).
+// sortBySizeDesc sorts largest first, stable, nils last.
 func sortBySizeDesc(results []statusEntry) {
 	sort.SliceStable(results, func(i, j int) bool {
 		a, b := results[i].sizeBytes, results[j].sizeBytes
@@ -236,8 +233,8 @@ func renderStatusDashboard(out io.Writer, p *termcolor.Painter, results []status
 	renderActionHints(out, p, summary)
 }
 
-// formatDiskLine builds the "Disk: total X  (main: Y, worktrees: Z)" summary.
-// When main-size computation failed, the "main:" fragment is omitted.
+// formatDiskLine builds the "Disk: total X  (main: Y, worktrees: Z)"
+// summary. The main: fragment is dropped when main-size errored.
 func formatDiskLine(p *termcolor.Painter, fp *diskFootprint) string {
 	total := p.Paint(resolver.FormatBytes(fp.total), termcolor.Bold)
 	worktrees := resolver.FormatBytes(fp.worktreesBytes)
@@ -319,7 +316,7 @@ func buildStatusRow(r statusEntry, prefixes []string, staleThreshold time.Time, 
 	return row
 }
 
-// formatSizeCell renders the SIZE column. Errors render as "?" in gray.
+// formatSizeCell renders the SIZE column. Nil (errored) renders as "?".
 func formatSizeCell(r statusEntry, p *termcolor.Painter) string {
 	if r.sizeBytes == nil {
 		return p.Paint("?", termcolor.Gray)
@@ -327,7 +324,7 @@ func formatSizeCell(r statusEntry, p *termcolor.Painter) string {
 	return resolver.FormatBytes(*r.sizeBytes)
 }
 
-// formatRecentCell renders the 7D column. Errors render as "?" in gray.
+// formatRecentCell renders the 7D column. Nil (errored) renders as "?".
 func formatRecentCell(r statusEntry, p *termcolor.Painter) string {
 	if r.recent7D == nil {
 		return p.Paint("?", termcolor.Gray)

--- a/cmd/status_detail_test.go
+++ b/cmd/status_detail_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
 	"github.com/lugassawan/rimba/internal/termcolor"
 	"github.com/spf13/cobra"
@@ -33,49 +34,6 @@ func TestFindMainEntry(t *testing.T) {
 	}
 	if findMainEntry(nil, "main") != nil {
 		t.Error("findMainEntry on nil entries should return nil")
-	}
-}
-
-func TestBuildFootprint(t *testing.T) {
-	main := &git.WorktreeEntry{Branch: "main", Path: "/repo"}
-	results := []statusEntry{
-		{sizeBytes: ptr(int64(1000))},
-		{sizeBytes: ptr(int64(500))},
-		{sizeBytes: nil}, // errored worktree: excluded from sum
-	}
-
-	fp := buildFootprint(results, main, 10_000, nil)
-	if fp.mainBytes != 10_000 || fp.worktreesBytes != 1500 || fp.total != 11_500 {
-		t.Errorf("fp = %+v, want main=10000 wt=1500 total=11500", fp)
-	}
-	if fp.mainErr != nil {
-		t.Errorf("mainErr = %v, want nil", fp.mainErr)
-	}
-}
-
-func TestBuildFootprintMainError(t *testing.T) {
-	main := &git.WorktreeEntry{Branch: "main", Path: "/repo"}
-	want := errors.New("permission denied")
-	fp := buildFootprint([]statusEntry{{sizeBytes: ptr(int64(200))}}, main, 0, want)
-
-	if fp.mainBytes != 0 {
-		t.Errorf("mainBytes = %d, want 0 when mainErr != nil", fp.mainBytes)
-	}
-	if fp.worktreesBytes != 200 {
-		t.Errorf("worktreesBytes = %d, want 200", fp.worktreesBytes)
-	}
-	if fp.total != 200 {
-		t.Errorf("total = %d, want 200 (excludes errored main)", fp.total)
-	}
-	if !errors.Is(fp.mainErr, want) {
-		t.Errorf("mainErr = %v, want %v", fp.mainErr, want)
-	}
-}
-
-func TestBuildFootprintNoMain(t *testing.T) {
-	fp := buildFootprint([]statusEntry{{sizeBytes: ptr(int64(42))}}, nil, 0, nil)
-	if fp.mainBytes != 0 || fp.total != 42 {
-		t.Errorf("fp = %+v, want main=0 total=42", fp)
 	}
 }
 
@@ -112,14 +70,14 @@ func TestSortBySizeDescAllNil(t *testing.T) {
 func TestFormatDiskLine(t *testing.T) {
 	p := termcolor.NewPainter(true) // no color
 
-	fp := &diskFootprint{mainBytes: 1024 * 1024, worktreesBytes: 2048, total: 1024*1024 + 2048}
+	fp := &operations.DiskFootprint{MainBytes: 1024 * 1024, WorktreesBytes: 2048, TotalBytes: 1024*1024 + 2048}
 	got := formatDiskLine(p, fp)
 	if !strings.Contains(got, "Disk:") || !strings.Contains(got, "main:") || !strings.Contains(got, "worktrees:") {
 		t.Errorf("formatDiskLine = %q, missing required fragments", got)
 	}
 
 	// Error path: main: fragment must be omitted.
-	fpErr := &diskFootprint{mainErr: errors.New("boom"), worktreesBytes: 512, total: 512}
+	fpErr := &operations.DiskFootprint{MainErr: errors.New("boom"), WorktreesBytes: 512, TotalBytes: 512}
 	got = formatDiskLine(p, fpErr)
 	if strings.Contains(got, "main:") {
 		t.Errorf("formatDiskLine on mainErr = %q, expected no 'main:' fragment", got)

--- a/cmd/status_detail_test.go
+++ b/cmd/status_detail_test.go
@@ -19,24 +19,6 @@ import (
 
 func ptr[T any](v T) *T { return &v }
 
-func TestFindMainEntry(t *testing.T) {
-	entries := []git.WorktreeEntry{
-		{Branch: "feature/a", Path: "/wt/a"},
-		{Branch: "main", Path: "/repo"},
-		{Branch: "feature/b", Path: "/wt/b"},
-	}
-	got := findMainEntry(entries, "main")
-	if got == nil || got.Path != "/repo" {
-		t.Errorf("findMainEntry = %+v, want /repo", got)
-	}
-	if findMainEntry(entries, "nope") != nil {
-		t.Error("findMainEntry on missing branch should return nil")
-	}
-	if findMainEntry(nil, "main") != nil {
-		t.Error("findMainEntry on nil entries should return nil")
-	}
-}
-
 func TestSortBySizeDesc(t *testing.T) {
 	results := []statusEntry{
 		{entry: git.WorktreeEntry{Branch: "small"}, sizeBytes: ptr(int64(100))},

--- a/cmd/status_detail_test.go
+++ b/cmd/status_detail_test.go
@@ -1,0 +1,298 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/output"
+	"github.com/lugassawan/rimba/internal/termcolor"
+	"github.com/spf13/cobra"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestFindMainEntry(t *testing.T) {
+	entries := []git.WorktreeEntry{
+		{Branch: "feature/a", Path: "/wt/a"},
+		{Branch: "main", Path: "/repo"},
+		{Branch: "feature/b", Path: "/wt/b"},
+	}
+	got := findMainEntry(entries, "main")
+	if got == nil || got.Path != "/repo" {
+		t.Errorf("findMainEntry = %+v, want /repo", got)
+	}
+	if findMainEntry(entries, "nope") != nil {
+		t.Error("findMainEntry on missing branch should return nil")
+	}
+	if findMainEntry(nil, "main") != nil {
+		t.Error("findMainEntry on nil entries should return nil")
+	}
+}
+
+func TestBuildFootprint(t *testing.T) {
+	main := &git.WorktreeEntry{Branch: "main", Path: "/repo"}
+	results := []statusEntry{
+		{sizeBytes: ptr(int64(1000))},
+		{sizeBytes: ptr(int64(500))},
+		{sizeBytes: nil}, // errored worktree: excluded from sum
+	}
+
+	fp := buildFootprint(results, main, 10_000, nil)
+	if fp.mainBytes != 10_000 || fp.worktreesBytes != 1500 || fp.total != 11_500 {
+		t.Errorf("fp = %+v, want main=10000 wt=1500 total=11500", fp)
+	}
+	if fp.mainErr != nil {
+		t.Errorf("mainErr = %v, want nil", fp.mainErr)
+	}
+}
+
+func TestBuildFootprintMainError(t *testing.T) {
+	main := &git.WorktreeEntry{Branch: "main", Path: "/repo"}
+	want := errors.New("permission denied")
+	fp := buildFootprint([]statusEntry{{sizeBytes: ptr(int64(200))}}, main, 0, want)
+
+	if fp.mainBytes != 0 {
+		t.Errorf("mainBytes = %d, want 0 when mainErr != nil", fp.mainBytes)
+	}
+	if fp.worktreesBytes != 200 {
+		t.Errorf("worktreesBytes = %d, want 200", fp.worktreesBytes)
+	}
+	if fp.total != 200 {
+		t.Errorf("total = %d, want 200 (excludes errored main)", fp.total)
+	}
+	if !errors.Is(fp.mainErr, want) {
+		t.Errorf("mainErr = %v, want %v", fp.mainErr, want)
+	}
+}
+
+func TestBuildFootprintNoMain(t *testing.T) {
+	fp := buildFootprint([]statusEntry{{sizeBytes: ptr(int64(42))}}, nil, 0, nil)
+	if fp.mainBytes != 0 || fp.total != 42 {
+		t.Errorf("fp = %+v, want main=0 total=42", fp)
+	}
+}
+
+func TestSortBySizeDesc(t *testing.T) {
+	results := []statusEntry{
+		{entry: git.WorktreeEntry{Branch: "small"}, sizeBytes: ptr(int64(100))},
+		{entry: git.WorktreeEntry{Branch: "errored"}, sizeBytes: nil},
+		{entry: git.WorktreeEntry{Branch: "big"}, sizeBytes: ptr(int64(5000))},
+		{entry: git.WorktreeEntry{Branch: "medium"}, sizeBytes: ptr(int64(1000))},
+		{entry: git.WorktreeEntry{Branch: "errored2"}, sizeBytes: nil},
+	}
+	sortBySizeDesc(results)
+	wantOrder := []string{"big", "medium", "small", "errored", "errored2"}
+	for i, w := range wantOrder {
+		if results[i].entry.Branch != w {
+			t.Errorf("index %d: got %q, want %q (full: %+v)", i, results[i].entry.Branch, w, results)
+		}
+	}
+}
+
+func TestSortBySizeDescAllNil(t *testing.T) {
+	// Two nil-sized entries: order is preserved (stable).
+	results := []statusEntry{
+		{entry: git.WorktreeEntry{Branch: "a"}},
+		{entry: git.WorktreeEntry{Branch: "b"}},
+	}
+	sortBySizeDesc(results)
+	if results[0].entry.Branch != "a" || results[1].entry.Branch != "b" {
+		t.Errorf("expected stable order [a, b], got [%s, %s]",
+			results[0].entry.Branch, results[1].entry.Branch)
+	}
+}
+
+func TestFormatDiskLine(t *testing.T) {
+	p := termcolor.NewPainter(true) // no color
+
+	fp := &diskFootprint{mainBytes: 1024 * 1024, worktreesBytes: 2048, total: 1024*1024 + 2048}
+	got := formatDiskLine(p, fp)
+	if !strings.Contains(got, "Disk:") || !strings.Contains(got, "main:") || !strings.Contains(got, "worktrees:") {
+		t.Errorf("formatDiskLine = %q, missing required fragments", got)
+	}
+
+	// Error path: main: fragment must be omitted.
+	fpErr := &diskFootprint{mainErr: errors.New("boom"), worktreesBytes: 512, total: 512}
+	got = formatDiskLine(p, fpErr)
+	if strings.Contains(got, "main:") {
+		t.Errorf("formatDiskLine on mainErr = %q, expected no 'main:' fragment", got)
+	}
+	if !strings.Contains(got, "worktrees:") {
+		t.Errorf("formatDiskLine on mainErr = %q, expected 'worktrees:' fragment", got)
+	}
+}
+
+func TestFormatSizeCell(t *testing.T) {
+	p := termcolor.NewPainter(true)
+
+	if got := formatSizeCell(statusEntry{sizeBytes: nil}, p); got != "?" {
+		t.Errorf("nil sizeBytes cell = %q, want '?'", got)
+	}
+	if got := formatSizeCell(statusEntry{sizeBytes: ptr(int64(2048))}, p); got != "2.0KB" {
+		t.Errorf("2048-byte cell = %q, want '2.0KB'", got)
+	}
+}
+
+func TestFormatRecentCell(t *testing.T) {
+	p := termcolor.NewPainter(true)
+
+	if got := formatRecentCell(statusEntry{recent7D: nil}, p); got != "?" {
+		t.Errorf("nil recent7D cell = %q, want '?'", got)
+	}
+	if got := formatRecentCell(statusEntry{recent7D: ptr(42)}, p); got != "42" {
+		t.Errorf("recent7D=42 cell = %q, want '42'", got)
+	}
+}
+
+// detailFixture spins up a mocked Runner backed by real temp dirs suitable
+// for exercising the full --detail code path end-to-end.
+type detailFixture struct {
+	mainPath, wtBigPath, wtSmallPath string
+	restore                          func()
+}
+
+func setupDetailFixture(t *testing.T) detailFixture {
+	t.Helper()
+	f := detailFixture{
+		mainPath:    t.TempDir(),
+		wtBigPath:   t.TempDir(),
+		wtSmallPath: t.TempDir(),
+	}
+	// Inflate big worktree so the sort is deterministic.
+	if err := os.WriteFile(filepath.Join(f.wtBigPath, "blob"), make([]byte, 8*1024), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(f.wtSmallPath, "tiny"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	worktreeList := fmt.Sprintf(
+		"worktree %s\nHEAD abc\nbranch refs/heads/main\n\n"+
+			"worktree %s\nHEAD def\nbranch refs/heads/feature/big\n\n"+
+			"worktree %s\nHEAD ghi\nbranch refs/heads/feature/small\n\n",
+		f.mainPath, f.wtBigPath, f.wtSmallPath,
+	)
+
+	f.restore = overrideNewRunner(&mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case args[0] == cmdRevParse && args[1] == cmdShowToplevel:
+				return f.mainPath, nil
+			case args[0] == cmdSymbolicRef:
+				return refsRemotesOriginMain, nil
+			case args[0] == cmdWorktreeTest && args[1] == cmdList:
+				return worktreeList, nil
+			case args[0] == cmdLog:
+				return "1700000000\tcommit msg", nil
+			case args[0] == cmdRevList && len(args) >= 2 && args[1] == "--count":
+				if strings.Contains(args[len(args)-1], "big") {
+					return "9", nil
+				}
+				return "3", nil
+			}
+			return "", nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if args[0] == cmdStatus {
+				return "", nil
+			}
+			if args[0] == cmdRevList {
+				return aheadBehindZero, nil
+			}
+			return "", nil
+		},
+	})
+	return f
+}
+
+func newDetailCmd(t *testing.T, jsonOut bool) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd, buf := newTestCmd()
+	cmd.Flags().Int(flagStaleDays, 14, "")
+	cmd.Flags().Bool(flagDetail, true, "")
+	_ = cmd.Flags().Set(flagDetail, "true")
+	if jsonOut {
+		_ = cmd.Flags().Set(flagJSON, "true")
+	}
+	return cmd, buf
+}
+
+// TestStatusDetailTable exercises --detail table output: new columns, the
+// Disk: summary line, and size-desc sort order.
+func TestStatusDetailTable(t *testing.T) {
+	f := setupDetailFixture(t)
+	defer f.restore()
+
+	cmd, buf := newDetailCmd(t, false)
+	if err := statusCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("statusCmd.RunE --detail: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{"SIZE", "7D", "Disk:", "main:", "worktrees:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in --detail output, got:\n%s", want, out)
+		}
+	}
+	bigIdx := strings.Index(out, "feature/big")
+	smallIdx := strings.Index(out, "feature/small")
+	if bigIdx < 0 || smallIdx < 0 || bigIdx >= smallIdx {
+		t.Errorf("expected feature/big before feature/small; big=%d small=%d\n%s",
+			bigIdx, smallIdx, out)
+	}
+}
+
+// TestStatusDetailJSON exercises --detail --json: new per-item fields and
+// the top-level disk object are present.
+func TestStatusDetailJSON(t *testing.T) {
+	f := setupDetailFixture(t)
+	defer f.restore()
+
+	cmd, buf := newDetailCmd(t, true)
+	if err := statusCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("statusCmd.RunE --detail --json: %v", err)
+	}
+
+	var env output.Envelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	data, ok := env.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("data type = %T, want map[string]any", env.Data)
+	}
+	assertDetailJSONShape(t, data)
+}
+
+func assertDetailJSONShape(t *testing.T, data map[string]any) {
+	t.Helper()
+
+	disk, ok := data["disk"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing disk key in JSON; full data: %+v", data)
+	}
+	for _, key := range []string{"total_bytes", "main_bytes", "worktrees_bytes"} {
+		if _, present := disk[key]; !present {
+			t.Errorf("disk.%s missing from JSON: %+v", key, disk)
+		}
+	}
+
+	worktrees, _ := data["worktrees"].([]any)
+	if len(worktrees) != 2 {
+		t.Fatalf("worktrees length = %d, want 2", len(worktrees))
+	}
+	first, _ := worktrees[0].(map[string]any)
+	if _, ok := first["size_bytes"]; !ok {
+		t.Errorf("worktrees[0] missing size_bytes: %+v", first)
+	}
+	if _, ok := first["recent_7d"]; !ok {
+		t.Errorf("worktrees[0] missing recent_7d: %+v", first)
+	}
+}

--- a/internal/fsutil/dirsize.go
+++ b/internal/fsutil/dirsize.go
@@ -1,5 +1,4 @@
-// Package fsutil provides filesystem utilities that are shared across
-// rimba commands (directory sizing, path helpers, etc.).
+// Package fsutil holds filesystem helpers shared across commands.
 package fsutil
 
 import (
@@ -7,10 +6,9 @@ import (
 	"path/filepath"
 )
 
-// DirSize walks path and returns the total byte size of regular files
-// reachable without traversing symlinks. On per-entry errors (permission
-// denied, races) it accumulates a best-effort total and returns the first
-// error observed. The returned size is meaningful even when err is non-nil.
+// DirSize returns the total size of regular files under path.
+// Symlinks are not followed. On partial failure (permission denied,
+// races) it returns the best-effort total and the first error seen.
 func DirSize(path string) (int64, error) {
 	var total int64
 	var firstErr error

--- a/internal/fsutil/dirsize.go
+++ b/internal/fsutil/dirsize.go
@@ -1,0 +1,47 @@
+// Package fsutil provides filesystem utilities that are shared across
+// rimba commands (directory sizing, path helpers, etc.).
+package fsutil
+
+import (
+	"io/fs"
+	"path/filepath"
+)
+
+// DirSize walks path and returns the total byte size of regular files
+// reachable without traversing symlinks. On per-entry errors (permission
+// denied, races) it accumulates a best-effort total and returns the first
+// error observed. The returned size is meaningful even when err is non-nil.
+func DirSize(path string) (int64, error) {
+	var total int64
+	var firstErr error
+
+	record := func(err error) {
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	walkErr := filepath.WalkDir(path, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			record(err)
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			record(infoErr)
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
+	if walkErr != nil {
+		record(walkErr)
+	}
+	return total, firstErr
+}

--- a/internal/fsutil/dirsize_test.go
+++ b/internal/fsutil/dirsize_test.go
@@ -1,0 +1,117 @@
+package fsutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/fsutil"
+)
+
+func TestDirSizeSumsRegularFiles(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.txt"), 100)
+	writeFile(t, filepath.Join(root, "nested", "b.txt"), 250)
+	writeFile(t, filepath.Join(root, "nested", "deeper", "c.txt"), 50)
+
+	got, err := fsutil.DirSize(root)
+	if err != nil {
+		t.Fatalf("DirSize returned error: %v", err)
+	}
+	if want := int64(400); got != want {
+		t.Errorf("DirSize = %d, want %d", got, want)
+	}
+}
+
+func TestDirSizeDoesNotFollowSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on Windows")
+	}
+
+	outside := t.TempDir()
+	writeFile(t, filepath.Join(outside, "huge.bin"), 10_000)
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "small.txt"), 42)
+	if err := os.Symlink(filepath.Join(outside, "huge.bin"), filepath.Join(root, "link")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	got, err := fsutil.DirSize(root)
+	if err != nil {
+		t.Fatalf("DirSize returned error: %v", err)
+	}
+	if got >= 10_000 {
+		t.Errorf("DirSize = %d, symlink target appears to have been followed (expected small count)", got)
+	}
+	if got < 42 {
+		t.Errorf("DirSize = %d, expected at least the small.txt byte count (42)", got)
+	}
+}
+
+func TestDirSizeEmptyDir(t *testing.T) {
+	root := t.TempDir()
+	got, err := fsutil.DirSize(root)
+	if err != nil {
+		t.Fatalf("DirSize returned error: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("DirSize = %d, want 0 for empty dir", got)
+	}
+}
+
+func TestDirSizeMissingPath(t *testing.T) {
+	_, err := fsutil.DirSize(filepath.Join(t.TempDir(), "does-not-exist"))
+	if err == nil {
+		t.Fatal("DirSize on missing path returned nil error, want non-nil")
+	}
+}
+
+func TestDirSizeBestEffortOnPartialError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based permission test is POSIX-specific")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses permission checks")
+	}
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "visible.txt"), 123)
+
+	denied := filepath.Join(root, "denied")
+	if err := os.Mkdir(denied, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, filepath.Join(denied, "secret.txt"), 999)
+	if err := os.Chmod(denied, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(denied, 0o755) })
+
+	got, err := fsutil.DirSize(root)
+	if err == nil {
+		t.Fatal("DirSize returned nil error despite permission-denied subdir")
+	}
+	if !strings.Contains(err.Error(), "denied") && !strings.Contains(err.Error(), "permission") {
+		t.Logf("DirSize error = %v (ok — non-nil)", err)
+	}
+	if got < 123 {
+		t.Errorf("DirSize = %d, want at least 123 (best-effort should include visible.txt)", got)
+	}
+}
+
+func writeFile(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	buf := make([]byte, size)
+	for i := range buf {
+		buf[i] = 'x'
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/git/commit_count.go
+++ b/internal/git/commit_count.go
@@ -1,0 +1,35 @@
+package git
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CommitCountSince returns the number of commits on branch with a committer
+// date newer than time.Now() - since. It wraps `git rev-list --count
+// --since=<unix-ts> <branch>`, using a unix timestamp to avoid locale/TZ
+// ambiguity in the --since parser.
+//
+// Note: git's --since stops walking the first-parent chain at the first
+// commit older than the cutoff, so a backdated ancestor hides newer
+// commits behind it. For the --detail "recent velocity" use case this is
+// the intended behavior: it measures how much the branch tip has moved.
+func CommitCountSince(r Runner, branch string, since time.Duration) (int, error) {
+	cutoff := time.Now().Add(-since).Unix()
+	out, err := r.Run(
+		"rev-list", "--count",
+		fmt.Sprintf("--since=%d", cutoff),
+		branch,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("commit count since for %s: %w", branch, err)
+	}
+
+	n, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("parse commit count %q: %w", out, err)
+	}
+	return n, nil
+}

--- a/internal/git/commit_count.go
+++ b/internal/git/commit_count.go
@@ -7,15 +7,12 @@ import (
 	"time"
 )
 
-// CommitCountSince returns the number of commits on branch with a committer
-// date newer than time.Now() - since. It wraps `git rev-list --count
-// --since=<unix-ts> <branch>`, using a unix timestamp to avoid locale/TZ
-// ambiguity in the --since parser.
+// CommitCountSince counts commits on branch within the last `since`
+// duration, via `git rev-list --count --since=<unix-ts>`.
 //
-// Note: git's --since stops walking the first-parent chain at the first
-// commit older than the cutoff, so a backdated ancestor hides newer
-// commits behind it. For the --detail "recent velocity" use case this is
-// the intended behavior: it measures how much the branch tip has moved.
+// git's --since stops at the first commit older than the cutoff, so an
+// older ancestor hides anything beyond it. That matches what we want
+// here: recent activity on the tip, not total commits in history.
 func CommitCountSince(r Runner, branch string, since time.Duration) (int, error) {
 	cutoff := time.Now().Add(-since).Unix()
 	out, err := r.Run(

--- a/internal/git/commit_count_test.go
+++ b/internal/git/commit_count_test.go
@@ -1,0 +1,90 @@
+package git_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+func TestCommitCountSinceCountsRecent(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	// NewTestRepo already made 1 initial commit "now".
+	// Add 2 more recent commits.
+	for i := range 2 {
+		testutil.CreateFile(t, repo, filepath.Join(".", "f"+string(rune('a'+i))), "x")
+		testutil.GitCmd(t, repo, "add", ".")
+		testutil.GitCmd(t, repo, "commit", "-m", "recent")
+	}
+
+	got, err := git.CommitCountSince(r, "main", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CommitCountSince: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("CommitCountSince = %d, want 3 (1 initial + 2 recent)", got)
+	}
+}
+
+func TestCommitCountSinceExcludesOldCommits(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	// Backdate the single existing commit by 30 days (amend with old
+	// committer+author date). With a 7-day since window, the result must
+	// be 0: git's --since stops walking once it hits an older commit.
+	oldDate := time.Now().Add(-30 * 24 * time.Hour).Format(time.RFC3339)
+	gitCmdWithCommitterDate(t, repo, oldDate, "commit", "--amend", "--no-edit")
+
+	got, err := git.CommitCountSince(r, "main", 7*24*time.Hour)
+	if err != nil {
+		t.Fatalf("CommitCountSince: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("CommitCountSince over 7 days = %d, want 0 (only commit is 30 days old)", got)
+	}
+}
+
+func TestCommitCountSinceUnknownBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	_, err := git.CommitCountSince(r, "no-such-branch", 7*24*time.Hour)
+	if err == nil {
+		t.Fatal("CommitCountSince on unknown branch returned nil error, want non-nil")
+	}
+}
+
+// gitCmdWithCommitterDate runs git with GIT_COMMITTER_DATE set, so that
+// `--since` filtering (which looks at committer date) can be tested.
+func gitCmdWithCommitterDate(t *testing.T, dir, date string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-c", "user.email=test@test.com", "-c", "user.name=Test"}, args...)...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_COMMITTER_DATE="+date,
+		"GIT_AUTHOR_DATE="+date,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %s: %v", args, out, err)
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -105,6 +105,17 @@ func FilterEntries(entries []WorktreeEntry, mainBranch string) []WorktreeEntry {
 	return out
 }
 
+// FindEntry returns the first entry matching branch, or nil if none.
+// Counterpart to FilterEntries.
+func FindEntry(entries []WorktreeEntry, branch string) *WorktreeEntry {
+	for i := range entries {
+		if entries[i].Branch == branch {
+			return &entries[i]
+		}
+	}
+	return nil
+}
+
 // Prune runs `git worktree prune` to clean up stale worktree references.
 func Prune(r Runner, dryRun bool) (string, error) {
 	args := []string{cmdWorktree, "prune"}

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -138,6 +138,24 @@ func TestFilterEntriesEmpty(t *testing.T) {
 	}
 }
 
+func TestFindEntry(t *testing.T) {
+	entries := []git.WorktreeEntry{
+		{Branch: "feature/a", Path: "/wt/a"},
+		{Branch: "main", Path: "/repo"},
+		{Branch: "feature/b", Path: "/wt/b"},
+	}
+	got := git.FindEntry(entries, "main")
+	if got == nil || got.Path != "/repo" {
+		t.Errorf("FindEntry(main) = %+v, want /repo", got)
+	}
+	if git.FindEntry(entries, "nope") != nil {
+		t.Error("FindEntry on missing branch should return nil")
+	}
+	if git.FindEntry(nil, "main") != nil {
+		t.Error("FindEntry on nil entries should return nil")
+	}
+}
+
 func TestMoveWorktree(t *testing.T) {
 	if testing.Short() {
 		t.Skip(skipIntegration)

--- a/internal/operations/footprint.go
+++ b/internal/operations/footprint.go
@@ -1,0 +1,26 @@
+package operations
+
+// DiskFootprint is the total disk usage of a rimba repo.
+// MainErr != nil means MainBytes could not be computed and is zero.
+type DiskFootprint struct {
+	TotalBytes     int64
+	MainBytes      int64
+	MainErr        error
+	WorktreesBytes int64
+}
+
+// BuildDiskFootprint sums worktreeSizes (nils are skipped) plus mainSize.
+// When mainErr != nil, MainBytes stays zero and mainErr is preserved.
+func BuildDiskFootprint(worktreeSizes []*int64, mainSize int64, mainErr error) DiskFootprint {
+	fp := DiskFootprint{MainErr: mainErr}
+	if mainErr == nil {
+		fp.MainBytes = mainSize
+	}
+	for _, s := range worktreeSizes {
+		if s != nil {
+			fp.WorktreesBytes += *s
+		}
+	}
+	fp.TotalBytes = fp.MainBytes + fp.WorktreesBytes
+	return fp
+}

--- a/internal/operations/footprint_test.go
+++ b/internal/operations/footprint_test.go
@@ -1,0 +1,44 @@
+package operations_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/operations"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestBuildDiskFootprint(t *testing.T) {
+	sizes := []*int64{ptr(int64(1000)), ptr(int64(500)), nil}
+	fp := operations.BuildDiskFootprint(sizes, 10_000, nil)
+
+	if fp.MainBytes != 10_000 || fp.WorktreesBytes != 1500 || fp.TotalBytes != 11_500 {
+		t.Errorf("fp = %+v, want main=10000 wt=1500 total=11500", fp)
+	}
+	if fp.MainErr != nil {
+		t.Errorf("MainErr = %v, want nil", fp.MainErr)
+	}
+}
+
+func TestBuildDiskFootprintMainError(t *testing.T) {
+	want := errors.New("permission denied")
+	fp := operations.BuildDiskFootprint([]*int64{ptr(int64(200))}, 0, want)
+
+	if fp.MainBytes != 0 {
+		t.Errorf("MainBytes = %d, want 0 when MainErr != nil", fp.MainBytes)
+	}
+	if fp.WorktreesBytes != 200 || fp.TotalBytes != 200 {
+		t.Errorf("wt=%d total=%d, want 200/200 (main excluded)", fp.WorktreesBytes, fp.TotalBytes)
+	}
+	if !errors.Is(fp.MainErr, want) {
+		t.Errorf("MainErr = %v, want %v", fp.MainErr, want)
+	}
+}
+
+func TestBuildDiskFootprintAllNil(t *testing.T) {
+	fp := operations.BuildDiskFootprint([]*int64{nil, nil}, 0, nil)
+	if fp.TotalBytes != 0 || fp.WorktreesBytes != 0 {
+		t.Errorf("fp = %+v, want zeros", fp)
+	}
+}

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -25,6 +25,16 @@ type StatusData struct {
 	Summary   StatusSummary `json:"summary"`
 	Worktrees []StatusItem  `json:"worktrees"`
 	StaleDays int           `json:"stale_days"`
+	Disk      *DiskSummary  `json:"disk,omitempty"`
+}
+
+// DiskSummary holds the footprint breakdown emitted under --detail.
+// MainBytes is a pointer so consumers can distinguish "main repo size is
+// zero" from "main repo size could not be computed" (pointer is nil).
+type DiskSummary struct {
+	TotalBytes     int64  `json:"total_bytes"`
+	MainBytes      *int64 `json:"main_bytes,omitempty"`
+	WorktreesBytes int64  `json:"worktrees_bytes"`
 }
 
 // StatusSummary holds aggregate counts for the status command.
@@ -37,11 +47,13 @@ type StatusSummary struct {
 
 // StatusItem holds per-worktree status in JSON output.
 type StatusItem struct {
-	Task   string                  `json:"task"`
-	Type   string                  `json:"type"`
-	Branch string                  `json:"branch"`
-	Status resolver.WorktreeStatus `json:"status"`
-	Age    *StatusAge              `json:"age"`
+	Task      string                  `json:"task"`
+	Type      string                  `json:"type"`
+	Branch    string                  `json:"branch"`
+	Status    resolver.WorktreeStatus `json:"status"`
+	Age       *StatusAge              `json:"age"`
+	SizeBytes *int64                  `json:"size_bytes,omitempty"`
+	Recent7D  *int                    `json:"recent_7d,omitempty"`
 }
 
 // StatusAge holds last-commit age information.

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -28,9 +28,9 @@ type StatusData struct {
 	Disk      *DiskSummary  `json:"disk,omitempty"`
 }
 
-// DiskSummary holds the footprint breakdown emitted under --detail.
-// MainBytes is a pointer so consumers can distinguish "main repo size is
-// zero" from "main repo size could not be computed" (pointer is nil).
+// DiskSummary is the footprint breakdown emitted under --detail.
+// MainBytes is a pointer so nil (omitted in JSON) means "could not be
+// computed", distinct from a real zero.
 type DiskSummary struct {
 	TotalBytes     int64  `json:"total_bytes"`
 	MainBytes      *int64 `json:"main_bytes,omitempty"`

--- a/internal/resolver/bytes.go
+++ b/internal/resolver/bytes.go
@@ -5,10 +5,9 @@ import (
 	"strconv"
 )
 
-// FormatBytes returns a human-readable size using 1024-base units (B, KB,
-// MB, GB, TB). One decimal place is shown for values under 10 in their unit
-// (e.g. "1.8GB"); whole numbers for larger values ("15MB"). Negative input
-// is clamped to zero.
+// FormatBytes renders n as a 1024-base size, e.g. "1.8GB" or "15MB".
+// Values under 10 in their unit get one decimal; larger values round to
+// whole numbers. n <= 0 returns "0B".
 func FormatBytes(n int64) string {
 	if n <= 0 {
 		return "0B"

--- a/internal/resolver/bytes.go
+++ b/internal/resolver/bytes.go
@@ -1,0 +1,33 @@
+package resolver
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// FormatBytes returns a human-readable size using 1024-base units (B, KB,
+// MB, GB, TB). One decimal place is shown for values under 10 in their unit
+// (e.g. "1.8GB"); whole numbers for larger values ("15MB"). Negative input
+// is clamped to zero.
+func FormatBytes(n int64) string {
+	if n <= 0 {
+		return "0B"
+	}
+
+	const unit = 1024
+	if n < unit {
+		return strconv.FormatInt(n, 10) + "B"
+	}
+
+	units := []string{"KB", "MB", "GB", "TB", "PB", "EB"}
+	f := float64(n) / unit
+	idx := 0
+	for f >= unit && idx < len(units)-1 {
+		f /= unit
+		idx++
+	}
+	if f < 10 {
+		return fmt.Sprintf("%.1f%s", f, units[idx])
+	}
+	return fmt.Sprintf("%.0f%s", f, units[idx])
+}

--- a/internal/resolver/bytes_test.go
+++ b/internal/resolver/bytes_test.go
@@ -1,0 +1,31 @@
+package resolver_test
+
+import (
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/resolver"
+)
+
+func TestFormatBytes(t *testing.T) {
+	cases := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0B"},
+		{512, "512B"},
+		{1023, "1023B"},
+		{1024, "1.0KB"},
+		{1536, "1.5KB"},
+		{1024 * 1024, "1.0MB"},
+		{15 * 1024 * 1024, "15MB"},
+		{1932735283, "1.8GB"}, // 1.8 * 1024^3, rounded to nearest byte
+		{2 * 1024 * 1024 * 1024 * 1024, "2.0TB"},
+		{-1, "0B"},
+	}
+	for _, tc := range cases {
+		got := resolver.FormatBytes(tc.n)
+		if got != tc.want {
+			t.Errorf("FormatBytes(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}

--- a/tests/e2e/status_detail_test.go
+++ b/tests/e2e/status_detail_test.go
@@ -1,0 +1,143 @@
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+// recentCellRE matches the trailing 7D cell (digits or "?") on a status row.
+var recentCellRE = regexp.MustCompile(`\s(\d+|\?)\s*$`)
+
+func TestStatusDetailShowsSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	const task = "sizable"
+	rimbaSuccess(t, repo, "add", task)
+
+	wtPath := worktreePathFor(t, repo, task)
+	// Write 5 KiB of data so the SIZE column renders as "5.0KB" (or above).
+	if err := os.WriteFile(filepath.Join(wtPath, "blob.bin"), make([]byte, 5*1024), 0o644); err != nil {
+		t.Fatalf("write blob: %v", err)
+	}
+
+	r := rimbaSuccess(t, repo, "status", "--detail")
+	assertContains(t, r.Stdout, "SIZE")
+	assertContains(t, r.Stdout, "7D")
+	assertContains(t, r.Stdout, "Disk:")
+	// The written file is 5 KiB; the worktree's own git metadata pushes it
+	// higher. Any KB/MB suffix in the SIZE column is acceptable evidence.
+	if !strings.Contains(r.Stdout, "KB") && !strings.Contains(r.Stdout, "MB") {
+		t.Errorf("expected SIZE column to contain KB or MB, got:\n%s", r.Stdout)
+	}
+}
+
+func TestStatusDetailSortsBySize(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	const smallTask = "tiny-wt"
+	const largeTask = "big-wt"
+	rimbaSuccess(t, repo, "add", smallTask)
+	rimbaSuccess(t, repo, "add", largeTask)
+
+	// Inflate the "big" worktree by 2 MB so it clearly dwarfs the small one.
+	bigPath := worktreePathFor(t, repo, largeTask)
+	if err := os.WriteFile(filepath.Join(bigPath, "blob.bin"), make([]byte, 2*1024*1024), 0o644); err != nil {
+		t.Fatalf("write big blob: %v", err)
+	}
+
+	r := rimbaSuccess(t, repo, "status", "--detail")
+	bigIdx := strings.Index(r.Stdout, largeTask)
+	smallIdx := strings.Index(r.Stdout, smallTask)
+	if bigIdx < 0 || smallIdx < 0 {
+		t.Fatalf("expected both tasks in output, got:\n%s", r.Stdout)
+	}
+	if bigIdx >= smallIdx {
+		t.Errorf("expected %q to appear before %q under --detail (size desc), got:\n%s",
+			largeTask, smallTask, r.Stdout)
+	}
+}
+
+func TestStatusDetailFootprint(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "footprint-task")
+
+	r := rimbaSuccess(t, repo, "status", "--detail")
+	assertContains(t, r.Stdout, "Disk:")
+	assertContains(t, r.Stdout, "main:")
+	assertContains(t, r.Stdout, "worktrees:")
+}
+
+func TestStatusDetailVelocity(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	const task = "velocity-task"
+	rimbaSuccess(t, repo, "add", task)
+
+	wtPath := worktreePathFor(t, repo, task)
+	// Add 3 commits in the worktree (recent). NewTestRepo's initial commit
+	// is reachable from this branch too, so 7D >= 4. The precise value
+	// depends on branch topology; asserting > 1 keeps the test focused
+	// on "velocity reflects recent commits" without being brittle.
+	for i := range 3 {
+		testutil.CreateFile(t, wtPath, "v"+string(rune('a'+i))+".txt", "x")
+		testutil.GitCmd(t, wtPath, "add", ".")
+		testutil.GitCmd(t, wtPath, "commit", "-m", "v")
+	}
+
+	r := rimbaSuccess(t, repo, "status", "--detail")
+	assertContains(t, r.Stdout, "7D")
+
+	taskLine := lineContaining(t, r.Stdout, task)
+	m := recentCellRE.FindStringSubmatch(taskLine)
+	if m == nil {
+		t.Fatalf("no 7D cell found at end of row; line: %q", taskLine)
+	}
+	recent := m[1]
+	if recent == "?" {
+		t.Fatalf("velocity for %q is '?', expected a number; line: %q", task, taskLine)
+	}
+	if recent == "0" || recent == "1" {
+		t.Errorf("expected 7D > 1 after creating 3 commits, got %s (line: %q)", recent, taskLine)
+	}
+}
+
+// worktreePathFor returns the path of the worktree created for task under
+// the default prefix in the given rimba repo.
+func worktreePathFor(t *testing.T, repo, task string) string {
+	t.Helper()
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.BranchName(defaultPrefix, task)
+	return resolver.WorktreePath(wtDir, branch)
+}
+
+// lineContaining returns the first line of s that contains sub, or fails the test.
+func lineContaining(t *testing.T, s, sub string) string {
+	t.Helper()
+	for line := range strings.SplitSeq(s, "\n") {
+		if strings.Contains(line, sub) {
+			return line
+		}
+	}
+	t.Fatalf("no line containing %q found in:\n%s", sub, s)
+	return ""
+}


### PR DESCRIPTION
## Summary
- Adds opt-in `rimba status --detail` flag that shows per-worktree disk size, a 7-day commit velocity column, and a `Disk:` footprint summary including the main repo. Default `status` output is byte-identical to before (human table, JSON, and exit codes all unchanged when the flag is absent).
- Rows are sorted by size desc under `--detail` so the biggest offender surfaces first — matches the cleanup use case described in the issue. Per-worktree errors render as `?` in the table and are omitted from JSON; the command still exits 0 so one flaky worktree doesn't fail the whole report.
- Small new helpers slot into existing conventions: `fsutil.DirSize` (new package, stdlib-only), `git.CommitCountSince` (follows the `func(r Runner, ...)` package pattern), and `resolver.FormatBytes` (placed next to `FormatAge`). Split across five focused commits.

## Test Plan
- [x] Unit tests pass (`make test`) — 1416 pass across 25 packages (up from 1155 baseline)
- [x] Linter passes (`make lint`) — 0 issues
- [x] Manual: `rimba status` output unchanged byte-for-byte pre/post; `rimba status --detail` renders SIZE/7D columns, `Disk: total ... (main: ..., worktrees: ...)` line, and sorts by size desc; `rimba status --detail --json` surfaces new fields (`size_bytes`, `recent_7d`, `disk`) while omitting them without the flag.

Closes #119
