### PR TITLE
[feat] Add internal/gh package for CLI detection and auth

### DIFF
--- a/internal/gh/auth.go
+++ b/internal/gh/auth.go
@@ -1,0 +1,27 @@
+package gh
+
+import (
+	"context"
+	"errors"
+
+	"github.com/lugassawan/rimba/internal/errhint"
+)
+
+// CheckAuth verifies that `gh` is installed and authenticated.
+// Returns nil if `gh auth status` succeeds; otherwise returns an
+// errhint.WithFix-wrapped error with guidance for the user.
+func CheckAuth(ctx context.Context, runner Runner) error {
+	if !IsAvailable() {
+		return errhint.WithFix(
+			errors.New("gh CLI not found on PATH"),
+			"install from https://cli.github.com and run: gh auth login",
+		)
+	}
+	if _, err := runner.Run(ctx, "auth", "status"); err != nil {
+		return errhint.WithFix(
+			errors.New("gh is not authenticated"),
+			"run: gh auth login",
+		)
+	}
+	return nil
+}

--- a/internal/gh/auth.go
+++ b/internal/gh/auth.go
@@ -7,9 +7,8 @@ import (
 	"github.com/lugassawan/rimba/internal/errhint"
 )
 
-// CheckAuth verifies that `gh` is installed and authenticated.
-// Returns nil if `gh auth status` succeeds; otherwise returns an
-// errhint.WithFix-wrapped error with guidance for the user.
+// CheckAuth returns nil if `gh` is installed and authenticated.
+// Otherwise it returns a wrapped error with a "To fix:" hint.
 func CheckAuth(ctx context.Context, runner Runner) error {
 	if !IsAvailable() {
 		return errhint.WithFix(

--- a/internal/gh/auth_test.go
+++ b/internal/gh/auth_test.go
@@ -1,0 +1,55 @@
+package gh
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestCheckAuthGhMissing(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	err := CheckAuth(context.Background(), &mockRunner{
+		run: func(context.Context, ...string) ([]byte, error) {
+			t.Fatal("runner should not be called when gh is missing")
+			return nil, nil
+		},
+	})
+
+	assertContains(t, err, "gh CLI not found on PATH")
+	assertContains(t, err, "To fix: install from https://cli.github.com and run: gh auth login")
+}
+
+func TestCheckAuthNotAuthenticated(t *testing.T) {
+	withFakeGhOnPath(t)
+
+	runner := &mockRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return []byte("You are not logged into any GitHub hosts."), errors.New("exit status 1")
+		},
+	}
+
+	err := CheckAuth(context.Background(), runner)
+	assertContains(t, err, "gh is not authenticated")
+	assertContains(t, err, "To fix: run: gh auth login")
+}
+
+func TestCheckAuthOK(t *testing.T) {
+	withFakeGhOnPath(t)
+
+	var captured []string
+	runner := &mockRunner{
+		run: func(_ context.Context, args ...string) ([]byte, error) {
+			captured = args
+			return []byte("Logged in to github.com as someone"), nil
+		},
+	}
+
+	if err := CheckAuth(context.Background(), runner); err != nil {
+		t.Fatalf("CheckAuth() = %v, want nil", err)
+	}
+	if !reflect.DeepEqual(captured, []string{"auth", "status"}) {
+		t.Errorf("captured args = %v, want [auth status]", captured)
+	}
+}

--- a/internal/gh/detect.go
+++ b/internal/gh/detect.go
@@ -1,0 +1,12 @@
+// Package gh provides shared helpers for detecting and authenticating the
+// GitHub CLI (`gh`), so downstream features share one detection path and
+// uniform error messages.
+package gh
+
+import "os/exec"
+
+// IsAvailable reports whether the `gh` binary is on PATH.
+func IsAvailable() bool {
+	_, err := exec.LookPath("gh")
+	return err == nil
+}

--- a/internal/gh/detect.go
+++ b/internal/gh/detect.go
@@ -1,11 +1,9 @@
-// Package gh provides shared helpers for detecting and authenticating the
-// GitHub CLI (`gh`), so downstream features share one detection path and
-// uniform error messages.
+// Package gh detects and authenticates the GitHub CLI.
 package gh
 
 import "os/exec"
 
-// IsAvailable reports whether the `gh` binary is on PATH.
+// IsAvailable reports whether `gh` is on PATH.
 func IsAvailable() bool {
 	_, err := exec.LookPath("gh")
 	return err == nil

--- a/internal/gh/detect_test.go
+++ b/internal/gh/detect_test.go
@@ -1,0 +1,22 @@
+package gh
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestIsAvailableMissing(t *testing.T) {
+	t.Setenv("PATH", "")
+	if IsAvailable() {
+		t.Fatal("IsAvailable() = true with empty PATH, want false")
+	}
+}
+
+func TestIsAvailablePresent(t *testing.T) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		t.Skip("gh not installed on host; skipping positive detection test")
+	}
+	if !IsAvailable() {
+		t.Fatal("IsAvailable() = false with gh on PATH, want true")
+	}
+}

--- a/internal/gh/mock_runner_test.go
+++ b/internal/gh/mock_runner_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 )
 
-// withFakeGhOnPath puts a dummy `gh` executable on PATH for the test's
-// lifetime so IsAvailable() returns true regardless of the host.
+// withFakeGhOnPath prepends a dummy `gh` executable to PATH for the
+// test's lifetime so IsAvailable() returns true regardless of the host.
 // The runner is always mocked, so the fake binary is never executed.
+// PATH is prepended (not replaced) so other tools stay resolvable.
 func withFakeGhOnPath(t *testing.T) {
 	t.Helper()
 	dir := t.TempDir()
@@ -18,7 +19,7 @@ func withFakeGhOnPath(t *testing.T) {
 	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("PATH", dir)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 // mockRunner implements Runner with a configurable closure for testing.

--- a/internal/gh/mock_runner_test.go
+++ b/internal/gh/mock_runner_test.go
@@ -1,0 +1,41 @@
+package gh
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withFakeGhOnPath puts a dummy `gh` executable on PATH for the test's
+// lifetime so IsAvailable() returns true regardless of the host.
+// The runner is always mocked, so the fake binary is never executed.
+func withFakeGhOnPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "gh")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+}
+
+// mockRunner implements Runner with a configurable closure for testing.
+type mockRunner struct {
+	run func(ctx context.Context, args ...string) ([]byte, error)
+}
+
+func (m *mockRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	return m.run(ctx, args...)
+}
+
+func assertContains(t *testing.T, err error, substr string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", substr)
+	}
+	if !strings.Contains(err.Error(), substr) {
+		t.Errorf("error = %q, want it to contain %q", err, substr)
+	}
+}

--- a/internal/gh/runner.go
+++ b/internal/gh/runner.go
@@ -1,0 +1,28 @@
+package gh
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Runner abstracts `gh` command execution so callers can inject fakes in tests.
+type Runner interface {
+	Run(ctx context.Context, args ...string) ([]byte, error)
+}
+
+// Default returns a Runner that shells out to the real `gh` binary.
+func Default() Runner {
+	return &execRunner{}
+}
+
+type execRunner struct{}
+
+func (r *execRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	out, err := exec.CommandContext(ctx, "gh", args...).CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("gh %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)
+	}
+	return out, nil
+}

--- a/internal/gh/runner.go
+++ b/internal/gh/runner.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 )
 
-// Runner abstracts `gh` command execution so callers can inject fakes in tests.
+// Runner runs `gh` commands. Tests inject a fake.
 type Runner interface {
 	Run(ctx context.Context, args ...string) ([]byte, error)
 }
 
-// Default returns a Runner that shells out to the real `gh` binary.
+// Default returns a Runner backed by the real `gh` binary.
 func Default() Runner {
 	return &execRunner{}
 }


### PR DESCRIPTION
## Summary
- Add `internal/gh` with `IsAvailable()`, `CheckAuth()`, and a mockable `Runner` so downstream features (#123 PR checkout, #126 CI status column) share one detection path and uniform `errhint.WithFix` error wording.
- `Runner` intentionally takes `context.Context` and returns `[]byte` (diverges from `internal/git.Runner` per issue spec) so `gh` calls support cancellation and raw-byte consumers.
- Tests use a `withFakeGhOnPath` helper that drops a dummy `gh` onto PATH for the test's lifetime, so the suite is portable across hosts with or without `gh` installed.

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] New tests cover: missing binary (PATH empty), auth failure, auth success, and exact args passed to the `Runner` (`[]string{"auth", "status"}`)

Closes #127
