### PR TITLE
[refactor] Extract operations.ListWorktrees use case shared by cmd and MCP

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/gh"
@@ -14,28 +12,11 @@ import (
 	"github.com/lugassawan/rimba/internal/hint"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
-	"github.com/lugassawan/rimba/internal/parallel"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/lugassawan/rimba/internal/termcolor"
 	"github.com/spf13/cobra"
 )
-
-const prQueryTimeout = 10 * time.Second
-
-// prInfo is the per-branch PR/CI summary. Nil fields mean unknown.
-type prInfo struct {
-	number *int
-	status *gh.CIStatus
-}
-
-// prInfoMap is keyed by branch. A nil map means gh was not queried.
-type prInfoMap map[string]prInfo
-
-type collectPair struct {
-	detail resolver.WorktreeDetail
-	info   prInfo
-}
 
 const (
 	flagType     = "type"
@@ -51,13 +32,6 @@ const (
 	hintFull    = "Show all columns (branch, path, PR/CI when gh is available)"
 	hintService = "Filter by service name (monorepo)"
 )
-
-// candidate holds a pre-filtered worktree entry before status collection.
-type candidate struct {
-	entry       git.WorktreeEntry
-	displayPath string
-	isCurrent   bool
-}
 
 var listCmd = &cobra.Command{
 	Use:   "list",
@@ -80,13 +54,16 @@ var listCmd = &cobra.Command{
 		}
 
 		r := newRunner()
-		entries, wtDir, err := listLoadEntries(r, cmd)
+		cfg := config.FromContext(cmd.Context())
+		repoRoot, err := git.MainRepoRoot(r)
 		if err != nil {
 			return err
 		}
+		cwd, _ := os.Getwd()
 
-		if len(entries) == 0 {
-			return listRenderEmpty(cmd, "No worktrees found.")
+		var ghR gh.Runner
+		if opts.full {
+			ghR = gh.Default()
 		}
 
 		listShowHints(cmd)
@@ -95,24 +72,32 @@ var listCmd = &cobra.Command{
 		defer s.Stop()
 		s.Start("Loading worktrees...")
 
-		prefixes := resolver.AllPrefixes()
-		candidates := listBuildCandidates(entries, wtDir, prefixes, opts.typeFilter)
-		rows, prInfos, ghWarning := listCollectAll(cmd.Context(), r, candidates, prefixes, opts.full)
-		rows = operations.FilterDetailsByStatus(rows, opts.dirty, opts.behind)
-		rows = resolver.FilterByService(rows, opts.service)
-
+		res, err := operations.ListWorktrees(cmd.Context(), r, ghR, operations.ListWorktreesRequest{
+			Full:        opts.full,
+			TypeFilter:  opts.typeFilter,
+			Dirty:       opts.dirty,
+			Behind:      opts.behind,
+			Service:     opts.service,
+			CurrentPath: cwd,
+			WorktreeDir: filepath.Join(repoRoot, cfg.WorktreeDir),
+		})
 		s.Stop()
-
-		if len(rows) == 0 {
-			return listRenderEmpty(cmd, "No worktrees match the given filters.")
+		if err != nil {
+			return err
 		}
 
-		resolver.SortDetailsByTask(rows)
+		if len(res.Rows) == 0 {
+			msg := "No worktrees found."
+			if opts.dirty || opts.behind || opts.typeFilter != "" || opts.service != "" {
+				msg = "No worktrees match the given filters."
+			}
+			return listRenderEmpty(cmd, msg)
+		}
 
 		if isJSON(cmd) {
-			return listRenderJSON(cmd, rows, prInfos)
+			return listRenderJSON(cmd, res.Rows, res.PRInfos)
 		}
-		listRenderTable(cmd, rows, opts.full, prInfos, ghWarning)
+		listRenderTable(cmd, res.Rows, opts.full, res.PRInfos, res.GhWarning)
 		return nil
 	},
 }
@@ -155,19 +140,6 @@ func listValidateType(typeFilter string) error {
 	return fmt.Errorf("invalid type %q; valid types: %s", typeFilter, strings.Join(valid, ", "))
 }
 
-func listLoadEntries(r git.Runner, cmd *cobra.Command) ([]git.WorktreeEntry, string, error) {
-	cfg := config.FromContext(cmd.Context())
-	repoRoot, err := git.MainRepoRoot(r)
-	if err != nil {
-		return nil, "", err
-	}
-	entries, err := git.ListWorktrees(r)
-	if err != nil {
-		return nil, "", err
-	}
-	return entries, filepath.Join(repoRoot, cfg.WorktreeDir), nil
-}
-
 func listShowHints(cmd *cobra.Command) {
 	if isJSON(cmd) {
 		return
@@ -179,93 +151,6 @@ func listShowHints(cmd *cobra.Command) {
 		Add(flagDirty, hintDirty).
 		Add(flagBehind, hintBehind).
 		Show()
-}
-
-func listBuildCandidates(entries []git.WorktreeEntry, wtDir string, prefixes []string, typeFilter string) []candidate {
-	cwd, _ := os.Getwd()
-	cwdResolved, _ := filepath.EvalSymlinks(cwd)
-	cwdResolved = filepath.Clean(cwdResolved)
-
-	var candidates []candidate
-	for _, e := range entries {
-		if e.Bare {
-			continue
-		}
-
-		if typeFilter != "" {
-			_, matchedPrefix := resolver.TaskFromBranch(e.Branch, prefixes)
-			entryType := strings.TrimSuffix(matchedPrefix, "/")
-			if entryType != typeFilter {
-				continue
-			}
-		}
-
-		displayPath := e.Path
-		if rel, err := filepath.Rel(wtDir, e.Path); err == nil && len(rel) < len(displayPath) {
-			displayPath = rel
-		}
-
-		entryResolved, _ := filepath.EvalSymlinks(e.Path)
-		entryResolved = filepath.Clean(entryResolved)
-		isCurrent := cwdResolved == entryResolved
-
-		candidates = append(candidates, candidate{entry: e, displayPath: displayPath, isCurrent: isCurrent})
-	}
-	return candidates
-}
-
-// listCollectAll gathers worktree details and, under --full, open PR/CI
-// rollup per branch in parallel. ghWarning is set when --full is requested
-// but gh is missing or unauthenticated.
-func listCollectAll(ctx context.Context, r git.Runner, candidates []candidate, prefixes []string, full bool) (rows []resolver.WorktreeDetail, prInfos prInfoMap, ghWarning string) {
-	var ghRunner gh.Runner
-	if full {
-		ghRunner = gh.Default()
-		if err := gh.CheckAuth(ctx, ghRunner); err != nil {
-			ghWarning = "gh unavailable; PR/CI columns blank"
-			ghRunner = nil
-		} else {
-			prInfos = make(prInfoMap, len(candidates))
-		}
-	}
-
-	results := parallel.Collect(len(candidates), 8, func(i int) collectPair {
-		c := candidates[i]
-		status := operations.CollectWorktreeStatus(r, c.entry.Path)
-		d := resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)
-		var info prInfo
-		if ghRunner != nil {
-			info = queryPRInfo(ctx, ghRunner, c.entry.Branch)
-		}
-		return collectPair{detail: d, info: info}
-	})
-
-	rows = make([]resolver.WorktreeDetail, len(results))
-	for i, res := range results {
-		rows[i] = res.detail
-		if prInfos != nil {
-			prInfos[res.detail.Branch] = res.info
-		}
-	}
-	return rows, prInfos, ghWarning
-}
-
-// queryPRInfo runs one gh pr list under a timeout. Errors degrade silently
-// so one slow or broken query does not fail the whole table.
-func queryPRInfo(ctx context.Context, ghRunner gh.Runner, branch string) prInfo {
-	qctx, cancel := context.WithTimeout(ctx, prQueryTimeout)
-	defer cancel()
-	pr, err := gh.QueryPRStatus(qctx, ghRunner, branch)
-	if err != nil || pr.Number == 0 {
-		return prInfo{}
-	}
-	n := pr.Number
-	info := prInfo{number: &n}
-	if pr.CIStatus != "" {
-		s := pr.CIStatus
-		info.status = &s
-	}
-	return info
 }
 
 func init() {
@@ -296,7 +181,6 @@ func init() {
 }
 
 // listArchivedBranches shows branches not associated with any active worktree.
-
 func listArchivedBranches(cmd *cobra.Command, r git.Runner, mainBranch string) error {
 	archived, err := operations.ListArchivedBranches(r, mainBranch)
 	if err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -181,14 +181,6 @@ func listShowHints(cmd *cobra.Command) {
 		Show()
 }
 
-func listRenderEmpty(cmd *cobra.Command, msg string) error {
-	if isJSON(cmd) {
-		return output.WriteJSON(cmd.OutOrStdout(), version, "list", make([]output.ListItem, 0))
-	}
-	fmt.Fprintln(cmd.OutOrStdout(), msg)
-	return nil
-}
-
 func listBuildCandidates(entries []git.WorktreeEntry, wtDir string, prefixes []string, typeFilter string) []candidate {
 	cwd, _ := os.Getwd()
 	cwdResolved, _ := filepath.EvalSymlinks(cwd)
@@ -276,65 +268,6 @@ func queryPRInfo(ctx context.Context, ghRunner gh.Runner, branch string) prInfo 
 	return info
 }
 
-func listRenderJSON(cmd *cobra.Command, rows []resolver.WorktreeDetail, prInfos prInfoMap) error {
-	items := make([]output.ListItem, len(rows))
-	for i, r := range rows {
-		items[i] = output.ListItem{
-			Task:      r.Task,
-			Service:   r.Service,
-			Type:      r.Type,
-			Branch:    r.Branch,
-			Path:      r.Path,
-			IsCurrent: r.IsCurrent,
-			Status:    r.Status,
-		}
-		if info, ok := prInfos[r.Branch]; ok {
-			items[i].PRNumber = info.number
-			if info.status != nil {
-				s := string(*info.status)
-				items[i].CIStatus = &s
-			}
-		}
-	}
-	return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
-}
-
-func listRenderTable(cmd *cobra.Command, rows []resolver.WorktreeDetail, full bool, prInfos prInfoMap, ghWarning string) {
-	hasService := resolver.HasService(rows)
-	noColor, _ := cmd.Flags().GetBool(flagNoColor)
-	p := termcolor.NewPainter(noColor)
-
-	if ghWarning != "" {
-		fmt.Fprintln(cmd.OutOrStdout(), p.Paint(ghWarning, termcolor.Yellow))
-	}
-
-	tbl := termcolor.NewTable(2)
-	tbl.AddRow(listHeader(p, hasService, full)...)
-
-	for _, row := range rows {
-		taskCell := "  " + row.Task
-		if row.IsCurrent {
-			taskCell = "* " + row.Task
-			taskCell = p.Paint(taskCell, termcolor.Green, termcolor.Bold)
-		}
-
-		typeCell := row.Type
-		if c := typeColor(row.Type); c != "" {
-			typeCell = p.Paint(typeCell, c)
-		}
-
-		statusCell := colorStatus(p, row.Status)
-		cells := listRow(taskCell, row, typeCell, statusCell, hasService, full)
-		if full {
-			info := prInfos[row.Branch]
-			cells = append(cells, formatPRCell(info.number, p), formatCICell(info.status, p))
-		}
-		tbl.AddRow(cells...)
-	}
-
-	tbl.Render(cmd.OutOrStdout())
-}
-
 func init() {
 	rootCmd.AddCommand(listCmd)
 
@@ -360,58 +293,6 @@ func init() {
 		}
 		return types, cobra.ShellCompDirectiveNoFileComp
 	})
-}
-
-func listHeader(p *termcolor.Painter, hasService, full bool) []string {
-	h := []string{p.Paint("TASK", termcolor.Bold)}
-	if hasService {
-		h = append(h, p.Paint("SERVICE", termcolor.Bold))
-	}
-	h = append(h, p.Paint("TYPE", termcolor.Bold))
-	if full {
-		h = append(h, p.Paint("BRANCH", termcolor.Bold), p.Paint("PATH", termcolor.Bold))
-	}
-	h = append(h, p.Paint("STATUS", termcolor.Bold))
-	if full {
-		h = append(h, p.Paint("PR", termcolor.Bold), p.Paint("CI", termcolor.Bold))
-	}
-	return h
-}
-
-func listRow(taskCell string, row resolver.WorktreeDetail, typeCell, statusCell string, hasService, full bool) []string {
-	cells := []string{taskCell}
-	if hasService {
-		cells = append(cells, row.Service)
-	}
-	cells = append(cells, typeCell)
-	if full {
-		cells = append(cells, row.Branch, row.Path)
-	}
-	cells = append(cells, statusCell)
-	return cells
-}
-
-func formatPRCell(n *int, p *termcolor.Painter) string {
-	if n == nil {
-		return p.Paint("–", termcolor.Gray)
-	}
-	return fmt.Sprintf("#%d", *n)
-}
-
-func formatCICell(status *gh.CIStatus, p *termcolor.Painter) string {
-	if status == nil {
-		return p.Paint("–", termcolor.Gray)
-	}
-	switch *status {
-	case gh.CIStatusSuccess:
-		return p.Paint("✓", termcolor.Green)
-	case gh.CIStatusPending:
-		return p.Paint("●", termcolor.Yellow)
-	case gh.CIStatusFailure:
-		return p.Paint("✗", termcolor.Red)
-	default:
-		return p.Paint("–", termcolor.Gray)
-	}
 }
 
 // listArchivedBranches shows branches not associated with any active worktree.

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -102,7 +102,6 @@ var listCmd = &cobra.Command{
 	},
 }
 
-// listOpts holds parsed list flags.
 type listOpts struct {
 	typeFilter string
 	dirty      bool
@@ -180,7 +179,6 @@ func init() {
 	})
 }
 
-// listArchivedBranches shows branches not associated with any active worktree.
 func listArchivedBranches(cmd *cobra.Command, r git.Runner, mainBranch string) error {
 	archived, err := operations.ListArchivedBranches(r, mainBranch)
 	if err != nil {

--- a/cmd/list_render.go
+++ b/cmd/list_render.go
@@ -110,7 +110,6 @@ func listRow(taskCell string, row resolver.WorktreeDetail, typeCell, statusCell 
 	return cells
 }
 
-// formatPRCell renders the PR column. n == 0 means no open PR (shown as dash).
 func formatPRCell(n int, p *termcolor.Painter) string {
 	if n == 0 {
 		return p.Paint("–", termcolor.Gray)
@@ -118,8 +117,6 @@ func formatPRCell(n int, p *termcolor.Painter) string {
 	return fmt.Sprintf("#%d", n)
 }
 
-// formatCICell renders the CI rollup column. Empty status means no checks
-// reported — distinct from "no PR" but rendered the same in the table.
 func formatCICell(status gh.CIStatus, p *termcolor.Painter) string {
 	switch status {
 	case gh.CIStatusSuccess:

--- a/cmd/list_render.go
+++ b/cmd/list_render.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/lugassawan/rimba/internal/gh"
+	"github.com/lugassawan/rimba/internal/output"
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/internal/termcolor"
+	"github.com/spf13/cobra"
+)
+
+func listRenderEmpty(cmd *cobra.Command, msg string) error {
+	if isJSON(cmd) {
+		return output.WriteJSON(cmd.OutOrStdout(), version, "list", make([]output.ListItem, 0))
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), msg)
+	return nil
+}
+
+func listRenderJSON(cmd *cobra.Command, rows []resolver.WorktreeDetail, prInfos prInfoMap) error {
+	items := make([]output.ListItem, len(rows))
+	for i, r := range rows {
+		items[i] = output.ListItem{
+			Task:      r.Task,
+			Service:   r.Service,
+			Type:      r.Type,
+			Branch:    r.Branch,
+			Path:      r.Path,
+			IsCurrent: r.IsCurrent,
+			Status:    r.Status,
+		}
+		if info, ok := prInfos[r.Branch]; ok {
+			items[i].PRNumber = info.number
+			if info.status != nil {
+				s := string(*info.status)
+				items[i].CIStatus = &s
+			}
+		}
+	}
+	return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
+}
+
+func listRenderTable(cmd *cobra.Command, rows []resolver.WorktreeDetail, full bool, prInfos prInfoMap, ghWarning string) {
+	hasService := resolver.HasService(rows)
+	noColor, _ := cmd.Flags().GetBool(flagNoColor)
+	p := termcolor.NewPainter(noColor)
+
+	if ghWarning != "" {
+		fmt.Fprintln(cmd.OutOrStdout(), p.Paint(ghWarning, termcolor.Yellow))
+	}
+
+	tbl := termcolor.NewTable(2)
+	tbl.AddRow(listHeader(p, hasService, full)...)
+
+	for _, row := range rows {
+		taskCell := "  " + row.Task
+		if row.IsCurrent {
+			taskCell = "* " + row.Task
+			taskCell = p.Paint(taskCell, termcolor.Green, termcolor.Bold)
+		}
+
+		typeCell := row.Type
+		if c := typeColor(row.Type); c != "" {
+			typeCell = p.Paint(typeCell, c)
+		}
+
+		statusCell := colorStatus(p, row.Status)
+		cells := listRow(taskCell, row, typeCell, statusCell, hasService, full)
+		if full {
+			info := prInfos[row.Branch]
+			cells = append(cells, formatPRCell(info.number, p), formatCICell(info.status, p))
+		}
+		tbl.AddRow(cells...)
+	}
+
+	tbl.Render(cmd.OutOrStdout())
+}
+
+func listHeader(p *termcolor.Painter, hasService, full bool) []string {
+	h := []string{p.Paint("TASK", termcolor.Bold)}
+	if hasService {
+		h = append(h, p.Paint("SERVICE", termcolor.Bold))
+	}
+	h = append(h, p.Paint("TYPE", termcolor.Bold))
+	if full {
+		h = append(h, p.Paint("BRANCH", termcolor.Bold), p.Paint("PATH", termcolor.Bold))
+	}
+	h = append(h, p.Paint("STATUS", termcolor.Bold))
+	if full {
+		h = append(h, p.Paint("PR", termcolor.Bold), p.Paint("CI", termcolor.Bold))
+	}
+	return h
+}
+
+func listRow(taskCell string, row resolver.WorktreeDetail, typeCell, statusCell string, hasService, full bool) []string {
+	cells := []string{taskCell}
+	if hasService {
+		cells = append(cells, row.Service)
+	}
+	cells = append(cells, typeCell)
+	if full {
+		cells = append(cells, row.Branch, row.Path)
+	}
+	cells = append(cells, statusCell)
+	return cells
+}
+
+func formatPRCell(n *int, p *termcolor.Painter) string {
+	if n == nil {
+		return p.Paint("–", termcolor.Gray)
+	}
+	return fmt.Sprintf("#%d", *n)
+}
+
+func formatCICell(status *gh.CIStatus, p *termcolor.Painter) string {
+	if status == nil {
+		return p.Paint("–", termcolor.Gray)
+	}
+	switch *status {
+	case gh.CIStatusSuccess:
+		return p.Paint("✓", termcolor.Green)
+	case gh.CIStatusPending:
+		return p.Paint("●", termcolor.Yellow)
+	case gh.CIStatusFailure:
+		return p.Paint("✗", termcolor.Red)
+	default:
+		return p.Paint("–", termcolor.Gray)
+	}
+}

--- a/cmd/list_render.go
+++ b/cmd/list_render.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lugassawan/rimba/internal/gh"
+	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/termcolor"
@@ -18,7 +19,7 @@ func listRenderEmpty(cmd *cobra.Command, msg string) error {
 	return nil
 }
 
-func listRenderJSON(cmd *cobra.Command, rows []resolver.WorktreeDetail, prInfos prInfoMap) error {
+func listRenderJSON(cmd *cobra.Command, rows []resolver.WorktreeDetail, prInfos map[string]operations.PRInfo) error {
 	items := make([]output.ListItem, len(rows))
 	for i, r := range rows {
 		items[i] = output.ListItem{
@@ -31,9 +32,12 @@ func listRenderJSON(cmd *cobra.Command, rows []resolver.WorktreeDetail, prInfos 
 			Status:    r.Status,
 		}
 		if info, ok := prInfos[r.Branch]; ok {
-			items[i].PRNumber = info.number
-			if info.status != nil {
-				s := string(*info.status)
+			if info.Number != 0 {
+				n := info.Number
+				items[i].PRNumber = &n
+			}
+			if info.CIStatus != "" {
+				s := string(info.CIStatus)
 				items[i].CIStatus = &s
 			}
 		}
@@ -41,7 +45,7 @@ func listRenderJSON(cmd *cobra.Command, rows []resolver.WorktreeDetail, prInfos 
 	return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
 }
 
-func listRenderTable(cmd *cobra.Command, rows []resolver.WorktreeDetail, full bool, prInfos prInfoMap, ghWarning string) {
+func listRenderTable(cmd *cobra.Command, rows []resolver.WorktreeDetail, full bool, prInfos map[string]operations.PRInfo, ghWarning string) {
 	hasService := resolver.HasService(rows)
 	noColor, _ := cmd.Flags().GetBool(flagNoColor)
 	p := termcolor.NewPainter(noColor)
@@ -69,7 +73,7 @@ func listRenderTable(cmd *cobra.Command, rows []resolver.WorktreeDetail, full bo
 		cells := listRow(taskCell, row, typeCell, statusCell, hasService, full)
 		if full {
 			info := prInfos[row.Branch]
-			cells = append(cells, formatPRCell(info.number, p), formatCICell(info.status, p))
+			cells = append(cells, formatPRCell(info.Number, p), formatCICell(info.CIStatus, p))
 		}
 		tbl.AddRow(cells...)
 	}
@@ -106,18 +110,18 @@ func listRow(taskCell string, row resolver.WorktreeDetail, typeCell, statusCell 
 	return cells
 }
 
-func formatPRCell(n *int, p *termcolor.Painter) string {
-	if n == nil {
+// formatPRCell renders the PR column. n == 0 means no open PR (shown as dash).
+func formatPRCell(n int, p *termcolor.Painter) string {
+	if n == 0 {
 		return p.Paint("–", termcolor.Gray)
 	}
-	return fmt.Sprintf("#%d", *n)
+	return fmt.Sprintf("#%d", n)
 }
 
-func formatCICell(status *gh.CIStatus, p *termcolor.Painter) string {
-	if status == nil {
-		return p.Paint("–", termcolor.Gray)
-	}
-	switch *status {
+// formatCICell renders the CI rollup column. Empty status means no checks
+// reported — distinct from "no PR" but rendered the same in the table.
+func formatCICell(status gh.CIStatus, p *termcolor.Painter) string {
+	switch status {
 	case gh.CIStatusSuccess:
 		return p.Paint("✓", termcolor.Green)
 	case gh.CIStatusPending:

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -4,29 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"strings"
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/gh"
+	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/termcolor"
 	"github.com/spf13/cobra"
 )
-
-var errSentinel = errors.New("sentinel")
-
-// ghMockRunner implements gh.Runner for list tests.
-type ghMockRunner struct {
-	out []byte
-	err error
-}
-
-func (m *ghMockRunner) Run(_ context.Context, _ ...string) ([]byte, error) {
-	return m.out, m.err
-}
 
 func newListTestCmd() (*cobra.Command, *bytes.Buffer) {
 	cmd, buf := newTestCmd()
@@ -778,37 +766,6 @@ func TestListBehindFilterWithMatch(t *testing.T) {
 	}
 }
 
-func TestListLoadEntriesRepoRootError(t *testing.T) {
-	r := &mockRunner{
-		run:      func(_ ...string) (string, error) { return "", errGitFailed },
-		runInDir: noopRunInDir,
-	}
-	cmd, _ := newListTestCmd()
-	cmd.SetContext(config.WithConfig(context.Background(), &config.Config{WorktreeDir: "worktrees"}))
-	if _, _, err := listLoadEntries(r, cmd); err == nil {
-		t.Fatal("expected error")
-	}
-}
-
-func TestListLoadEntriesListError(t *testing.T) {
-	calls := 0
-	r := &mockRunner{
-		run: func(_ ...string) (string, error) {
-			calls++
-			if calls == 1 {
-				return "/repo", nil // MainRepoRoot succeeds
-			}
-			return "", errGitFailed
-		},
-		runInDir: noopRunInDir,
-	}
-	cmd, _ := newListTestCmd()
-	cmd.SetContext(config.WithConfig(context.Background(), &config.Config{WorktreeDir: "worktrees"}))
-	if _, _, err := listLoadEntries(r, cmd); err == nil {
-		t.Fatal("expected list error")
-	}
-}
-
 func TestListValidateTypeEmpty(t *testing.T) {
 	if err := listValidateType(""); err != nil {
 		t.Errorf("expected nil for empty type, got %v", err)
@@ -874,28 +831,26 @@ func TestListRenderTableWithFullAndService(t *testing.T) {
 
 func TestFormatPRCell(t *testing.T) {
 	p := termcolor.NewPainter(true)
-	if got := formatPRCell(nil, p); got != "–" {
-		t.Errorf("nil: got %q, want –", got)
+	if got := formatPRCell(0, p); got != "–" {
+		t.Errorf("0: got %q, want –", got)
 	}
-	n := 412
-	if got := formatPRCell(&n, p); got != "#412" {
+	if got := formatPRCell(412, p); got != "#412" {
 		t.Errorf("412: got %q, want #412", got)
 	}
 }
 
 func TestFormatCICell(t *testing.T) {
 	p := termcolor.NewPainter(true)
-	success, pending, failure, unknown := gh.CIStatusSuccess, gh.CIStatusPending, gh.CIStatusFailure, gh.CIStatus("WHATEVER")
 
 	cases := map[string]struct {
-		in   *gh.CIStatus
+		in   gh.CIStatus
 		want string
 	}{
-		"nil":     {nil, "–"},
-		"success": {&success, "✓"},
-		"pending": {&pending, "●"},
-		"failure": {&failure, "✗"},
-		"unknown": {&unknown, "–"},
+		"empty":   {"", "–"},
+		"success": {gh.CIStatusSuccess, "✓"},
+		"pending": {gh.CIStatusPending, "●"},
+		"failure": {gh.CIStatusFailure, "✗"},
+		"unknown": {gh.CIStatus("WHATEVER"), "–"},
 	}
 	for name, tc := range cases {
 		if got := formatCICell(tc.in, p); got != tc.want {
@@ -909,9 +864,9 @@ func TestListRenderTableFullWithPRInfo(t *testing.T) {
 	rows := []resolver.WorktreeDetail{
 		{Task: "a", Branch: "feature/a", Type: "feature", Path: "/wt/a", Status: resolver.WorktreeStatus{}},
 	}
-	n := 777
-	s := gh.CIStatusSuccess
-	info := prInfoMap{"feature/a": {number: &n, status: &s}}
+	info := map[string]operations.PRInfo{
+		"feature/a": {Number: 777, CIStatus: gh.CIStatusSuccess},
+	}
 
 	listRenderTable(cmd, rows, true, info, "gh unavailable; PR/CI columns blank")
 	out := buf.String()
@@ -927,9 +882,9 @@ func TestListRenderJSONPopulatesPRInfo(t *testing.T) {
 	rows := []resolver.WorktreeDetail{
 		{Task: "a", Branch: "feature/a", Type: "feature", Path: "/wt/a"},
 	}
-	n := 9
-	s := gh.CIStatusPending
-	info := prInfoMap{"feature/a": {number: &n, status: &s}}
+	info := map[string]operations.PRInfo{
+		"feature/a": {Number: 9, CIStatus: gh.CIStatusPending},
+	}
 	if err := listRenderJSON(cmd, rows, info); err != nil {
 		t.Fatalf("listRenderJSON: %v", err)
 	}
@@ -948,32 +903,5 @@ func TestListRenderJSONPopulatesPRInfo(t *testing.T) {
 	}
 	if got.CIStatus == nil || *got.CIStatus != "PENDING" {
 		t.Errorf("CIStatus = %v, want PENDING", got.CIStatus)
-	}
-}
-
-func TestQueryPRInfoNoOpenPR(t *testing.T) {
-	r := &ghMockRunner{out: []byte("[]"), err: nil}
-	got := queryPRInfo(context.Background(), r, "feature/x")
-	if got.number != nil || got.status != nil {
-		t.Errorf("expected zero prInfo, got %+v", got)
-	}
-}
-
-func TestQueryPRInfoPopulated(t *testing.T) {
-	r := &ghMockRunner{out: []byte(`[{"number":42,"statusCheckRollup":[{"conclusion":"SUCCESS"}]}]`), err: nil}
-	got := queryPRInfo(context.Background(), r, "feature/x")
-	if got.number == nil || *got.number != 42 {
-		t.Errorf("number = %v, want 42", got.number)
-	}
-	if got.status == nil || *got.status != "SUCCESS" {
-		t.Errorf("status = %v, want SUCCESS", got.status)
-	}
-}
-
-func TestQueryPRInfoErrorDegrades(t *testing.T) {
-	r := &ghMockRunner{err: errSentinel}
-	got := queryPRInfo(context.Background(), r, "feature/x")
-	if got.number != nil || got.status != nil {
-		t.Errorf("expected zero prInfo on error, got %+v", got)
 	}
 }

--- a/internal/mcp/tool_list.go
+++ b/internal/mcp/tool_list.go
@@ -56,8 +56,6 @@ func handleList(hctx *HandlerContext) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid type %q; valid types: feature, bugfix, hotfix, docs, test, chore", typeFilter)), nil
 		}
 
-		// MCP does not expose --full or mark a current worktree, so ghR is
-		// nil and CurrentPath is empty. The use case owns the rest.
 		res, err := operations.ListWorktrees(ctx, r, nil, operations.ListWorktreesRequest{
 			TypeFilter:  typeFilter,
 			Dirty:       dirty,
@@ -72,7 +70,6 @@ func handleList(hctx *HandlerContext) server.ToolHandlerFunc {
 	}
 }
 
-// detailsToListItems converts worktree details to list items.
 func detailsToListItems(rows []resolver.WorktreeDetail) []listItem {
 	items := make([]listItem, len(rows))
 	for i, row := range rows {
@@ -110,7 +107,6 @@ func handleListArchived(r git.Runner, hctx *HandlerContext) (*mcp.CallToolResult
 	return marshalResult(items)
 }
 
-// configDefault returns the default_source from config, or "" if unset.
 func configDefault(hctx *HandlerContext) string {
 	if hctx.Config != nil {
 		return hctx.Config.DefaultSource
@@ -118,7 +114,6 @@ func configDefault(hctx *HandlerContext) string {
 	return ""
 }
 
-// marshalResult serializes data to JSON and wraps it in a tool result.
 func marshalResult(data any) (*mcp.CallToolResult, error) {
 	b, err := json.Marshal(data)
 	if err != nil {

--- a/internal/mcp/tool_list.go
+++ b/internal/mcp/tool_list.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
-	"github.com/lugassawan/rimba/internal/parallel"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -35,12 +34,6 @@ func registerListTool(s *server.MCPServer, hctx *HandlerContext) {
 	s.AddTool(tool, handleList(hctx))
 }
 
-// listCandidate holds a worktree entry with its display path for list filtering.
-type listCandidate struct {
-	entry       git.WorktreeEntry
-	displayPath string
-}
-
 func handleList(hctx *HandlerContext) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		typeFilter := req.GetString("type", "")
@@ -63,30 +56,19 @@ func handleList(hctx *HandlerContext) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid type %q; valid types: feature, bugfix, hotfix, docs, test, chore", typeFilter)), nil
 		}
 
-		entries, err := git.ListWorktrees(r)
+		// MCP does not expose --full or mark a current worktree, so ghR is
+		// nil and CurrentPath is empty. The use case owns the rest.
+		res, err := operations.ListWorktrees(ctx, r, nil, operations.ListWorktreesRequest{
+			TypeFilter:  typeFilter,
+			Dirty:       dirty,
+			Behind:      behind,
+			WorktreeDir: filepath.Join(hctx.RepoRoot, cfg.WorktreeDir),
+		})
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		if len(entries) == 0 {
-			return marshalResult(make([]listItem, 0))
-		}
-
-		wtDir := filepath.Join(hctx.RepoRoot, cfg.WorktreeDir)
-		prefixes := resolver.AllPrefixes()
-
-		candidates := filterListCandidates(entries, wtDir, typeFilter, prefixes)
-
-		rows := parallel.Collect(len(candidates), 8, func(i int) resolver.WorktreeDetail {
-			c := candidates[i]
-			status := operations.CollectWorktreeStatus(r, c.entry.Path)
-			return resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, false)
-		})
-
-		rows = operations.FilterDetailsByStatus(rows, dirty, behind)
-		resolver.SortDetailsByTask(rows)
-
-		return marshalResult(detailsToListItems(rows))
+		return marshalResult(detailsToListItems(res.Rows))
 	}
 }
 
@@ -104,32 +86,6 @@ func detailsToListItems(rows []resolver.WorktreeDetail) []listItem {
 		}
 	}
 	return items
-}
-
-// filterListCandidates filters worktree entries by type and computes display paths.
-func filterListCandidates(entries []git.WorktreeEntry, wtDir, typeFilter string, prefixes []string) []listCandidate {
-	var candidates []listCandidate
-	for _, e := range entries {
-		if e.Bare {
-			continue
-		}
-
-		if typeFilter != "" {
-			_, matchedPrefix := resolver.TaskFromBranch(e.Branch, prefixes)
-			entryType := strings.TrimSuffix(matchedPrefix, "/")
-			if entryType != typeFilter {
-				continue
-			}
-		}
-
-		displayPath := e.Path
-		if rel, err := filepath.Rel(wtDir, e.Path); err == nil && len(rel) < len(displayPath) {
-			displayPath = rel
-		}
-
-		candidates = append(candidates, listCandidate{entry: e, displayPath: displayPath})
-	}
-	return candidates
 }
 
 func handleListArchived(r git.Runner, hctx *HandlerContext) (*mcp.CallToolResult, error) {

--- a/internal/operations/add_test.go
+++ b/internal/operations/add_test.go
@@ -199,7 +199,7 @@ func TestAddWorktreeWithDeps(t *testing.T) {
 				return "", nil
 			}
 			// ListWorktrees for deps
-			if len(args) > 0 && args[0] == gitCmdWorktree && len(args) > 1 && args[1] == "list" {
+			if len(args) > 0 && args[0] == gitCmdWorktree && len(args) > 1 && args[1] == cmdList {
 				return "worktree " + tmpDir + "\nHEAD abc\nbranch refs/heads/main\n\n", nil
 			}
 			return "", nil

--- a/internal/operations/list_worktrees.go
+++ b/internal/operations/list_worktrees.go
@@ -16,60 +16,43 @@ const (
 	listWorktreesConcurrency = 8
 	prQueryTimeout           = 10 * time.Second
 
-	// GhUnavailableWarning is surfaced when --full is requested but gh is
-	// missing or unauthenticated. Callers render it verbatim.
 	GhUnavailableWarning = "gh unavailable; PR/CI columns blank"
 )
 
 // ListWorktreesRequest configures ListWorktrees.
 type ListWorktreesRequest struct {
-	// Full enables PR/CI lookup. Requires a non-nil ghR; when Full is true
-	// and ghR is nil, the use case behaves as if Full were false.
-	Full bool
-	// TypeFilter keeps only worktrees whose branch prefix matches (e.g. "feature").
-	// Empty string means no filter. Caller validates before passing.
-	TypeFilter string
-	// Dirty keeps only worktrees with uncommitted changes.
-	Dirty bool
-	// Behind keeps only worktrees behind upstream.
-	Behind bool
-	// Service keeps only worktrees with matching service (monorepo).
-	Service string
-	// CurrentPath marks the worktree whose resolved path equals this value as
-	// IsCurrent. Empty string means no worktree is marked.
-	CurrentPath string
-	// WorktreeDir is the absolute directory holding worktrees; used to
-	// compute a relative display path when shorter than the absolute.
-	WorktreeDir string
+	Full        bool   // include PR/CI (requires non-nil ghR)
+	TypeFilter  string // branch prefix, e.g. "feature"
+	Dirty       bool
+	Behind      bool
+	Service     string // monorepo service filter
+	CurrentPath string // marks matching worktree as IsCurrent; "" to skip
+	WorktreeDir string // absolute; used to shorten display paths
 }
 
 // PRInfo is the per-branch PR/CI summary.
 //
-// Three states matter to consumers:
-//   - PRInfos map is nil         → gh not queried (Full off or auth failed)
-//   - PRInfos[branch].Number == 0 → queried, no open PR for this branch
-//   - PRInfos[branch].Number  > 0 → known PR; CIStatus may still be "" when
-//     the PR has no checks reported.
+// Encoding: the PRInfos map is nil when gh was not queried. Within the map,
+// Number == 0 means no open PR for that branch; Number > 0 means a known PR
+// where CIStatus may still be empty (no checks reported).
 type PRInfo struct {
 	Number   int
 	CIStatus gh.CIStatus
 }
 
-// ListWorktreesResult carries the shaped rows plus optional PR data and
-// a user-facing gh warning.
+// ListWorktreesResult carries the shaped rows with optional PR data and a gh warning.
 type ListWorktreesResult struct {
 	Rows      []resolver.WorktreeDetail
 	PRInfos   map[string]PRInfo
 	GhWarning string
 }
 
-// ListWorktrees is the shared pipeline used by `rimba list` and the MCP list
-// tool: candidate filter → optional gh auth check → parallel status (+PR)
-// collection → dirty/behind filter → service filter → sort.
+// ListWorktrees is the shared pipeline for `rimba list` and the MCP list tool:
+// candidate filter → optional gh auth check → parallel status (+PR) collection
+// → dirty/behind filter → service filter → sort.
 //
-// ghR is nil when the caller cannot or does not want to query gh. When
-// req.Full is true and ghR is non-nil but auth fails, the use case falls
-// back to the non-full path and populates GhWarning.
+// Pass ghR=nil to skip PR/CI lookup. When req.Full is true and auth fails, the
+// use case falls back silently and populates GhWarning.
 func ListWorktrees(
 	ctx context.Context,
 	gitR git.Runner,
@@ -98,10 +81,6 @@ func ListWorktrees(
 		}
 	}
 
-	// activeGhR is captured by value into each worker closure below —
-	// reassignment above happens-before goroutine start, but an explicit
-	// local makes the intent obvious and keeps the race detector happy
-	// if the sequence is ever reordered.
 	results := parallel.Collect(len(candidates), listWorktreesConcurrency, func(i int) listWorktreeResult {
 		c := candidates[i]
 		status := CollectWorktreeStatus(gitR, c.entry.Path)
@@ -128,16 +107,12 @@ func ListWorktrees(
 	return ListWorktreesResult{Rows: rows, PRInfos: prInfos, GhWarning: ghWarning}, nil
 }
 
-// listCandidate is a pre-filtered worktree entry paired with its display
-// path and current-worktree marker.
 type listCandidate struct {
 	entry       git.WorktreeEntry
 	displayPath string
 	isCurrent   bool
 }
 
-// listWorktreeResult pairs a resolved detail with its optional PR info
-// during the parallel collect stage.
 type listWorktreeResult struct {
 	detail resolver.WorktreeDetail
 	info   PRInfo

--- a/internal/operations/list_worktrees.go
+++ b/internal/operations/list_worktrees.go
@@ -87,23 +87,28 @@ func ListWorktrees(
 	var (
 		prInfos   map[string]PRInfo
 		ghWarning string
+		activeGhR = ghR
 	)
-	if req.Full && ghR != nil {
-		if err := gh.CheckAuth(ctx, ghR); err != nil {
+	if req.Full && activeGhR != nil {
+		if err := gh.CheckAuth(ctx, activeGhR); err != nil {
 			ghWarning = GhUnavailableWarning
-			ghR = nil
+			activeGhR = nil
 		} else {
 			prInfos = make(map[string]PRInfo, len(candidates))
 		}
 	}
 
+	// activeGhR is captured by value into each worker closure below —
+	// reassignment above happens-before goroutine start, but an explicit
+	// local makes the intent obvious and keeps the race detector happy
+	// if the sequence is ever reordered.
 	results := parallel.Collect(len(candidates), listWorktreesConcurrency, func(i int) listWorktreeResult {
 		c := candidates[i]
 		status := CollectWorktreeStatus(gitR, c.entry.Path)
 		d := resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)
 		var info PRInfo
-		if ghR != nil {
-			info = queryPRInfo(ctx, ghR, c.entry.Branch)
+		if activeGhR != nil {
+			info = queryPRInfo(ctx, activeGhR, c.entry.Branch)
 		}
 		return listWorktreeResult{detail: d, info: info}
 	})

--- a/internal/operations/list_worktrees.go
+++ b/internal/operations/list_worktrees.go
@@ -1,0 +1,188 @@
+package operations
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/lugassawan/rimba/internal/gh"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/parallel"
+	"github.com/lugassawan/rimba/internal/resolver"
+)
+
+const (
+	listWorktreesConcurrency = 8
+	prQueryTimeout           = 10 * time.Second
+
+	// GhUnavailableWarning is surfaced when --full is requested but gh is
+	// missing or unauthenticated. Callers render it verbatim.
+	GhUnavailableWarning = "gh unavailable; PR/CI columns blank"
+)
+
+// ListWorktreesRequest configures ListWorktrees.
+type ListWorktreesRequest struct {
+	// Full enables PR/CI lookup. Requires a non-nil ghR; when Full is true
+	// and ghR is nil, the use case behaves as if Full were false.
+	Full bool
+	// TypeFilter keeps only worktrees whose branch prefix matches (e.g. "feature").
+	// Empty string means no filter. Caller validates before passing.
+	TypeFilter string
+	// Dirty keeps only worktrees with uncommitted changes.
+	Dirty bool
+	// Behind keeps only worktrees behind upstream.
+	Behind bool
+	// Service keeps only worktrees with matching service (monorepo).
+	Service string
+	// CurrentPath marks the worktree whose resolved path equals this value as
+	// IsCurrent. Empty string means no worktree is marked.
+	CurrentPath string
+	// WorktreeDir is the absolute directory holding worktrees; used to
+	// compute a relative display path when shorter than the absolute.
+	WorktreeDir string
+}
+
+// PRInfo is the per-branch PR/CI summary.
+//
+// Three states matter to consumers:
+//   - PRInfos map is nil         → gh not queried (Full off or auth failed)
+//   - PRInfos[branch].Number == 0 → queried, no open PR for this branch
+//   - PRInfos[branch].Number  > 0 → known PR; CIStatus may still be "" when
+//     the PR has no checks reported.
+type PRInfo struct {
+	Number   int
+	CIStatus gh.CIStatus
+}
+
+// ListWorktreesResult carries the shaped rows plus optional PR data and
+// a user-facing gh warning.
+type ListWorktreesResult struct {
+	Rows      []resolver.WorktreeDetail
+	PRInfos   map[string]PRInfo
+	GhWarning string
+}
+
+// ListWorktrees is the shared pipeline used by `rimba list` and the MCP list
+// tool: candidate filter → optional gh auth check → parallel status (+PR)
+// collection → dirty/behind filter → service filter → sort.
+//
+// ghR is nil when the caller cannot or does not want to query gh. When
+// req.Full is true and ghR is non-nil but auth fails, the use case falls
+// back to the non-full path and populates GhWarning.
+func ListWorktrees(
+	ctx context.Context,
+	gitR git.Runner,
+	ghR gh.Runner,
+	req ListWorktreesRequest,
+) (ListWorktreesResult, error) {
+	entries, err := git.ListWorktrees(gitR)
+	if err != nil {
+		return ListWorktreesResult{}, err
+	}
+
+	prefixes := resolver.AllPrefixes()
+	candidates := buildListCandidates(entries, req.WorktreeDir, req.CurrentPath, req.TypeFilter, prefixes)
+
+	var (
+		prInfos   map[string]PRInfo
+		ghWarning string
+	)
+	if req.Full && ghR != nil {
+		if err := gh.CheckAuth(ctx, ghR); err != nil {
+			ghWarning = GhUnavailableWarning
+			ghR = nil
+		} else {
+			prInfos = make(map[string]PRInfo, len(candidates))
+		}
+	}
+
+	results := parallel.Collect(len(candidates), listWorktreesConcurrency, func(i int) listWorktreeResult {
+		c := candidates[i]
+		status := CollectWorktreeStatus(gitR, c.entry.Path)
+		d := resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)
+		var info PRInfo
+		if ghR != nil {
+			info = queryPRInfo(ctx, ghR, c.entry.Branch)
+		}
+		return listWorktreeResult{detail: d, info: info}
+	})
+
+	rows := make([]resolver.WorktreeDetail, len(results))
+	for i, res := range results {
+		rows[i] = res.detail
+		if prInfos != nil {
+			prInfos[res.detail.Branch] = res.info
+		}
+	}
+
+	rows = FilterDetailsByStatus(rows, req.Dirty, req.Behind)
+	rows = resolver.FilterByService(rows, req.Service)
+	resolver.SortDetailsByTask(rows)
+
+	return ListWorktreesResult{Rows: rows, PRInfos: prInfos, GhWarning: ghWarning}, nil
+}
+
+// listCandidate is a pre-filtered worktree entry paired with its display
+// path and current-worktree marker.
+type listCandidate struct {
+	entry       git.WorktreeEntry
+	displayPath string
+	isCurrent   bool
+}
+
+// listWorktreeResult pairs a resolved detail with its optional PR info
+// during the parallel collect stage.
+type listWorktreeResult struct {
+	detail resolver.WorktreeDetail
+	info   PRInfo
+}
+
+func buildListCandidates(entries []git.WorktreeEntry, wtDir, currentPath, typeFilter string, prefixes []string) []listCandidate {
+	currentResolved := ""
+	if currentPath != "" {
+		r, _ := filepath.EvalSymlinks(currentPath)
+		currentResolved = filepath.Clean(r)
+	}
+
+	var candidates []listCandidate
+	for _, e := range entries {
+		if e.Bare {
+			continue
+		}
+
+		if typeFilter != "" {
+			_, matchedPrefix := resolver.TaskFromBranch(e.Branch, prefixes)
+			entryType := strings.TrimSuffix(matchedPrefix, "/")
+			if entryType != typeFilter {
+				continue
+			}
+		}
+
+		displayPath := e.Path
+		if rel, err := filepath.Rel(wtDir, e.Path); err == nil && len(rel) < len(displayPath) {
+			displayPath = rel
+		}
+
+		isCurrent := false
+		if currentResolved != "" {
+			entryResolved, _ := filepath.EvalSymlinks(e.Path)
+			isCurrent = currentResolved == filepath.Clean(entryResolved)
+		}
+
+		candidates = append(candidates, listCandidate{entry: e, displayPath: displayPath, isCurrent: isCurrent})
+	}
+	return candidates
+}
+
+// queryPRInfo runs one gh pr list under a timeout. Errors degrade silently
+// so one slow or broken query does not fail the whole table.
+func queryPRInfo(ctx context.Context, ghR gh.Runner, branch string) PRInfo {
+	qctx, cancel := context.WithTimeout(ctx, prQueryTimeout)
+	defer cancel()
+	pr, err := gh.QueryPRStatus(qctx, ghR, branch)
+	if err != nil || pr.Number == 0 {
+		return PRInfo{}
+	}
+	return PRInfo{Number: pr.Number, CIStatus: pr.CIStatus}
+}

--- a/internal/operations/list_worktrees_test.go
+++ b/internal/operations/list_worktrees_test.go
@@ -1,0 +1,402 @@
+package operations
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/gh"
+)
+
+const (
+	branchBugfixLogin  = "bugfix/login"
+	branchChoreLogout  = "chore/logout"
+	branchFeatureAuth  = "feature/auth"
+	pathWtFeatureAuth  = "/wt/feature-auth"
+	pathWtBugfixLogin  = "/wt/bugfix-login"
+	pathWtChoreLogout  = "/wt/chore-logout"
+	wtDirTest          = "/wt"
+	dirtyStatusFixture = "M file.go"
+	prListEntrySuccess = `[{"number":12,"statusCheckRollup":[{"status":"COMPLETED","conclusion":"SUCCESS"}]}]`
+	prListEntryPending = `[{"number":13,"statusCheckRollup":[{"status":"IN_PROGRESS","conclusion":""}]}]`
+	prListEntryFailure = `[{"number":14,"statusCheckRollup":[{"status":"COMPLETED","conclusion":"FAILURE"}]}]`
+	prListEntryNoCheck = `[{"number":15,"statusCheckRollup":[]}]`
+	prListNoOpenPR     = `[]`
+)
+
+// threeWorktreeRunner returns a git runner preloaded with three worktrees
+// (feature/auth dirty+behind, bugfix/login clean, chore/logout clean).
+func threeWorktreeRunner() *mockRunner {
+	porcelain := porcelainEntries(
+		struct{ path, branch string }{pathWtFeatureAuth, branchFeatureAuth},
+		struct{ path, branch string }{pathWtBugfixLogin, branchBugfixLogin},
+		struct{ path, branch string }{pathWtChoreLogout, branchChoreLogout},
+	)
+	return &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == cmdWorktreeTest && args[1] == cmdList {
+				return porcelain, nil
+			}
+			return "", nil
+		},
+		runInDir: func(dir string, args ...string) (string, error) {
+			if dir != pathWtFeatureAuth {
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdStatus {
+				return dirtyStatusFixture, nil
+			}
+			if len(args) >= 1 && args[0] == "rev-list" {
+				return "2\t0", nil // behind=2, ahead=0
+			}
+			return "", nil
+		},
+	}
+}
+
+// mockGHRunner routes gh calls by args: "auth status" → auth check,
+// "pr list --head <branch>" → PR query.
+type mockGHRunner struct {
+	authErr    error
+	prByBranch map[string]string // branch → raw gh pr list JSON or "" for network err
+	prErr      error             // if non-nil, every pr query fails
+}
+
+func (m *mockGHRunner) Run(_ context.Context, args ...string) ([]byte, error) {
+	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
+		return nil, m.authErr
+	}
+	if len(args) >= 2 && args[0] == "pr" && args[1] == "list" {
+		if m.prErr != nil {
+			return nil, m.prErr
+		}
+		for i, a := range args {
+			if a == "--head" && i+1 < len(args) {
+				branch := args[i+1]
+				if out, ok := m.prByBranch[branch]; ok {
+					return []byte(out), nil
+				}
+				return []byte(prListNoOpenPR), nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// withFakeGhOnPath puts a dummy gh binary on PATH so gh.IsAvailable()
+// returns true. The runner is always mocked so the binary is never executed.
+func withFakeGhOnPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "gh")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestListWorktreesNoFiltersNoFull(t *testing.T) {
+	gitR := threeWorktreeRunner()
+	res, err := ListWorktrees(context.Background(), gitR, nil, ListWorktreesRequest{
+		WorktreeDir: wtDirTest,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if len(res.Rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(res.Rows))
+	}
+	if res.PRInfos != nil {
+		t.Error("PRInfos should be nil when Full=false")
+	}
+	if res.GhWarning != "" {
+		t.Errorf("GhWarning = %q, want empty", res.GhWarning)
+	}
+	// Sorted alphabetically by task: auth, login, logout
+	wantOrder := []string{"auth", "login", "logout"}
+	for i, want := range wantOrder {
+		if res.Rows[i].Task != want {
+			t.Errorf("Rows[%d].Task = %q, want %q", i, res.Rows[i].Task, want)
+		}
+	}
+}
+
+func TestListWorktreesTypeFilter(t *testing.T) {
+	gitR := threeWorktreeRunner()
+	res, err := ListWorktrees(context.Background(), gitR, nil, ListWorktreesRequest{
+		TypeFilter:  "bugfix",
+		WorktreeDir: wtDirTest,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if len(res.Rows) != 1 || res.Rows[0].Branch != branchBugfixLogin {
+		t.Fatalf("want 1 bugfix row, got %+v", res.Rows)
+	}
+}
+
+func TestListWorktreesDirtyFilter(t *testing.T) {
+	gitR := threeWorktreeRunner()
+	res, err := ListWorktrees(context.Background(), gitR, nil, ListWorktreesRequest{
+		Dirty:       true,
+		WorktreeDir: wtDirTest,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if len(res.Rows) != 1 || res.Rows[0].Branch != branchFeatureAuth {
+		t.Fatalf("want 1 dirty row, got %+v", res.Rows)
+	}
+}
+
+func TestListWorktreesBehindFilter(t *testing.T) {
+	gitR := threeWorktreeRunner()
+	res, err := ListWorktrees(context.Background(), gitR, nil, ListWorktreesRequest{
+		Behind:      true,
+		WorktreeDir: wtDirTest,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if len(res.Rows) != 1 || res.Rows[0].Branch != branchFeatureAuth {
+		t.Fatalf("want 1 behind row, got %+v", res.Rows)
+	}
+}
+
+func TestListWorktreesServiceFilter(t *testing.T) {
+	porcelain := porcelainEntries(
+		struct{ path, branch string }{"/wt/auth-api-feature-login", "auth-api/feature/login"},
+		struct{ path, branch string }{"/wt/web-app-feature-login", "web-app/feature/login"},
+	)
+	gitR := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == cmdWorktreeTest && args[1] == cmdList {
+				return porcelain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	res, err := ListWorktrees(context.Background(), gitR, nil, ListWorktreesRequest{
+		Service:     "auth-api",
+		WorktreeDir: wtDirTest,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if len(res.Rows) != 1 || res.Rows[0].Service != "auth-api" {
+		t.Fatalf("want 1 auth-api row, got %+v", res.Rows)
+	}
+}
+
+func TestListWorktreesFullGhUnauth(t *testing.T) {
+	withFakeGhOnPath(t)
+	gitR := threeWorktreeRunner()
+	ghR := &mockGHRunner{authErr: errors.New("unauth")}
+
+	res, err := ListWorktrees(context.Background(), gitR, ghR, ListWorktreesRequest{
+		Full:        true,
+		WorktreeDir: wtDirTest,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if res.GhWarning != GhUnavailableWarning {
+		t.Errorf("GhWarning = %q, want %q", res.GhWarning, GhUnavailableWarning)
+	}
+	if res.PRInfos != nil {
+		t.Error("PRInfos should be nil when gh auth fails")
+	}
+	if len(res.Rows) != 3 {
+		t.Errorf("got %d rows, want 3", len(res.Rows))
+	}
+}
+
+func TestListWorktreesFullGhNoPR(t *testing.T) {
+	withFakeGhOnPath(t)
+	gitR := threeWorktreeRunner()
+	ghR := &mockGHRunner{prByBranch: map[string]string{}}
+
+	res, err := ListWorktrees(context.Background(), gitR, ghR, ListWorktreesRequest{
+		Full:        true,
+		WorktreeDir: wtDirTest,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if res.GhWarning != "" {
+		t.Errorf("GhWarning = %q, want empty", res.GhWarning)
+	}
+	if res.PRInfos == nil {
+		t.Fatal("PRInfos should be non-nil when gh auth succeeds")
+	}
+	for _, row := range res.Rows {
+		info := res.PRInfos[row.Branch]
+		if info.Number != 0 || info.CIStatus != "" {
+			t.Errorf("branch %q: got %+v, want zero PRInfo", row.Branch, info)
+		}
+	}
+}
+
+func TestListWorktreesFullPRRollupStates(t *testing.T) {
+	withFakeGhOnPath(t)
+
+	cases := []struct {
+		name       string
+		prJSON     string
+		wantNumber int
+		wantCI     gh.CIStatus
+	}{
+		{"success", prListEntrySuccess, 12, gh.CIStatusSuccess},
+		{"pending", prListEntryPending, 13, gh.CIStatusPending},
+		{"failure", prListEntryFailure, 14, gh.CIStatusFailure},
+		{"no-checks", prListEntryNoCheck, 15, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gitR := threeWorktreeRunner()
+			ghR := &mockGHRunner{
+				prByBranch: map[string]string{branchFeatureAuth: tc.prJSON},
+			}
+			res, err := ListWorktrees(context.Background(), gitR, ghR, ListWorktreesRequest{
+				Full:        true,
+				WorktreeDir: wtDirTest,
+			})
+			if err != nil {
+				t.Fatalf("ListWorktrees: %v", err)
+			}
+			info := res.PRInfos[branchFeatureAuth]
+			if info.Number != tc.wantNumber {
+				t.Errorf("Number = %d, want %d", info.Number, tc.wantNumber)
+			}
+			if info.CIStatus != tc.wantCI {
+				t.Errorf("CIStatus = %q, want %q", info.CIStatus, tc.wantCI)
+			}
+		})
+	}
+}
+
+func TestListWorktreesFullPRQueryErrorDegradesSilently(t *testing.T) {
+	withFakeGhOnPath(t)
+	gitR := threeWorktreeRunner()
+	ghR := &mockGHRunner{prErr: errors.New("network down")}
+
+	res, err := ListWorktrees(context.Background(), gitR, ghR, ListWorktreesRequest{
+		Full:        true,
+		WorktreeDir: wtDirTest,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	// Every branch ends up with a zero PRInfo (silent degradation).
+	if res.PRInfos == nil {
+		t.Fatal("PRInfos should be non-nil; auth succeeded")
+	}
+	for _, row := range res.Rows {
+		if got := res.PRInfos[row.Branch]; got.Number != 0 {
+			t.Errorf("branch %q: got Number=%d, want 0 under query error", row.Branch, got.Number)
+		}
+	}
+}
+
+func TestListWorktreesFullWithNilGhRunnerSkipsQueries(t *testing.T) {
+	// When Full=true but ghR is nil, use case behaves as Full=false.
+	gitR := threeWorktreeRunner()
+	res, err := ListWorktrees(context.Background(), gitR, nil, ListWorktreesRequest{
+		Full:        true,
+		WorktreeDir: wtDirTest,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if res.PRInfos != nil {
+		t.Error("PRInfos should be nil when ghR is nil")
+	}
+	if res.GhWarning != "" {
+		t.Errorf("GhWarning = %q, want empty (no gh attempted)", res.GhWarning)
+	}
+}
+
+func TestListWorktreesCurrentPathMarksRow(t *testing.T) {
+	// Use a real tmp dir so EvalSymlinks returns the expected path.
+	dir := t.TempDir()
+	wtPath := filepath.Join(dir, "feature-auth")
+	if err := os.Mkdir(wtPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	porcelain := porcelainEntries(
+		struct{ path, branch string }{wtPath, branchFeatureAuth},
+		struct{ path, branch string }{filepath.Join(dir, "bugfix-login"), branchBugfixLogin},
+	)
+	if err := os.Mkdir(filepath.Join(dir, "bugfix-login"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitR := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == cmdWorktreeTest && args[1] == cmdList {
+				return porcelain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	res, err := ListWorktrees(context.Background(), gitR, nil, ListWorktreesRequest{
+		CurrentPath: wtPath,
+		WorktreeDir: dir,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+
+	var currentCount int
+	for _, row := range res.Rows {
+		if row.IsCurrent {
+			currentCount++
+			if row.Branch != branchFeatureAuth {
+				t.Errorf("IsCurrent on %q, want on %q", row.Branch, branchFeatureAuth)
+			}
+		}
+	}
+	if currentCount != 1 {
+		t.Errorf("IsCurrent rows = %d, want 1", currentCount)
+	}
+}
+
+func TestListWorktreesGitListError(t *testing.T) {
+	gitR := &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", errGitFailed },
+		runInDir: noopRunInDir,
+	}
+	_, err := ListWorktrees(context.Background(), gitR, nil, ListWorktreesRequest{})
+	if err == nil {
+		t.Fatal("expected error from git.ListWorktrees")
+	}
+}
+
+func TestListWorktreesSkipsBareEntries(t *testing.T) {
+	porcelain := cmdWorktreeTest + " /repo/.git/worktrees/bare\nHEAD abc\nbare\n\n" +
+		cmdWorktreeTest + " " + pathWtFeatureAuth + "\nHEAD def\nbranch refs/heads/" + branchFeatureAuth + "\n"
+	gitR := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == cmdWorktreeTest && args[1] == cmdList {
+				return porcelain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	res, err := ListWorktrees(context.Background(), gitR, nil, ListWorktreesRequest{
+		WorktreeDir: wtDirTest,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("got %d rows (bare should be skipped), want 1", len(res.Rows))
+	}
+}

--- a/internal/operations/list_worktrees_test.go
+++ b/internal/operations/list_worktrees_test.go
@@ -26,8 +26,7 @@ const (
 	prListNoOpenPR     = `[]`
 )
 
-// threeWorktreeRunner returns a git runner preloaded with three worktrees
-// (feature/auth dirty+behind, bugfix/login clean, chore/logout clean).
+// threeWorktreeRunner preloads feature/auth (dirty+behind), bugfix/login, chore/logout.
 func threeWorktreeRunner() *mockRunner {
 	porcelain := porcelainEntries(
 		struct{ path, branch string }{pathWtFeatureAuth, branchFeatureAuth},
@@ -56,8 +55,7 @@ func threeWorktreeRunner() *mockRunner {
 	}
 }
 
-// mockGHRunner routes gh calls by args: "auth status" → auth check,
-// "pr list --head <branch>" → PR query.
+// mockGHRunner routes "auth status" to authErr and "pr list --head <branch>" to prByBranch.
 type mockGHRunner struct {
 	authErr    error
 	prByBranch map[string]string // branch → raw gh pr list JSON or "" for network err
@@ -114,7 +112,6 @@ func TestListWorktreesNoFiltersNoFull(t *testing.T) {
 	if res.GhWarning != "" {
 		t.Errorf("GhWarning = %q, want empty", res.GhWarning)
 	}
-	// Sorted alphabetically by task: auth, login, logout
 	wantOrder := []string{"auth", "login", "logout"}
 	for i, want := range wantOrder {
 		if res.Rows[i].Task != want {
@@ -281,9 +278,6 @@ func TestListWorktreesFullPRRollupStates(t *testing.T) {
 }
 
 func TestListWorktreesFullComposesWithDirtyFilter(t *testing.T) {
-	// Exercises the parallel collect + PR query path alongside a
-	// post-collect status filter, guarding against regressions where
-	// filtering accidentally drops rows whose PR info was populated.
 	withFakeGhOnPath(t)
 	gitR := threeWorktreeRunner()
 	ghR := &mockGHRunner{
@@ -301,8 +295,7 @@ func TestListWorktreesFullComposesWithDirtyFilter(t *testing.T) {
 	if len(res.Rows) != 1 || res.Rows[0].Branch != branchFeatureAuth {
 		t.Fatalf("want 1 dirty row (feature/auth), got %+v", res.Rows)
 	}
-	// PRInfos still carries entries for all three candidates queried
-	// before the post-collect status filter — this is the contract.
+	// PRInfos carries entries for all candidates queried before the status filter runs.
 	if got := res.PRInfos[branchFeatureAuth]; got.Number != 12 || got.CIStatus != gh.CIStatusSuccess {
 		t.Errorf("PRInfos[feature/auth] = %+v, want {12, SUCCESS}", got)
 	}
@@ -332,7 +325,6 @@ func TestListWorktreesFullPRQueryErrorDegradesSilently(t *testing.T) {
 }
 
 func TestListWorktreesFullWithNilGhRunnerSkipsQueries(t *testing.T) {
-	// When Full=true but ghR is nil, use case behaves as Full=false.
 	gitR := threeWorktreeRunner()
 	res, err := ListWorktrees(context.Background(), gitR, nil, ListWorktreesRequest{
 		Full:        true,
@@ -350,7 +342,7 @@ func TestListWorktreesFullWithNilGhRunnerSkipsQueries(t *testing.T) {
 }
 
 func TestListWorktreesCurrentPathMarksRow(t *testing.T) {
-	// Use a real tmp dir so EvalSymlinks returns the expected path.
+	// Real tmp dir needed so EvalSymlinks resolves to the path we compare against.
 	dir := t.TempDir()
 	wtPath := filepath.Join(dir, "feature-auth")
 	if err := os.Mkdir(wtPath, 0o755); err != nil {

--- a/internal/operations/list_worktrees_test.go
+++ b/internal/operations/list_worktrees_test.go
@@ -280,6 +280,34 @@ func TestListWorktreesFullPRRollupStates(t *testing.T) {
 	}
 }
 
+func TestListWorktreesFullComposesWithDirtyFilter(t *testing.T) {
+	// Exercises the parallel collect + PR query path alongside a
+	// post-collect status filter, guarding against regressions where
+	// filtering accidentally drops rows whose PR info was populated.
+	withFakeGhOnPath(t)
+	gitR := threeWorktreeRunner()
+	ghR := &mockGHRunner{
+		prByBranch: map[string]string{branchFeatureAuth: prListEntrySuccess},
+	}
+
+	res, err := ListWorktrees(context.Background(), gitR, ghR, ListWorktreesRequest{
+		Full:        true,
+		Dirty:       true,
+		WorktreeDir: wtDirTest,
+	})
+	if err != nil {
+		t.Fatalf("ListWorktrees: %v", err)
+	}
+	if len(res.Rows) != 1 || res.Rows[0].Branch != branchFeatureAuth {
+		t.Fatalf("want 1 dirty row (feature/auth), got %+v", res.Rows)
+	}
+	// PRInfos still carries entries for all three candidates queried
+	// before the post-collect status filter — this is the contract.
+	if got := res.PRInfos[branchFeatureAuth]; got.Number != 12 || got.CIStatus != gh.CIStatusSuccess {
+		t.Errorf("PRInfos[feature/auth] = %+v, want {12, SUCCESS}", got)
+	}
+}
+
 func TestListWorktreesFullPRQueryErrorDegradesSilently(t *testing.T) {
 	withFakeGhOnPath(t)
 	gitR := threeWorktreeRunner()

--- a/internal/operations/status_test.go
+++ b/internal/operations/status_test.go
@@ -30,8 +30,8 @@ func TestCollectWorktreeStatusDirty(t *testing.T) {
 	r := &mockRunner{
 		run: func(_ ...string) (string, error) { return "", nil },
 		runInDir: func(_ string, args ...string) (string, error) {
-			if len(args) >= 1 && args[0] == "status" {
-				return "M file.go", nil
+			if len(args) >= 1 && args[0] == gitCmdStatus {
+				return dirtyStatusFixture, nil
 			}
 			return "", nil
 		},


### PR DESCRIPTION
## Summary
- Extract `internal/operations/list_worktrees.go` as a single use case for the data pipeline (candidate filter → optional gh auth check → parallel status/PR collection → dirty/behind filter → service filter → sort). Both `cmd/list.go` and `internal/mcp/tool_list.go` now call it.
- Flat-value `PRInfo{Number int, CIStatus gh.CIStatus}` in the use case; rendering layers convert to `*int`/`*string` at the output boundary. Encodes three states without pointers: nil map = not queried, `Number == 0` = no open PR, `Number > 0` = known PR.
- Extract `cmd/list_render.go` out of `cmd/list.go` — table/JSON rendering + glyph helpers live separately from the command flow. `cmd/list.go` shrinks from 469 → 236 lines.
- MCP tool output shape unchanged (still passes `Full=false`); adding `--full` PR/CI to the MCP surface is now a one-field flip, tracked as a follow-up per the issue's out-of-scope list.

## Test Plan
- [x] Unit tests pass (`make test`) — 1467/1467 across 26 packages
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2e tests pass (`go test ./tests/e2e/`) — 232/232
- [x] Coverage ≥ 97% (`make test-coverage`) — 97.1% total, 100% on the new use case
- [x] Race detector clean on `./internal/operations/`
- [x] Manual smoke plan covered by existing e2e tests: `TestListFullJSONOmitsCIStatusWhenNoChecks`, `TestMonorepoListShowsServiceColumn`, `TestMonorepoListServiceFilter`, `TestStandardListNoServiceColumn` etc. all still pass

Closes #132
