### PR TITLE
[feat] Add --full PR/CI columns to rimba list

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/hint"
 	"github.com/lugassawan/rimba/internal/operations"
@@ -17,6 +20,22 @@ import (
 	"github.com/lugassawan/rimba/internal/termcolor"
 	"github.com/spf13/cobra"
 )
+
+const prQueryTimeout = 10 * time.Second
+
+// prInfo is the per-branch PR/CI summary. Nil fields mean unknown.
+type prInfo struct {
+	number *int
+	status *string
+}
+
+// prInfoMap is keyed by branch. A nil map means gh was not queried.
+type prInfoMap map[string]prInfo
+
+type collectPair struct {
+	detail resolver.WorktreeDetail
+	info   prInfo
+}
 
 const (
 	flagType     = "type"
@@ -29,7 +48,7 @@ const (
 	hintType    = "Filter by prefix type (feature, bugfix, hotfix, etc.)"
 	hintDirty   = "Show only worktrees with uncommitted changes"
 	hintBehind  = "Show only worktrees behind upstream"
-	hintFull    = "Show all columns including branch and path"
+	hintFull    = "Show all columns (branch, path, PR/CI when gh is available)"
 	hintService = "Filter by service name (monorepo)"
 )
 
@@ -43,7 +62,7 @@ type candidate struct {
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all worktrees",
-	Long:  "Lists all git worktrees with task, type, and status. Use --full to show all columns including branch and path.",
+	Long:  "Lists all git worktrees with task, type, and status. Use --full to show branch, path, and (when gh is installed and authenticated) PR number and CI rollup.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := listReadFlags(cmd)
 
@@ -78,7 +97,7 @@ var listCmd = &cobra.Command{
 
 		prefixes := resolver.AllPrefixes()
 		candidates := listBuildCandidates(entries, wtDir, prefixes, opts.typeFilter)
-		rows := listCollectRows(r, candidates, prefixes)
+		rows, prInfos, ghWarning := listCollectAll(cmd.Context(), r, candidates, prefixes, opts.full)
 		rows = operations.FilterDetailsByStatus(rows, opts.dirty, opts.behind)
 		rows = resolver.FilterByService(rows, opts.service)
 
@@ -91,9 +110,9 @@ var listCmd = &cobra.Command{
 		resolver.SortDetailsByTask(rows)
 
 		if isJSON(cmd) {
-			return listRenderJSON(cmd, rows)
+			return listRenderJSON(cmd, rows, prInfos)
 		}
-		listRenderTable(cmd, rows, opts.full)
+		listRenderTable(cmd, rows, opts.full, prInfos, ghWarning)
 		return nil
 	},
 }
@@ -203,15 +222,61 @@ func listBuildCandidates(entries []git.WorktreeEntry, wtDir string, prefixes []s
 	return candidates
 }
 
-func listCollectRows(r git.Runner, candidates []candidate, prefixes []string) []resolver.WorktreeDetail {
-	return parallel.Collect(len(candidates), 8, func(i int) resolver.WorktreeDetail {
+// listCollectAll gathers worktree details and, under --full, open PR/CI
+// rollup per branch in parallel. ghWarning is set when --full is requested
+// but gh is missing or unauthenticated.
+func listCollectAll(ctx context.Context, r git.Runner, candidates []candidate, prefixes []string, full bool) (rows []resolver.WorktreeDetail, prInfos prInfoMap, ghWarning string) {
+	var ghRunner gh.Runner
+	if full {
+		ghRunner = gh.Default()
+		if err := gh.CheckAuth(ctx, ghRunner); err != nil {
+			ghWarning = "gh unavailable; PR/CI columns blank"
+			ghRunner = nil
+		} else {
+			prInfos = make(prInfoMap, len(candidates))
+		}
+	}
+
+	results := parallel.Collect(len(candidates), 8, func(i int) collectPair {
 		c := candidates[i]
 		status := operations.CollectWorktreeStatus(r, c.entry.Path)
-		return resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)
+		d := resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)
+		var info prInfo
+		if ghRunner != nil {
+			info = queryPRInfo(ctx, ghRunner, c.entry.Branch)
+		}
+		return collectPair{detail: d, info: info}
 	})
+
+	rows = make([]resolver.WorktreeDetail, len(results))
+	for i, res := range results {
+		rows[i] = res.detail
+		if prInfos != nil {
+			prInfos[res.detail.Branch] = res.info
+		}
+	}
+	return rows, prInfos, ghWarning
 }
 
-func listRenderJSON(cmd *cobra.Command, rows []resolver.WorktreeDetail) error {
+// queryPRInfo runs one gh pr list under a timeout. Errors degrade silently
+// so one slow or broken query does not fail the whole table.
+func queryPRInfo(ctx context.Context, ghRunner gh.Runner, branch string) prInfo {
+	qctx, cancel := context.WithTimeout(ctx, prQueryTimeout)
+	defer cancel()
+	pr, err := gh.QueryPRStatus(qctx, ghRunner, branch)
+	if err != nil || pr.Number == 0 {
+		return prInfo{}
+	}
+	n := pr.Number
+	info := prInfo{number: &n}
+	if pr.CIStatus != "" {
+		s := pr.CIStatus
+		info.status = &s
+	}
+	return info
+}
+
+func listRenderJSON(cmd *cobra.Command, rows []resolver.WorktreeDetail, prInfos prInfoMap) error {
 	items := make([]output.ListItem, len(rows))
 	for i, r := range rows {
 		items[i] = output.ListItem{
@@ -223,14 +288,22 @@ func listRenderJSON(cmd *cobra.Command, rows []resolver.WorktreeDetail) error {
 			IsCurrent: r.IsCurrent,
 			Status:    r.Status,
 		}
+		if info, ok := prInfos[r.Branch]; ok {
+			items[i].PRNumber = info.number
+			items[i].CIStatus = info.status
+		}
 	}
 	return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
 }
 
-func listRenderTable(cmd *cobra.Command, rows []resolver.WorktreeDetail, full bool) {
+func listRenderTable(cmd *cobra.Command, rows []resolver.WorktreeDetail, full bool, prInfos prInfoMap, ghWarning string) {
 	hasService := resolver.HasService(rows)
 	noColor, _ := cmd.Flags().GetBool(flagNoColor)
 	p := termcolor.NewPainter(noColor)
+
+	if ghWarning != "" {
+		fmt.Fprintln(cmd.OutOrStdout(), p.Paint(ghWarning, termcolor.Yellow))
+	}
 
 	tbl := termcolor.NewTable(2)
 	tbl.AddRow(listHeader(p, hasService, full)...)
@@ -248,7 +321,12 @@ func listRenderTable(cmd *cobra.Command, rows []resolver.WorktreeDetail, full bo
 		}
 
 		statusCell := colorStatus(p, row.Status)
-		tbl.AddRow(listRow(taskCell, row, typeCell, statusCell, hasService, full)...)
+		cells := listRow(taskCell, row, typeCell, statusCell, hasService, full)
+		if full {
+			info := prInfos[row.Branch]
+			cells = append(cells, formatPRCell(info.number, p), formatCICell(info.status, p))
+		}
+		tbl.AddRow(cells...)
 	}
 
 	tbl.Render(cmd.OutOrStdout())
@@ -262,7 +340,7 @@ func init() {
 	listCmd.Flags().Bool(flagDirty, false, "show only dirty worktrees")
 	listCmd.Flags().Bool(flagBehind, false, "show only worktrees behind upstream")
 	listCmd.Flags().Bool(flagArchived, false, "show archived branches (not in any active worktree)")
-	listCmd.Flags().Bool(flagFull, false, "show all columns including branch and path")
+	listCmd.Flags().Bool(flagFull, false, "show all columns (branch, path, PR/CI when gh is available)")
 
 	listCmd.MarkFlagsMutuallyExclusive(flagArchived, flagType)
 	listCmd.MarkFlagsMutuallyExclusive(flagArchived, flagDirty)
@@ -281,7 +359,6 @@ func init() {
 	})
 }
 
-// listArchivedBranches shows branches not associated with any active worktree.
 func listHeader(p *termcolor.Painter, hasService, full bool) []string {
 	h := []string{p.Paint("TASK", termcolor.Bold)}
 	if hasService {
@@ -292,6 +369,9 @@ func listHeader(p *termcolor.Painter, hasService, full bool) []string {
 		h = append(h, p.Paint("BRANCH", termcolor.Bold), p.Paint("PATH", termcolor.Bold))
 	}
 	h = append(h, p.Paint("STATUS", termcolor.Bold))
+	if full {
+		h = append(h, p.Paint("PR", termcolor.Bold), p.Paint("CI", termcolor.Bold))
+	}
 	return h
 }
 
@@ -307,6 +387,31 @@ func listRow(taskCell string, row resolver.WorktreeDetail, typeCell, statusCell 
 	cells = append(cells, statusCell)
 	return cells
 }
+
+func formatPRCell(n *int, p *termcolor.Painter) string {
+	if n == nil {
+		return p.Paint("–", termcolor.Gray)
+	}
+	return fmt.Sprintf("#%d", *n)
+}
+
+func formatCICell(status *string, p *termcolor.Painter) string {
+	if status == nil {
+		return p.Paint("–", termcolor.Gray)
+	}
+	switch *status {
+	case "SUCCESS":
+		return p.Paint("✓", termcolor.Green)
+	case "PENDING":
+		return p.Paint("●", termcolor.Yellow)
+	case "FAILURE":
+		return p.Paint("✗", termcolor.Red)
+	default:
+		return p.Paint("–", termcolor.Gray)
+	}
+}
+
+// listArchivedBranches shows branches not associated with any active worktree.
 
 func listArchivedBranches(cmd *cobra.Command, r git.Runner, mainBranch string) error {
 	archived, err := operations.ListArchivedBranches(r, mainBranch)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -21,18 +21,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	prQueryTimeout = 10 * time.Second
-
-	ciStatusSuccess = "SUCCESS"
-	ciStatusPending = "PENDING"
-	ciStatusFailure = "FAILURE"
-)
+const prQueryTimeout = 10 * time.Second
 
 // prInfo is the per-branch PR/CI summary. Nil fields mean unknown.
 type prInfo struct {
 	number *int
-	status *string
+	status *gh.CIStatus
 }
 
 // prInfoMap is keyed by branch. A nil map means gh was not queried.
@@ -296,7 +290,10 @@ func listRenderJSON(cmd *cobra.Command, rows []resolver.WorktreeDetail, prInfos 
 		}
 		if info, ok := prInfos[r.Branch]; ok {
 			items[i].PRNumber = info.number
-			items[i].CIStatus = info.status
+			if info.status != nil {
+				s := string(*info.status)
+				items[i].CIStatus = &s
+			}
 		}
 	}
 	return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
@@ -401,16 +398,16 @@ func formatPRCell(n *int, p *termcolor.Painter) string {
 	return fmt.Sprintf("#%d", *n)
 }
 
-func formatCICell(status *string, p *termcolor.Painter) string {
+func formatCICell(status *gh.CIStatus, p *termcolor.Painter) string {
 	if status == nil {
 		return p.Paint("–", termcolor.Gray)
 	}
 	switch *status {
-	case ciStatusSuccess:
+	case gh.CIStatusSuccess:
 		return p.Paint("✓", termcolor.Green)
-	case ciStatusPending:
+	case gh.CIStatusPending:
 		return p.Paint("●", termcolor.Yellow)
-	case ciStatusFailure:
+	case gh.CIStatusFailure:
 		return p.Paint("✗", termcolor.Red)
 	default:
 		return p.Paint("–", termcolor.Gray)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -21,7 +21,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const prQueryTimeout = 10 * time.Second
+const (
+	prQueryTimeout = 10 * time.Second
+
+	ciStatusSuccess = "SUCCESS"
+	ciStatusPending = "PENDING"
+	ciStatusFailure = "FAILURE"
+)
 
 // prInfo is the per-branch PR/CI summary. Nil fields mean unknown.
 type prInfo struct {
@@ -400,11 +406,11 @@ func formatCICell(status *string, p *termcolor.Painter) string {
 		return p.Paint("–", termcolor.Gray)
 	}
 	switch *status {
-	case "SUCCESS":
+	case ciStatusSuccess:
 		return p.Paint("✓", termcolor.Green)
-	case "PENDING":
+	case ciStatusPending:
 		return p.Paint("●", termcolor.Yellow)
-	case "FAILURE":
+	case ciStatusFailure:
 		return p.Paint("✗", termcolor.Red)
 	default:
 		return p.Paint("–", termcolor.Gray)

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/output"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/termcolor"
@@ -884,10 +885,10 @@ func TestFormatPRCell(t *testing.T) {
 
 func TestFormatCICell(t *testing.T) {
 	p := termcolor.NewPainter(true)
-	success, pending, failure, unknown := ciStatusSuccess, ciStatusPending, ciStatusFailure, "WHATEVER"
+	success, pending, failure, unknown := gh.CIStatusSuccess, gh.CIStatusPending, gh.CIStatusFailure, gh.CIStatus("WHATEVER")
 
 	cases := map[string]struct {
-		in   *string
+		in   *gh.CIStatus
 		want string
 	}{
 		"nil":     {nil, "–"},
@@ -909,7 +910,7 @@ func TestListRenderTableFullWithPRInfo(t *testing.T) {
 		{Task: "a", Branch: "feature/a", Type: "feature", Path: "/wt/a", Status: resolver.WorktreeStatus{}},
 	}
 	n := 777
-	s := "SUCCESS"
+	s := gh.CIStatusSuccess
 	info := prInfoMap{"feature/a": {number: &n, status: &s}}
 
 	listRenderTable(cmd, rows, true, info, "gh unavailable; PR/CI columns blank")
@@ -927,7 +928,7 @@ func TestListRenderJSONPopulatesPRInfo(t *testing.T) {
 		{Task: "a", Branch: "feature/a", Type: "feature", Path: "/wt/a"},
 	}
 	n := 9
-	s := "PENDING"
+	s := gh.CIStatusPending
 	info := prInfoMap{"feature/a": {number: &n, status: &s}}
 	if err := listRenderJSON(cmd, rows, info); err != nil {
 		t.Fatalf("listRenderJSON: %v", err)

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -848,9 +848,9 @@ func TestListRenderTableWithFullAndService(t *testing.T) {
 		{Task: "foo", Branch: "feature/foo", Type: "feature", Path: "/wt/foo", Service: "web", IsCurrent: true, Status: resolver.WorktreeStatus{}},
 		{Task: "bar", Branch: "bugfix/bar", Type: "bugfix", Path: "/wt/bar", Status: resolver.WorktreeStatus{Dirty: true}},
 	}
-	listRenderTable(cmd, rows, true)
+	listRenderTable(cmd, rows, true, nil, "")
 	out := buf.String()
-	for _, want := range []string{"foo", "bar", "feature/foo", "bugfix/bar", "SERVICE", "BRANCH", "PATH"} {
+	for _, want := range []string{"foo", "bar", "feature/foo", "bugfix/bar", "SERVICE", "BRANCH", "PATH", "PR", "CI"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("want %q in output: %s", want, out)
 		}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -4,14 +4,28 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/output"
 	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/internal/termcolor"
 	"github.com/spf13/cobra"
 )
+
+var errSentinel = errors.New("sentinel")
+
+// ghMockRunner implements gh.Runner for list tests.
+type ghMockRunner struct {
+	out []byte
+	err error
+}
+
+func (m *ghMockRunner) Run(_ context.Context, _ ...string) ([]byte, error) {
+	return m.out, m.err
+}
 
 func newListTestCmd() (*cobra.Command, *bytes.Buffer) {
 	cmd, buf := newTestCmd()
@@ -854,5 +868,111 @@ func TestListRenderTableWithFullAndService(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("want %q in output: %s", want, out)
 		}
+	}
+}
+
+func TestFormatPRCell(t *testing.T) {
+	p := termcolor.NewPainter(true)
+	if got := formatPRCell(nil, p); got != "–" {
+		t.Errorf("nil: got %q, want –", got)
+	}
+	n := 412
+	if got := formatPRCell(&n, p); got != "#412" {
+		t.Errorf("412: got %q, want #412", got)
+	}
+}
+
+func TestFormatCICell(t *testing.T) {
+	p := termcolor.NewPainter(true)
+	success, pending, failure, unknown := ciStatusSuccess, ciStatusPending, ciStatusFailure, "WHATEVER"
+
+	cases := map[string]struct {
+		in   *string
+		want string
+	}{
+		"nil":     {nil, "–"},
+		"success": {&success, "✓"},
+		"pending": {&pending, "●"},
+		"failure": {&failure, "✗"},
+		"unknown": {&unknown, "–"},
+	}
+	for name, tc := range cases {
+		if got := formatCICell(tc.in, p); got != tc.want {
+			t.Errorf("%s: got %q, want %q", name, got, tc.want)
+		}
+	}
+}
+
+func TestListRenderTableFullWithPRInfo(t *testing.T) {
+	cmd, buf := newListTestCmd()
+	rows := []resolver.WorktreeDetail{
+		{Task: "a", Branch: "feature/a", Type: "feature", Path: "/wt/a", Status: resolver.WorktreeStatus{}},
+	}
+	n := 777
+	s := "SUCCESS"
+	info := prInfoMap{"feature/a": {number: &n, status: &s}}
+
+	listRenderTable(cmd, rows, true, info, "gh unavailable; PR/CI columns blank")
+	out := buf.String()
+	for _, want := range []string{"#777", "✓", "gh unavailable"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("want %q in output: %s", want, out)
+		}
+	}
+}
+
+func TestListRenderJSONPopulatesPRInfo(t *testing.T) {
+	cmd, buf := newListTestCmd()
+	rows := []resolver.WorktreeDetail{
+		{Task: "a", Branch: "feature/a", Type: "feature", Path: "/wt/a"},
+	}
+	n := 9
+	s := "PENDING"
+	info := prInfoMap{"feature/a": {number: &n, status: &s}}
+	if err := listRenderJSON(cmd, rows, info); err != nil {
+		t.Fatalf("listRenderJSON: %v", err)
+	}
+	var payload struct {
+		Data []output.ListItem `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(payload.Data) != 1 {
+		t.Fatalf("got %d items, want 1", len(payload.Data))
+	}
+	got := payload.Data[0]
+	if got.PRNumber == nil || *got.PRNumber != 9 {
+		t.Errorf("PRNumber = %v, want 9", got.PRNumber)
+	}
+	if got.CIStatus == nil || *got.CIStatus != "PENDING" {
+		t.Errorf("CIStatus = %v, want PENDING", got.CIStatus)
+	}
+}
+
+func TestQueryPRInfoNoOpenPR(t *testing.T) {
+	r := &ghMockRunner{out: []byte("[]"), err: nil}
+	got := queryPRInfo(context.Background(), r, "feature/x")
+	if got.number != nil || got.status != nil {
+		t.Errorf("expected zero prInfo, got %+v", got)
+	}
+}
+
+func TestQueryPRInfoPopulated(t *testing.T) {
+	r := &ghMockRunner{out: []byte(`[{"number":42,"statusCheckRollup":[{"conclusion":"SUCCESS"}]}]`), err: nil}
+	got := queryPRInfo(context.Background(), r, "feature/x")
+	if got.number == nil || *got.number != 42 {
+		t.Errorf("number = %v, want 42", got.number)
+	}
+	if got.status == nil || *got.status != "SUCCESS" {
+		t.Errorf("status = %v, want SUCCESS", got.status)
+	}
+}
+
+func TestQueryPRInfoErrorDegrades(t *testing.T) {
+	r := &ghMockRunner{err: errSentinel}
+	got := queryPRInfo(context.Background(), r, "feature/x")
+	if got.number != nil || got.status != nil {
+		t.Errorf("expected zero prInfo on error, got %+v", got)
 	}
 }

--- a/internal/gh/pr_status.go
+++ b/internal/gh/pr_status.go
@@ -1,0 +1,67 @@
+package gh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// PRStatus is the open PR for a branch. Zero value means no open PR.
+type PRStatus struct {
+	Number   int
+	CIStatus string
+}
+
+type prCheck struct {
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+type prListEntry struct {
+	Number            int       `json:"number"`
+	StatusCheckRollup []prCheck `json:"statusCheckRollup"`
+}
+
+// QueryPRStatus returns the open PR and CI rollup for branch.
+// No open PR returns the zero PRStatus with a nil error.
+func QueryPRStatus(ctx context.Context, r Runner, branch string) (PRStatus, error) {
+	out, err := r.Run(ctx, "pr", "list", "--head", branch, "--state", "open", "--json", "number,statusCheckRollup", "--limit", "1")
+	if err != nil {
+		return PRStatus{}, err
+	}
+	var entries []prListEntry
+	if err := json.Unmarshal(out, &entries); err != nil {
+		return PRStatus{}, fmt.Errorf("parse gh pr list: %w", err)
+	}
+	if len(entries) == 0 {
+		return PRStatus{}, nil
+	}
+	e := entries[0]
+	return PRStatus{Number: e.Number, CIStatus: reduceRollup(e.StatusCheckRollup)}, nil
+}
+
+func reduceRollup(checks []prCheck) string {
+	if len(checks) == 0 {
+		return ""
+	}
+	failure := map[string]bool{
+		"FAILURE": true, "ERROR": true, "TIMED_OUT": true,
+		"CANCELLED": true, "ACTION_REQUIRED": true,
+	}
+	pending := map[string]bool{
+		"IN_PROGRESS": true, "QUEUED": true, "WAITING": true, "PENDING": true,
+	}
+	sawPending := false
+	for _, c := range checks {
+		if failure[c.Conclusion] {
+			return "FAILURE"
+		}
+		if pending[c.Status] {
+			sawPending = true
+		}
+	}
+	if sawPending {
+		return "PENDING"
+	}
+	return "SUCCESS"
+}

--- a/internal/gh/pr_status.go
+++ b/internal/gh/pr_status.go
@@ -6,10 +6,21 @@ import (
 	"fmt"
 )
 
+// CIStatus is the aggregated CI rollup state for a PR.
+type CIStatus string
+
+// Rollup states reduceRollup can produce. An empty CIStatus means
+// "no checks reported" (distinct from "no PR").
+const (
+	CIStatusSuccess CIStatus = "SUCCESS"
+	CIStatusPending CIStatus = "PENDING"
+	CIStatusFailure CIStatus = "FAILURE"
+)
+
 // PRStatus is the open PR for a branch. Zero value means no open PR.
 type PRStatus struct {
 	Number   int
-	CIStatus string
+	CIStatus CIStatus
 }
 
 type prCheck struct {
@@ -21,6 +32,23 @@ type prListEntry struct {
 	Number            int       `json:"number"`
 	StatusCheckRollup []prCheck `json:"statusCheckRollup"`
 }
+
+// Raw gh rollup states grouped by how reduceRollup collapses them.
+var (
+	failureConclusions = map[string]bool{
+		"FAILURE":         true,
+		"ERROR":           true,
+		"TIMED_OUT":       true,
+		"CANCELLED":       true,
+		"ACTION_REQUIRED": true,
+	}
+	pendingStatuses = map[string]bool{
+		"IN_PROGRESS": true,
+		"QUEUED":      true,
+		"WAITING":     true,
+		"PENDING":     true,
+	}
+)
 
 // QueryPRStatus returns the open PR and CI rollup for branch.
 // No open PR returns the zero PRStatus with a nil error.
@@ -40,28 +68,21 @@ func QueryPRStatus(ctx context.Context, r Runner, branch string) (PRStatus, erro
 	return PRStatus{Number: e.Number, CIStatus: reduceRollup(e.StatusCheckRollup)}, nil
 }
 
-func reduceRollup(checks []prCheck) string {
+func reduceRollup(checks []prCheck) CIStatus {
 	if len(checks) == 0 {
 		return ""
 	}
-	failure := map[string]bool{
-		"FAILURE": true, "ERROR": true, "TIMED_OUT": true,
-		"CANCELLED": true, "ACTION_REQUIRED": true,
-	}
-	pending := map[string]bool{
-		"IN_PROGRESS": true, "QUEUED": true, "WAITING": true, "PENDING": true,
-	}
 	sawPending := false
 	for _, c := range checks {
-		if failure[c.Conclusion] {
-			return "FAILURE"
+		if failureConclusions[c.Conclusion] {
+			return CIStatusFailure
 		}
-		if pending[c.Status] {
+		if pendingStatuses[c.Status] {
 			sawPending = true
 		}
 	}
 	if sawPending {
-		return "PENDING"
+		return CIStatusPending
 	}
-	return "SUCCESS"
+	return CIStatusSuccess
 }

--- a/internal/gh/pr_status_test.go
+++ b/internal/gh/pr_status_test.go
@@ -1,0 +1,150 @@
+package gh
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+const statusFailure = "FAILURE"
+
+func TestQueryPRStatusNoOpenPR(t *testing.T) {
+	runner := &mockRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return []byte("[]\n"), nil
+		},
+	}
+
+	got, err := QueryPRStatus(context.Background(), runner, "feature/none")
+	if err != nil {
+		t.Fatalf("QueryPRStatus() err = %v, want nil", err)
+	}
+	if (got != PRStatus{}) {
+		t.Errorf("QueryPRStatus() = %+v, want zero value", got)
+	}
+}
+
+func TestQueryPRStatusSuccessRollup(t *testing.T) {
+	runner := &mockRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return []byte(`[{"number":412,"statusCheckRollup":[{"conclusion":"SUCCESS"},{"conclusion":"SUCCESS"}]}]`), nil
+		},
+	}
+
+	got, err := QueryPRStatus(context.Background(), runner, "feature/auth")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	want := PRStatus{Number: 412, CIStatus: "SUCCESS"}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestQueryPRStatusPendingRollup(t *testing.T) {
+	runner := &mockRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return []byte(`[{"number":418,"statusCheckRollup":[{"conclusion":"SUCCESS"},{"status":"IN_PROGRESS"}]}]`), nil
+		},
+	}
+
+	got, err := QueryPRStatus(context.Background(), runner, "fix/race")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got.CIStatus != "PENDING" || got.Number != 418 {
+		t.Errorf("got %+v, want PENDING #418", got)
+	}
+}
+
+func TestQueryPRStatusFailureWins(t *testing.T) {
+	runner := &mockRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return []byte(`[{"number":501,"statusCheckRollup":[{"conclusion":"SUCCESS"},{"conclusion":"FAILURE"},{"status":"IN_PROGRESS"}]}]`), nil
+		},
+	}
+
+	got, err := QueryPRStatus(context.Background(), runner, "pr/501")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got.CIStatus != statusFailure {
+		t.Errorf("got %+v, want FAILURE", got)
+	}
+}
+
+func TestQueryPRStatusEmptyRollup(t *testing.T) {
+	runner := &mockRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return []byte(`[{"number":999,"statusCheckRollup":[]}]`), nil
+		},
+	}
+
+	got, err := QueryPRStatus(context.Background(), runner, "some")
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	want := PRStatus{Number: 999, CIStatus: ""}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestQueryPRStatusInvalidJSON(t *testing.T) {
+	runner := &mockRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return []byte("not json"), nil
+		},
+	}
+
+	_, err := QueryPRStatus(context.Background(), runner, "x")
+	if err == nil {
+		t.Fatal("expected parse error, got nil")
+	}
+}
+
+func TestQueryPRStatusRunnerError(t *testing.T) {
+	runner := &mockRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return nil, errors.New("exit 1")
+		},
+	}
+
+	_, err := QueryPRStatus(context.Background(), runner, "x")
+	if err == nil {
+		t.Fatal("expected runner error, got nil")
+	}
+}
+
+func TestQueryPRStatusArgsPassedToRunner(t *testing.T) {
+	var captured []string
+	runner := &mockRunner{
+		run: func(_ context.Context, args ...string) ([]byte, error) {
+			captured = args
+			return []byte("[]"), nil
+		},
+	}
+
+	if _, err := QueryPRStatus(context.Background(), runner, "feature/x"); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+
+	want := []string{"pr", "list", "--head", "feature/x", "--state", "open", "--json", "number,statusCheckRollup", "--limit", "1"}
+	if !reflect.DeepEqual(captured, want) {
+		t.Errorf("args = %v, want %v", captured, want)
+	}
+}
+
+func TestQueryPRStatusActionRequiredMapsToFailure(t *testing.T) {
+	runner := &mockRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return []byte(`[{"number":7,"statusCheckRollup":[{"conclusion":"ACTION_REQUIRED"}]}]`), nil
+		},
+	}
+
+	got, _ := QueryPRStatus(context.Background(), runner, "x")
+	if got.CIStatus != statusFailure {
+		t.Errorf("ACTION_REQUIRED: got %s, want FAILURE", got.CIStatus)
+	}
+}

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -3,6 +3,8 @@ package output
 import "github.com/lugassawan/rimba/internal/resolver"
 
 // ListItem represents a worktree entry in JSON output.
+// PRNumber and CIStatus are set under --full when gh is available;
+// nil (omitted) means unknown.
 type ListItem struct {
 	Task      string                  `json:"task"`
 	Service   string                  `json:"service,omitempty"`
@@ -11,6 +13,8 @@ type ListItem struct {
 	Path      string                  `json:"path"`
 	IsCurrent bool                    `json:"is_current"`
 	Status    resolver.WorktreeStatus `json:"status"`
+	PRNumber  *int                    `json:"pr_number,omitempty"`
+	CIStatus  *string                 `json:"ci_status,omitempty"`
 }
 
 // ListArchivedItem represents an archived branch in JSON output.

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -3,8 +3,7 @@ package output
 import "github.com/lugassawan/rimba/internal/resolver"
 
 // ListItem represents a worktree entry in JSON output.
-// PRNumber and CIStatus are set under --full when gh is available;
-// nil (omitted) means unknown.
+// PRNumber and CIStatus are set under --full; nil means unknown.
 type ListItem struct {
 	Task      string                  `json:"task"`
 	Service   string                  `json:"service,omitempty"`

--- a/tests/e2e/list_full_test.go
+++ b/tests/e2e/list_full_test.go
@@ -1,0 +1,210 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ghStubScript is a fake `gh` that answers `auth status` and `pr list`
+// from files in $GH_STUB_DIR. An `unauth` file flips auth to exit 1.
+const ghStubScript = `#!/bin/sh
+case "$1" in
+  auth)
+    if [ -f "$GH_STUB_DIR/unauth" ]; then
+      echo "not logged in" >&2
+      exit 1
+    fi
+    echo "Logged in"
+    exit 0
+    ;;
+  pr)
+    branch="$4"
+    f="$GH_STUB_DIR/pr_$branch.json"
+    if [ -f "$f" ]; then
+      cat "$f"
+    else
+      echo "[]"
+    fi
+    exit 0
+    ;;
+esac
+echo "unexpected gh invocation: $*" >&2
+exit 2
+`
+
+// stubGh installs ghStubScript as `gh` on a fresh dir and returns a PATH
+// env entry that prepends it.
+func stubGh(t *testing.T) (dir string, env []string) {
+	t.Helper()
+	dir = t.TempDir()
+	path := filepath.Join(dir, "gh")
+	if err := os.WriteFile(path, []byte(ghStubScript), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	env = []string{"PATH=" + dir + string(os.PathListSeparator) + os.Getenv("PATH")}
+	return dir, env
+}
+
+// writeStubPR writes the JSON response for one branch. Slashes in branch
+// names become subdirectories under stubDir.
+func writeStubPR(t *testing.T, stubDir, branch, content string) {
+	t.Helper()
+	p := filepath.Join(stubDir, "pr_"+branch+".json")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+}
+
+func TestListFullWithGhStubShowsPRAndCI(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "feat-auth")
+	rimbaSuccess(t, repo, "add", "feat-pending")
+	rimbaSuccess(t, repo, "add", "feat-failing")
+	rimbaSuccess(t, repo, "add", "feat-nopr")
+
+	stubDir, env := stubGh(t)
+	env = append(env, "GH_STUB_DIR="+stubDir)
+
+	writeStubPR(t, stubDir, "feature/feat-auth",
+		`[{"number":412,"statusCheckRollup":[{"conclusion":"SUCCESS"}]}]`)
+	writeStubPR(t, stubDir, "feature/feat-pending",
+		`[{"number":418,"statusCheckRollup":[{"conclusion":"SUCCESS"},{"status":"IN_PROGRESS"}]}]`)
+	writeStubPR(t, stubDir, "feature/feat-failing",
+		`[{"number":501,"statusCheckRollup":[{"conclusion":"FAILURE"}]}]`)
+
+	r := rimbaWithEnv(t, repo, env, "list", "--full")
+	if r.ExitCode != 0 {
+		t.Fatalf("exit = %d\nstdout: %s\nstderr: %s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+
+	for _, want := range []string{"PR", "CI", "#412", "#418", "●", "#501", "✗"} {
+		assertContains(t, r.Stdout, want)
+	}
+	if !strings.Contains(r.Stdout, "feat-nopr") {
+		t.Errorf("expected feat-nopr row in:\n%s", r.Stdout)
+	}
+}
+
+func TestListFullWithGhStubJSONEmitsPRFields(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "feat-json")
+
+	stubDir, env := stubGh(t)
+	env = append(env, "GH_STUB_DIR="+stubDir)
+	writeStubPR(t, stubDir, "feature/feat-json",
+		`[{"number":777,"statusCheckRollup":[{"conclusion":"SUCCESS"}]}]`)
+
+	r := rimbaWithEnv(t, repo, env, "list", "--full", "--json")
+	if r.ExitCode != 0 {
+		t.Fatalf("exit = %d\nstdout: %s\nstderr: %s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+
+	var payload struct {
+		Data []struct {
+			Task     string  `json:"task"`
+			PRNumber *int    `json:"pr_number"`
+			CIStatus *string `json:"ci_status"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(r.Stdout), &payload); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, r.Stdout)
+	}
+
+	var match bool
+	for _, row := range payload.Data {
+		if row.Task == "feat-json" {
+			match = true
+			if row.PRNumber == nil || *row.PRNumber != 777 {
+				t.Errorf("pr_number = %v, want 777", row.PRNumber)
+			}
+			if row.CIStatus == nil || *row.CIStatus != "SUCCESS" {
+				t.Errorf("ci_status = %v, want SUCCESS", row.CIStatus)
+			}
+		}
+	}
+	if !match {
+		t.Errorf("feat-json row missing; payload: %+v", payload)
+	}
+}
+
+func TestListFullWarnsWhenGhUnauthenticated(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "feat-unauth")
+
+	stubDir, env := stubGh(t)
+	env = append(env, "GH_STUB_DIR="+stubDir)
+	if err := os.WriteFile(filepath.Join(stubDir, "unauth"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := rimbaWithEnv(t, repo, env, "list", "--full")
+	if r.ExitCode != 0 {
+		t.Fatalf("exit = %d\nstdout: %s\nstderr: %s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+
+	assertContains(t, r.Stdout, "gh unavailable")
+	for _, want := range []string{"PR", "CI", "feat-unauth"} {
+		assertContains(t, r.Stdout, want)
+	}
+}
+
+func TestListFullJSONOmitsCIStatusWhenNoChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "feat-nochecks")
+
+	stubDir, env := stubGh(t)
+	env = append(env, "GH_STUB_DIR="+stubDir)
+	writeStubPR(t, stubDir, "feature/feat-nochecks",
+		`[{"number":42,"statusCheckRollup":[]}]`)
+
+	r := rimbaWithEnv(t, repo, env, "list", "--full", "--json")
+	if r.ExitCode != 0 {
+		t.Fatalf("exit = %d\nstdout: %s\nstderr: %s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+
+	if strings.Contains(r.Stdout, `"ci_status"`) {
+		t.Errorf("expected ci_status omitted when rollup empty:\n%s", r.Stdout)
+	}
+	if !strings.Contains(r.Stdout, `"pr_number": 42`) {
+		t.Errorf("expected pr_number 42 in output:\n%s", r.Stdout)
+	}
+}
+
+func TestListJSONOmitsPRFieldsWithoutFullFlag(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "no-full-task")
+
+	r := rimbaSuccess(t, repo, "list", "--json")
+	if strings.Contains(r.Stdout, "pr_number") {
+		t.Errorf("pr_number should be absent without --full:\n%s", r.Stdout)
+	}
+	if strings.Contains(r.Stdout, "ci_status") {
+		t.Errorf("ci_status should be absent without --full:\n%s", r.Stdout)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #126.

Extends `rimba list --full` to show the open PR number and a glyph-encoded CI rollup per worktree, using the `internal/gh/` package (from #130) for availability/auth detection. Queries run in parallel via the existing `parallel.Collect(8)` pattern.

- `PR` column: `#NNNN` for an open PR, `–` otherwise
- `CI` column: `✓` success (green), `●` pending (yellow), `✗` failure (red), `–` for no PR / unknown

When `gh` is missing or unauthenticated, a single warning line prints above the table (`gh unavailable; PR/CI columns blank`) and both columns render `–`. Per-row query errors and timeouts degrade silently — one slow branch never blocks the whole table. JSON sets `pr_number` / `ci_status` only when the data is known; they stay omitted without `--full` or when gh is unavailable.

## Deviations from the issue body

- **File placed at `internal/gh/pr_status.go`** (not `internal/git/`) — it shells out to `gh`, reuses `gh.Runner`, and lives alongside `CheckAuth`. Keeps the `git` package focused on the `git` binary.
- **`--full` extends, not replaces**. Existing `BRANCH` / `PATH` columns stay (added in #94). PR/CI append after `STATUS` when `--full` is set.

## Test Plan

- [x] `make fmt` — clean
- [x] `make lint` — 0 issues
- [x] `go test ./...` — 1447/1447 pass
- [x] `make test-e2e` — all suites pass, including 5 new `list_full_test.go` tests
- [x] Unit tests cover `reduceRollup` matrix (SUCCESS / PENDING / FAILURE / empty / ACTION_REQUIRED) via `mockRunner`
- [x] E2e tests cover table rendering, JSON output, gh-unauthenticated warning, empty-rollup JSON omission, and back-compat without `--full`