### PR TITLE
[feat] 3-tier agent file installation (user/team/local) replacing --agent-files

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,8 +15,11 @@ import (
 )
 
 const (
-	flagAgentFiles = "agent-files"
-	flagPersonal   = "personal"
+	flagPersonal  = "personal"
+	flagGlobal    = "global"
+	flagAgents    = "agents"
+	flagLocal     = "local"
+	flagUninstall = "uninstall"
 )
 
 var initCmd = &cobra.Command{
@@ -25,12 +29,45 @@ var initCmd = &cobra.Command{
 settings.toml (team-shared) and settings.local.toml (personal overrides).
 
 If a legacy .rimba.toml file exists, it is migrated into the new directory layout.
-Use --agent-files to also install AI agent instruction files.
+Use --agents to also install AI agent instruction files at project level (committed).
+Use --agents --local to install them gitignored (personal overrides).
+Use -g to install agent files at user level (~/) — works outside a git repository.
 Use --personal to gitignore the entire .rimba/ directory instead of just the local
 config file. In personal mode, settings.local.toml is not created since the whole
 directory is already personal.`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		global, _ := cmd.Flags().GetBool(flagGlobal)
+		agents, _ := cmd.Flags().GetBool(flagAgents)
+		local, _ := cmd.Flags().GetBool(flagLocal)
+		uninstall, _ := cmd.Flags().GetBool(flagUninstall)
+
+		// Flag validation
+		if local && !agents {
+			return errhint.WithFix(
+				errors.New("--local requires --agents"),
+				"run: rimba init --agents --local",
+			)
+		}
+		if uninstall && !global && !agents {
+			return errhint.WithFix(
+				errors.New("--uninstall requires -g or --agents"),
+				"run: rimba init -g --uninstall  OR  rimba init --agents --uninstall",
+			)
+		}
+
+		// Global (-g) branch: no repo required.
+		if global {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("resolve home directory: %w", err)
+			}
+			if uninstall {
+				return runAgentOp(cmd, home, "user", agentfile.UninstallGlobal, "Removed")
+			}
+			return runAgentOp(cmd, home, "user", agentfile.InstallGlobal, "Installed")
+		}
+
 		r := newRunner()
 
 		repoRoot, err := git.RepoRoot(r)
@@ -143,26 +180,49 @@ directory is already personal.`,
 			}
 		}
 
-		// Install agent instruction files if requested
-		installAgentFiles, _ := cmd.Flags().GetBool(flagAgentFiles)
-		if installAgentFiles {
-			results, err := agentfile.InstallProject(repoRoot)
-			if err != nil {
-				return fmt.Errorf("install agent files: %w", err)
+		// Project-level agent files
+		if agents {
+			if uninstall {
+				if local {
+					return runAgentOp(cmd, repoRoot, "project-local", agentfile.UninstallLocal, "Removed")
+				}
+				return runAgentOp(cmd, repoRoot, "project", agentfile.UninstallProject, "Removed")
 			}
-			for _, res := range results {
-				fmt.Fprintf(cmd.OutOrStdout(), "  Agent:        %s (%s)\n", res.RelPath, res.Action)
+			if local {
+				return runAgentOp(cmd, repoRoot, "project-local", agentfile.InstallLocal, "Installed")
 			}
+			return runAgentOp(cmd, repoRoot, "project", agentfile.InstallProject, "Installed")
 		}
 
 		return nil
 	},
 }
 
+// runAgentOp runs fn(dir) and prints results to cmd output.
+func runAgentOp(cmd *cobra.Command, dir, tier string, fn func(string) ([]agentfile.Result, error), verb string) error {
+	results, err := fn(dir)
+	if err != nil {
+		return fmt.Errorf("agent files: %w", err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s rimba agent files (%s):\n", verb, tier)
+	for _, res := range results {
+		relPath := res.RelPath
+		if tier == "user" {
+			relPath = "~/" + relPath
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s (%s)\n", relPath, res.Action)
+	}
+	return nil
+}
+
 func init() {
 	rootCmd.AddCommand(initCmd)
-	initCmd.Flags().Bool(flagAgentFiles, false, "Install AI agent instruction files (AGENTS.md, copilot, cursor, claude)")
 	initCmd.Flags().Bool(flagPersonal, false, "Gitignore the .rimba/ directory (for solo developers)")
+	initCmd.Flags().BoolP(flagGlobal, "g", false, "Install rimba agent files at user level (~/)")
+	initCmd.Flags().Bool(flagAgents, false, "Install rimba agent files in this project (committed to repo)")
+	initCmd.Flags().Bool(flagLocal, false, "With --agents, install as project-local (gitignored)")
+	initCmd.Flags().Bool(flagUninstall, false, "Remove installed agent files (requires -g, --agents, or --agents --local)")
+	initCmd.MarkFlagsMutuallyExclusive(flagGlobal, flagAgents)
 }
 
 // dirExists returns true if path exists and is a directory.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -32,6 +32,8 @@ If a legacy .rimba.toml file exists, it is migrated into the new directory layou
 Use --agents to also install AI agent instruction files at project level (committed).
 Use --agents --local to install them gitignored (personal overrides).
 Use -g to install agent files at user level (~/) — works outside a git repository.
+Use -g --uninstall to remove user-level files, --agents --uninstall for project-team files,
+or --agents --local --uninstall for project-local files.
 Use --personal to gitignore the entire .rimba/ directory instead of just the local
 config file. In personal mode, settings.local.toml is not created since the whole
 directory is already personal.`,
@@ -221,7 +223,7 @@ func init() {
 	initCmd.Flags().BoolP(flagGlobal, "g", false, "Install rimba agent files at user level (~/)")
 	initCmd.Flags().Bool(flagAgents, false, "Install rimba agent files in this project (committed to repo)")
 	initCmd.Flags().Bool(flagLocal, false, "With --agents, install as project-local (gitignored)")
-	initCmd.Flags().Bool(flagUninstall, false, "Remove installed agent files (requires -g, --agents, or --agents --local)")
+	initCmd.Flags().Bool(flagUninstall, false, "Remove agent files: use with -g, --agents, or --agents --local")
 	initCmd.MarkFlagsMutuallyExclusive(flagGlobal, flagAgents)
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -146,7 +146,7 @@ directory is already personal.`,
 		// Install agent instruction files if requested
 		installAgentFiles, _ := cmd.Flags().GetBool(flagAgentFiles)
 		if installAgentFiles {
-			results, err := agentfile.Install(repoRoot)
+			results, err := agentfile.InstallProject(repoRoot)
 			if err != nil {
 				return fmt.Errorf("install agent files: %w", err)
 			}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/spf13/cobra"
 )
 
 func TestInitSuccess(t *testing.T) {
@@ -184,7 +185,7 @@ func TestInitCreatesAgentFiles(t *testing.T) {
 	defer restore()
 
 	cmd, buf := newTestCmd()
-	cmd.Flags().Bool(flagAgentFiles, true, "")
+	cmd.Flags().Bool(flagAgents, true, "")
 
 	if err := initCmd.RunE(cmd, nil); err != nil {
 		t.Fatalf("initCmd.RunE: %v", err)
@@ -192,7 +193,7 @@ func TestInitCreatesAgentFiles(t *testing.T) {
 
 	out := buf.String()
 
-	// Verify agent file output lines
+	// Verify agent file output lines for all 7 project specs
 	agentFiles := []string{
 		"AGENTS.md",
 		filepath.Join(".github", "copilot-instructions.md"),
@@ -236,7 +237,7 @@ func TestInitExistingConfigInstallsAgentFiles(t *testing.T) {
 	defer restore()
 
 	cmd, buf := newTestCmd()
-	cmd.Flags().Bool(flagAgentFiles, true, "")
+	cmd.Flags().Bool(flagAgents, true, "")
 
 	// Should succeed (not error) when .rimba/ already exists
 	err := initCmd.RunE(cmd, nil)
@@ -275,14 +276,14 @@ func TestInitAgentFilesIdempotent(t *testing.T) {
 
 	// First init
 	cmd1, _ := newTestCmd()
-	cmd1.Flags().Bool(flagAgentFiles, true, "")
+	cmd1.Flags().Bool(flagAgents, true, "")
 	if err := initCmd.RunE(cmd1, nil); err != nil {
 		t.Fatalf("first initCmd.RunE: %v", err)
 	}
 
 	// Second init (config exists now)
 	cmd2, buf2 := newTestCmd()
-	cmd2.Flags().Bool(flagAgentFiles, true, "")
+	cmd2.Flags().Bool(flagAgents, true, "")
 	if err := initCmd.RunE(cmd2, nil); err != nil {
 		t.Fatalf("second initCmd.RunE: %v", err)
 	}
@@ -328,11 +329,194 @@ func TestInitWithoutFlagSkipsAgentFiles(t *testing.T) {
 
 	out := buf.String()
 	if strings.Contains(out, "Agent:") {
-		t.Errorf("output should not mention agent files without --agent-files flag, got:\n%s", out)
+		t.Errorf("output should not mention agent files without agent flag, got:\n%s", out)
 	}
 
 	if _, err := os.Stat(filepath.Join(repoDir, "AGENTS.md")); err == nil {
-		t.Error("AGENTS.md should not be created without --agent-files flag")
+		t.Error("AGENTS.md should not be created without --agents flag")
+	}
+}
+
+// --- Tests for new 3-tier flag surface ---
+
+func TestInitGlobalInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// -g does not need a git repo
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("not a git repository")
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().Bool(flagGlobal, true, "")
+
+	if err := initCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("initCmd.RunE: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "user") {
+		t.Errorf("output should mention 'user', got:\n%s", out)
+	}
+
+	// Verify Claude skill was created
+	claudePath := filepath.Join(home, ".claude", "skills", "rimba", "SKILL.md")
+	if _, err := os.Stat(claudePath); os.IsNotExist(err) {
+		t.Errorf("global claude skill not created at %s", claudePath)
+	}
+}
+
+func TestInitGlobalNoRepoRequired(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Simulate git.RepoRoot failing (not in a repo)
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("not a git repository")
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	cmd.Flags().Bool(flagGlobal, true, "")
+
+	if err := initCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("-g should succeed outside a git repo, got: %v", err)
+	}
+}
+
+func TestInitGlobalUninstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Install first
+	r := &mockRunner{
+		run:      func(...string) (string, error) { return "", errors.New("not a git repo") },
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd1, _ := newTestCmd()
+	cmd1.Flags().Bool(flagGlobal, true, "")
+	if err := initCmd.RunE(cmd1, nil); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Uninstall
+	cmd2, buf := newTestCmd()
+	cmd2.Flags().Bool(flagGlobal, true, "")
+	cmd2.Flags().Bool(flagUninstall, true, "")
+	if err := initCmd.RunE(cmd2, nil); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Removed") {
+		t.Errorf("output should say 'Removed', got:\n%s", out)
+	}
+
+	// Claude skill should be gone
+	claudePath := filepath.Join(home, ".claude", "skills", "rimba", "SKILL.md")
+	if _, err := os.Stat(claudePath); err == nil {
+		t.Error("claude skill should be removed after uninstall")
+	}
+}
+
+func TestInitAgentsLocalAddsGitignore(t *testing.T) {
+	repoDir := t.TempDir()
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	cmd.Flags().Bool(flagAgents, true, "")
+	cmd.Flags().Bool(flagLocal, true, "")
+
+	if err := initCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("initCmd.RunE: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(repoDir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	gitignore := string(data)
+	// AGENTS.md should be in .gitignore (local tier)
+	if !strings.Contains(gitignore, "AGENTS.md") {
+		t.Errorf(".gitignore should contain AGENTS.md, got:\n%s", gitignore)
+	}
+}
+
+func TestInitFlagValidationErrors(t *testing.T) {
+	repoDir := t.TempDir()
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	tests := []struct {
+		name    string
+		setup   func(*cobra.Command)
+		wantErr string
+	}{
+		{
+			name: "--local without --agents",
+			setup: func(cmd *cobra.Command) {
+				cmd.Flags().Bool(flagLocal, true, "")
+			},
+			wantErr: "--local requires --agents",
+		},
+		{
+			name: "--uninstall without target",
+			setup: func(cmd *cobra.Command) {
+				cmd.Flags().Bool(flagUninstall, true, "")
+			},
+			wantErr: "--uninstall requires",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, _ := newTestCmd()
+			tt.setup(cmd)
+			err := initCmd.RunE(cmd, nil)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/agentfile/agentfile.go
+++ b/internal/agentfile/agentfile.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/lugassawan/rimba/internal/fileutil"
 )
 
 const (
@@ -47,22 +49,114 @@ type FileStatus struct {
 	Installed bool
 }
 
-// Specs returns the specifications for all agent instruction files.
-func Specs() []Spec {
+// GlobalSpecs returns the specifications for all agent instruction files installed at user level (~/).
+func GlobalSpecs() []Spec {
 	return []Spec{
-		{RelPath: "AGENTS.md", Kind: KindBlock, Content: agentsBlock},
-		{RelPath: filepath.Join(".github", "copilot-instructions.md"), Kind: KindBlock, Content: copilotBlock},
-		{RelPath: filepath.Join(".cursor", "rules", "rimba.mdc"), Kind: KindWhole, Content: cursorContent},
+		{RelPath: filepath.Join(".claude", "skills", "rimba", "SKILL.md"), Kind: KindWhole, Content: globalClaudeSkillContent},
+		{RelPath: filepath.Join(".cursor", "rules", "rimba.mdc"), Kind: KindWhole, Content: globalCursorContent},
+		{RelPath: filepath.Join(".github", "copilot-instructions.md"), Kind: KindBlock, Content: globalCopilotBlock},
+		{RelPath: filepath.Join(".codex", "AGENTS.md"), Kind: KindBlock, Content: globalCodexBlock},
+		{RelPath: filepath.Join(".gemini", "GEMINI.md"), Kind: KindBlock, Content: globalGeminiBlock},
+		{RelPath: filepath.Join(".codeium", "windsurf", "memories", "global_rules.md"), Kind: KindBlock, Content: globalWindsurfBlock},
+		{RelPath: filepath.Join(".roo", "rules", "rimba.md"), Kind: KindWhole, Content: globalRooContent},
+	}
+}
+
+// ProjectSpecs returns the specifications for all agent instruction files installed at project level.
+func ProjectSpecs() []Spec {
+	return []Spec{
 		{RelPath: filepath.Join(".claude", "skills", "rimba", "SKILL.md"), Kind: KindWhole, Content: claudeSkillContent},
+		{RelPath: filepath.Join(".cursor", "rules", "rimba.mdc"), Kind: KindWhole, Content: cursorContent},
+		{RelPath: filepath.Join(".github", "copilot-instructions.md"), Kind: KindBlock, Content: copilotBlock},
+		{RelPath: "AGENTS.md", Kind: KindBlock, Content: agentsBlock},
+		{RelPath: "GEMINI.md", Kind: KindBlock, Content: geminiBlock},
+		{RelPath: filepath.Join(".windsurf", "rules", "rimba.md"), Kind: KindWhole, Content: windsurfContent},
+		{RelPath: filepath.Join(".clinerules", "rimba.md"), Kind: KindWhole, Content: rooContent},
 	}
 }
 
-// Install creates or updates all agent instruction files under repoRoot.
-// It is idempotent: re-running replaces existing content.
-func Install(repoRoot string) ([]Result, error) {
-	var results []Result
-	for _, spec := range Specs() {
-		r, err := installOne(repoRoot, spec)
+// Specs returns the project-level agent instruction files.
+//
+// Deprecated: use ProjectSpecs.
+func Specs() []Spec { return ProjectSpecs() }
+
+// InstallGlobal creates or updates all agent instruction files under homeDir.
+func InstallGlobal(homeDir string) ([]Result, error) {
+	return installSpecs(homeDir, GlobalSpecs())
+}
+
+// UninstallGlobal removes rimba content from all user-level agent instruction files.
+func UninstallGlobal(homeDir string) ([]Result, error) {
+	return uninstallSpecs(homeDir, GlobalSpecs())
+}
+
+// StatusGlobal checks the installation state of all user-level agent instruction files.
+func StatusGlobal(homeDir string) []FileStatus {
+	return checkSpecs(homeDir, GlobalSpecs())
+}
+
+// InstallProject creates or updates all project-team agent instruction files under repoRoot.
+func InstallProject(repoRoot string) ([]Result, error) {
+	return installSpecs(repoRoot, ProjectSpecs())
+}
+
+// UninstallProject removes rimba content from all project-team agent instruction files.
+func UninstallProject(repoRoot string) ([]Result, error) {
+	return uninstallSpecs(repoRoot, ProjectSpecs())
+}
+
+// StatusProject checks the installation state of all project-team agent instruction files.
+func StatusProject(repoRoot string) []FileStatus {
+	return checkSpecs(repoRoot, ProjectSpecs())
+}
+
+// InstallLocal creates or updates all project-local agent instruction files and adds them to .gitignore.
+func InstallLocal(repoRoot string) ([]Result, error) {
+	results, err := installSpecs(repoRoot, ProjectSpecs())
+	if err != nil {
+		return results, err
+	}
+	for _, spec := range ProjectSpecs() {
+		if _, gitErr := fileutil.EnsureGitignore(repoRoot, spec.RelPath); gitErr != nil {
+			return results, fmt.Errorf("gitignore %s: %w", spec.RelPath, gitErr)
+		}
+	}
+	return results, nil
+}
+
+// UninstallLocal removes project-local agent instruction files and their .gitignore entries.
+func UninstallLocal(repoRoot string) ([]Result, error) {
+	results, err := uninstallSpecs(repoRoot, ProjectSpecs())
+	if err != nil {
+		return results, err
+	}
+	for _, spec := range ProjectSpecs() {
+		if _, gitErr := fileutil.RemoveGitignoreEntry(repoRoot, spec.RelPath); gitErr != nil {
+			return results, fmt.Errorf("gitignore %s: %w", spec.RelPath, gitErr)
+		}
+	}
+	return results, nil
+}
+
+// Install creates or updates all project-level agent instruction files under repoRoot.
+//
+// Deprecated: use InstallProject.
+func Install(repoRoot string) ([]Result, error) { return InstallProject(repoRoot) }
+
+// Uninstall removes rimba content from all project-level agent instruction files under repoRoot.
+//
+// Deprecated: use UninstallProject.
+func Uninstall(repoRoot string) ([]Result, error) { return UninstallProject(repoRoot) }
+
+// Status checks the installation state of all project-level agent instruction files.
+//
+// Deprecated: use StatusProject.
+func Status(repoRoot string) []FileStatus { return StatusProject(repoRoot) }
+
+func installSpecs(baseDir string, specs []Spec) ([]Result, error) {
+	results := make([]Result, 0, len(specs))
+	for _, spec := range specs {
+		r, err := installOne(baseDir, spec)
 		if err != nil {
 			return results, fmt.Errorf("%s: %w", spec.RelPath, err)
 		}
@@ -71,11 +165,10 @@ func Install(repoRoot string) ([]Result, error) {
 	return results, nil
 }
 
-// Uninstall removes rimba content from all agent instruction files under repoRoot.
-func Uninstall(repoRoot string) ([]Result, error) {
-	var results []Result
-	for _, spec := range Specs() {
-		r, err := uninstallOne(repoRoot, spec)
+func uninstallSpecs(baseDir string, specs []Spec) ([]Result, error) {
+	results := make([]Result, 0, len(specs))
+	for _, spec := range specs {
+		r, err := uninstallOne(baseDir, spec)
 		if err != nil {
 			return results, fmt.Errorf("%s: %w", spec.RelPath, err)
 		}
@@ -84,12 +177,10 @@ func Uninstall(repoRoot string) ([]Result, error) {
 	return results, nil
 }
 
-// Status checks the installation state of all agent instruction files.
-func Status(repoRoot string) []FileStatus {
-	specs := Specs()
+func checkSpecs(baseDir string, specs []Spec) []FileStatus {
 	statuses := make([]FileStatus, 0, len(specs))
 	for _, spec := range specs {
-		statuses = append(statuses, checkOne(repoRoot, spec))
+		statuses = append(statuses, checkOne(baseDir, spec))
 	}
 	return statuses
 }

--- a/internal/agentfile/agentfile.go
+++ b/internal/agentfile/agentfile.go
@@ -100,8 +100,8 @@ func ensureDir(dir string) bool {
 	return os.MkdirAll(dir, 0750) == nil //nolint:gosec // dir needs to be accessible
 }
 
-func installOne(repoRoot string, spec Spec) (Result, error) {
-	path := filepath.Join(repoRoot, spec.RelPath)
+func installOne(baseDir string, spec Spec) (Result, error) {
+	path := filepath.Join(baseDir, spec.RelPath)
 
 	if spec.Kind == KindWhole {
 		return installWhole(path, spec)
@@ -164,8 +164,8 @@ func installBlock(path string, spec Spec) (Result, error) {
 	return Result{RelPath: spec.RelPath, Action: action}, nil
 }
 
-func uninstallOne(repoRoot string, spec Spec) (Result, error) {
-	path := filepath.Join(repoRoot, spec.RelPath)
+func uninstallOne(baseDir string, spec Spec) (Result, error) {
+	path := filepath.Join(baseDir, spec.RelPath)
 
 	if spec.Kind == KindWhole {
 		return uninstallWhole(path, spec)
@@ -212,8 +212,8 @@ func uninstallBlock(path string, spec Spec) (Result, error) {
 	return Result{RelPath: spec.RelPath, Action: actionRemoved}, nil
 }
 
-func checkOne(repoRoot string, spec Spec) FileStatus {
-	path := filepath.Join(repoRoot, spec.RelPath)
+func checkOne(baseDir string, spec Spec) FileStatus {
+	path := filepath.Join(baseDir, spec.RelPath)
 
 	if spec.Kind == KindWhole {
 		_, err := os.Stat(path)

--- a/internal/agentfile/agentfile.go
+++ b/internal/agentfile/agentfile.go
@@ -112,11 +112,12 @@ func StatusProject(repoRoot string) []FileStatus {
 
 // InstallLocal creates or updates all project-local agent instruction files and adds them to .gitignore.
 func InstallLocal(repoRoot string) ([]Result, error) {
-	results, err := installSpecs(repoRoot, ProjectSpecs())
+	specs := ProjectSpecs()
+	results, err := installSpecs(repoRoot, specs)
 	if err != nil {
 		return results, err
 	}
-	for _, spec := range ProjectSpecs() {
+	for _, spec := range specs {
 		if _, gitErr := fileutil.EnsureGitignore(repoRoot, spec.RelPath); gitErr != nil {
 			return results, fmt.Errorf("gitignore %s: %w", spec.RelPath, gitErr)
 		}
@@ -126,11 +127,12 @@ func InstallLocal(repoRoot string) ([]Result, error) {
 
 // UninstallLocal removes project-local agent instruction files and their .gitignore entries.
 func UninstallLocal(repoRoot string) ([]Result, error) {
-	results, err := uninstallSpecs(repoRoot, ProjectSpecs())
+	specs := ProjectSpecs()
+	results, err := uninstallSpecs(repoRoot, specs)
 	if err != nil {
 		return results, err
 	}
-	for _, spec := range ProjectSpecs() {
+	for _, spec := range specs {
 		if _, gitErr := fileutil.RemoveGitignoreEntry(repoRoot, spec.RelPath); gitErr != nil {
 			return results, fmt.Errorf("gitignore %s: %w", spec.RelPath, gitErr)
 		}

--- a/internal/agentfile/agentfile_test.go
+++ b/internal/agentfile/agentfile_test.go
@@ -471,6 +471,119 @@ func TestClaudeSkillContentHasFrontmatter(t *testing.T) {
 	}
 }
 
+// --- New project-tier content tests ---
+
+func TestGeminiBlockHasMarkers(t *testing.T) {
+	content := geminiBlock()
+	if !strings.HasPrefix(content, BeginMarker) {
+		t.Error("gemini block should start with BEGIN marker")
+	}
+	if !strings.HasSuffix(content, EndMarker) {
+		t.Error("gemini block should end with END marker")
+	}
+	if !strings.Contains(content, "rimba") {
+		t.Error("gemini block should mention rimba")
+	}
+}
+
+func TestWindsurfContentNotEmpty(t *testing.T) {
+	content := windsurfContent()
+	if content == "" {
+		t.Error("windsurf content should not be empty")
+	}
+	if !strings.Contains(content, "rimba") {
+		t.Error("windsurf content should mention rimba")
+	}
+}
+
+func TestRooContentNotEmpty(t *testing.T) {
+	content := rooContent()
+	if content == "" {
+		t.Error("roo content should not be empty")
+	}
+	if !strings.Contains(content, "rimba") {
+		t.Error("roo content should mention rimba")
+	}
+}
+
+// --- Global (user-tier) content tests ---
+
+func TestGlobalClaudeSkillContentHasFrontmatter(t *testing.T) {
+	content := globalClaudeSkillContent()
+	if !strings.HasPrefix(content, "---\n") {
+		t.Error("global claude skill content should start with YAML frontmatter")
+	}
+	if !strings.Contains(content, "name: rimba") {
+		t.Error("global claude skill content should have name field")
+	}
+	if !strings.Contains(content, "description:") {
+		t.Error("global claude skill content should have description field")
+	}
+}
+
+func TestGlobalCursorContentHasFrontmatterNoGlobs(t *testing.T) {
+	content := globalCursorContent()
+	if !strings.HasPrefix(content, "---\n") {
+		t.Error("global cursor content should start with YAML frontmatter")
+	}
+	if !strings.Contains(content, "alwaysApply: true") {
+		t.Error("global cursor content should have alwaysApply: true")
+	}
+	if strings.Contains(content, "globs:") {
+		t.Error("global cursor content should not have globs field")
+	}
+}
+
+func TestGlobalCopilotBlockHasMarkers(t *testing.T) {
+	content := globalCopilotBlock()
+	if !strings.HasPrefix(content, BeginMarker) {
+		t.Error("global copilot block should start with BEGIN marker")
+	}
+	if !strings.HasSuffix(content, EndMarker) {
+		t.Error("global copilot block should end with END marker")
+	}
+}
+
+func TestGlobalCodexBlockHasMarkers(t *testing.T) {
+	content := globalCodexBlock()
+	if !strings.HasPrefix(content, BeginMarker) {
+		t.Error("global codex block should start with BEGIN marker")
+	}
+	if !strings.HasSuffix(content, EndMarker) {
+		t.Error("global codex block should end with END marker")
+	}
+}
+
+func TestGlobalGeminiBlockHasMarkers(t *testing.T) {
+	content := globalGeminiBlock()
+	if !strings.HasPrefix(content, BeginMarker) {
+		t.Error("global gemini block should start with BEGIN marker")
+	}
+	if !strings.HasSuffix(content, EndMarker) {
+		t.Error("global gemini block should end with END marker")
+	}
+}
+
+func TestGlobalWindsurfBlockHasMarkers(t *testing.T) {
+	content := globalWindsurfBlock()
+	if !strings.HasPrefix(content, BeginMarker) {
+		t.Error("global windsurf block should start with BEGIN marker")
+	}
+	if !strings.HasSuffix(content, EndMarker) {
+		t.Error("global windsurf block should end with END marker")
+	}
+}
+
+func TestGlobalRooContentNotEmpty(t *testing.T) {
+	content := globalRooContent()
+	if content == "" {
+		t.Error("global roo content should not be empty")
+	}
+	if !strings.Contains(content, "rimba") {
+		t.Error("global roo content should mention rimba")
+	}
+}
+
 // --- Error handling tests ---
 
 func TestInstallReadError(t *testing.T) {

--- a/internal/agentfile/agentfile_test.go
+++ b/internal/agentfile/agentfile_test.go
@@ -15,10 +15,9 @@ const (
 
 // --- Specs tests ---
 
-func TestSpecsReturnsFourFiles(t *testing.T) {
-	specs := Specs()
-	if len(specs) != 4 {
-		t.Fatalf("Specs() returned %d items, want 4", len(specs))
+func TestSpecsReturnsSeven(t *testing.T) {
+	if got := len(Specs()); got != 7 {
+		t.Fatalf("Specs() returned %d items, want 7", got)
 	}
 }
 
@@ -41,8 +40,8 @@ func TestInstallCreatesAllFiles(t *testing.T) {
 		t.Fatalf(fatalInstall, err)
 	}
 
-	if len(results) != 4 {
-		t.Fatalf("Install returned %d results, want 4", len(results))
+	if len(results) != 7 {
+		t.Fatalf("Install returned %d results, want 7", len(results))
 	}
 
 	for _, r := range results {
@@ -223,8 +222,8 @@ func TestUninstallRemovesBlock(t *testing.T) {
 		t.Fatalf(fatalUninstall, err)
 	}
 
-	if len(results) != 4 {
-		t.Fatalf("Uninstall returned %d results, want 4", len(results))
+	if len(results) != 7 {
+		t.Fatalf("Uninstall returned %d results, want 7", len(results))
 	}
 
 	// AGENTS.md should still exist with user content
@@ -303,8 +302,8 @@ func TestStatusNotInstalled(t *testing.T) {
 	dir := t.TempDir()
 
 	statuses := Status(dir)
-	if len(statuses) != 4 {
-		t.Fatalf("Status returned %d items, want 4", len(statuses))
+	if len(statuses) != 7 {
+		t.Fatalf("Status returned %d items, want 7", len(statuses))
 	}
 
 	for _, s := range statuses {
@@ -581,6 +580,252 @@ func TestGlobalRooContentNotEmpty(t *testing.T) {
 	}
 	if !strings.Contains(content, "rimba") {
 		t.Error("global roo content should mention rimba")
+	}
+}
+
+// --- GlobalSpecs / ProjectSpecs tests ---
+
+func TestGlobalSpecsCountIsSeven(t *testing.T) {
+	if got := len(GlobalSpecs()); got != 7 {
+		t.Fatalf("GlobalSpecs() returned %d items, want 7", got)
+	}
+}
+
+func TestProjectSpecsCountIsSeven(t *testing.T) {
+	if got := len(ProjectSpecs()); got != 7 {
+		t.Fatalf("ProjectSpecs() returned %d items, want 7", got)
+	}
+}
+
+func TestGlobalSpecsContentNotEmpty(t *testing.T) {
+	for _, spec := range GlobalSpecs() {
+		if spec.Content() == "" {
+			t.Errorf("GlobalSpec %q returned empty content", spec.RelPath)
+		}
+	}
+}
+
+func TestProjectSpecsContentNotEmpty(t *testing.T) {
+	for _, spec := range ProjectSpecs() {
+		if spec.Content() == "" {
+			t.Errorf("ProjectSpec %q returned empty content", spec.RelPath)
+		}
+	}
+}
+
+// --- InstallGlobal / UninstallGlobal tests ---
+
+func TestInstallGlobalCreatesAllFiles(t *testing.T) {
+	home := t.TempDir()
+
+	results, err := InstallGlobal(home)
+	if err != nil {
+		t.Fatalf("InstallGlobal: %v", err)
+	}
+
+	if len(results) != 7 {
+		t.Fatalf("InstallGlobal returned %d results, want 7", len(results))
+	}
+	for _, r := range results {
+		if r.Action != actionCreated {
+			t.Errorf("%s: action = %q, want %q", r.RelPath, r.Action, actionCreated)
+		}
+		path := filepath.Join(home, r.RelPath)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("%s: file not created at %s", r.RelPath, path)
+		}
+	}
+}
+
+func TestInstallGlobalIdempotent(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := InstallGlobal(home); err != nil {
+		t.Fatalf("first InstallGlobal: %v", err)
+	}
+	results, err := InstallGlobal(home)
+	if err != nil {
+		t.Fatalf("second InstallGlobal: %v", err)
+	}
+	for _, r := range results {
+		if r.Action != actionUpdated {
+			t.Errorf("%s: action = %q, want %q on re-install", r.RelPath, r.Action, actionUpdated)
+		}
+	}
+
+	// Block files must have exactly one marker pair.
+	for _, spec := range GlobalSpecs() {
+		if spec.Kind != KindBlock {
+			continue
+		}
+		path := filepath.Join(home, spec.RelPath)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", spec.RelPath, err)
+		}
+		s := string(data)
+		if strings.Count(s, BeginMarker) != 1 {
+			t.Errorf("%s: %d BEGIN markers, want 1", spec.RelPath, strings.Count(s, BeginMarker))
+		}
+	}
+}
+
+func TestGlobalBlockPreservesExistingUserContent(t *testing.T) {
+	home := t.TempDir()
+
+	// Pre-seed ~/.codex/AGENTS.md with user content.
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	userContent := "# My Codex Config\n\nPersonal instructions.\n"
+	if err := os.WriteFile(filepath.Join(codexDir, "AGENTS.md"), []byte(userContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := InstallGlobal(home); err != nil {
+		t.Fatalf("InstallGlobal: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexDir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read AGENTS.md: %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "My Codex Config") {
+		t.Error("user content should be preserved")
+	}
+	if !strings.Contains(s, BeginMarker) {
+		t.Error("rimba block should be appended")
+	}
+}
+
+func TestUninstallGlobalRemovesAllFiles(t *testing.T) {
+	home := t.TempDir()
+
+	if _, err := InstallGlobal(home); err != nil {
+		t.Fatalf("InstallGlobal: %v", err)
+	}
+	results, err := UninstallGlobal(home)
+	if err != nil {
+		t.Fatalf("UninstallGlobal: %v", err)
+	}
+	if len(results) != 7 {
+		t.Fatalf("UninstallGlobal returned %d results, want 7", len(results))
+	}
+	for _, r := range results {
+		if r.Action != actionRemoved {
+			t.Errorf("%s: action = %q, want %q", r.RelPath, r.Action, actionRemoved)
+		}
+	}
+}
+
+func TestStatusGlobalReflectsInstall(t *testing.T) {
+	home := t.TempDir()
+
+	before := StatusGlobal(home)
+	for _, s := range before {
+		if s.Installed {
+			t.Errorf("%s: expected not installed before install", s.RelPath)
+		}
+	}
+
+	if _, err := InstallGlobal(home); err != nil {
+		t.Fatalf("InstallGlobal: %v", err)
+	}
+
+	after := StatusGlobal(home)
+	for _, s := range after {
+		if !s.Installed {
+			t.Errorf("%s: expected installed after install", s.RelPath)
+		}
+	}
+}
+
+// --- InstallProject / UninstallProject tests ---
+
+func TestInstallProjectCreatesAllFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	results, err := InstallProject(dir)
+	if err != nil {
+		t.Fatalf("InstallProject: %v", err)
+	}
+	if len(results) != 7 {
+		t.Fatalf("InstallProject returned %d results, want 7", len(results))
+	}
+	for _, r := range results {
+		if r.Action != actionCreated {
+			t.Errorf("%s: action = %q, want %q", r.RelPath, r.Action, actionCreated)
+		}
+	}
+}
+
+func TestUninstallProjectRemovesFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := InstallProject(dir); err != nil {
+		t.Fatalf("InstallProject: %v", err)
+	}
+	if _, err := UninstallProject(dir); err != nil {
+		t.Fatalf("UninstallProject: %v", err)
+	}
+
+	// Whole-file types should be deleted.
+	for _, spec := range ProjectSpecs() {
+		if spec.Kind != KindWhole {
+			continue
+		}
+		path := filepath.Join(dir, spec.RelPath)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("%s: should be deleted after uninstall", spec.RelPath)
+		}
+	}
+}
+
+// --- InstallLocal / UninstallLocal tests ---
+
+func TestInstallLocalAddsGitignoreEntries(t *testing.T) {
+	dir := t.TempDir()
+
+	// Need a git repo-like directory; EnsureGitignore just needs the directory.
+	if _, err := InstallLocal(dir); err != nil {
+		t.Fatalf("InstallLocal: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	gitignore := string(data)
+
+	for _, spec := range ProjectSpecs() {
+		if !strings.Contains(gitignore, spec.RelPath) {
+			t.Errorf(".gitignore missing entry for %s", spec.RelPath)
+		}
+	}
+}
+
+func TestUninstallLocalRemovesGitignoreEntries(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := InstallLocal(dir); err != nil {
+		t.Fatalf("InstallLocal: %v", err)
+	}
+	if _, err := UninstallLocal(dir); err != nil {
+		t.Fatalf("UninstallLocal: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	gitignore := string(data)
+
+	for _, spec := range ProjectSpecs() {
+		if strings.Contains(gitignore, spec.RelPath) {
+			t.Errorf(".gitignore still has entry for %s after uninstall", spec.RelPath)
+		}
 	}
 }
 

--- a/internal/agentfile/content.go
+++ b/internal/agentfile/content.go
@@ -168,6 +168,256 @@ Envelope: ` + "`" + `{"version", "command", "data"}` + "`" + ` or ` + "`" + `{"v
 `
 }
 
+// geminiBlock returns the rimba block for GEMINI.md (shared file, block-based).
+func geminiBlock() string {
+	return `<!-- BEGIN RIMBA -->
+<!-- Managed by rimba — do not edit this block manually -->
+
+# rimba — Git Worktree Manager
+
+rimba manages parallel git worktrees so you can work on multiple tasks simultaneously.
+It is optional and detected via ` + "`" + `.rimba/settings.toml` + "`" + ` in the repo root.
+
+## Prerequisites
+
+Run ` + "`" + `rimba version` + "`" + ` to check if rimba is installed.
+If not found, **ask the user** before installing. Never install automatically.
+
+## Command Reference
+
+| Concern | Commands |
+|---------|----------|
+| Create & navigate | ` + "`" + `rimba add <task>` + "`" + `, ` + "`" + `rimba open <task>` + "`" + ` |
+| Inspect | ` + "`" + `rimba list` + "`" + `, ` + "`" + `rimba status` + "`" + ` |
+| Sync & merge | ` + "`" + `rimba sync [task]` + "`" + `, ` + "`" + `rimba merge <task>` + "`" + ` |
+| Clean up | ` + "`" + `rimba clean --merged` + "`" + `, ` + "`" + `rimba archive <task>` + "`" + `, ` + "`" + `rimba remove <task>` + "`" + ` |
+| Cross-cutting | ` + "`" + `rimba exec <cmd>` + "`" + `, ` + "`" + `rimba conflict-check` + "`" + ` |
+| AI integration | ` + "`" + `rimba mcp` + "`" + ` (MCP server for AI coding agents) |
+
+<!-- END RIMBA -->`
+}
+
+// windsurfContent returns the full content for .windsurf/rules/rimba.md (whole-file, project-level).
+func windsurfContent() string {
+	return `# rimba — Git Worktree Manager
+
+rimba manages parallel git worktrees so you can work on multiple tasks simultaneously.
+It is optional and detected via ` + "`" + `.rimba/settings.toml` + "`" + ` in the repo root.
+
+## Prerequisites
+
+Run ` + "`" + `rimba version` + "`" + ` to check if rimba is installed.
+If not found, **ask the user** before installing. Never install automatically.
+
+## Top Commands
+
+1. ` + "`" + `rimba add <task>` + "`" + ` — create worktree + branch
+2. ` + "`" + `rimba list` + "`" + ` — list all worktrees
+3. ` + "`" + `rimba status` + "`" + ` — health overview
+4. ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
+5. ` + "`" + `rimba clean --merged` + "`" + ` — remove merged worktrees
+6. ` + "`" + `rimba sync [task]` + "`" + ` — rebase onto main
+7. ` + "`" + `rimba mcp` + "`" + ` — start MCP server for AI tool integration
+`
+}
+
+// rooContent returns the full content for .clinerules/rimba.md (whole-file, project-level).
+func rooContent() string {
+	return `# rimba — Git Worktree Manager
+
+rimba manages parallel git worktrees so you can work on multiple tasks simultaneously.
+It is optional and detected via ` + "`" + `.rimba/settings.toml` + "`" + ` in the repo root.
+
+## Prerequisites
+
+Run ` + "`" + `rimba version` + "`" + ` to check if rimba is installed.
+If not found, **ask the user** before installing. Never install automatically.
+
+## Top Commands
+
+1. ` + "`" + `rimba add <task>` + "`" + ` — create worktree + branch
+2. ` + "`" + `rimba list` + "`" + ` — list all worktrees
+3. ` + "`" + `rimba status` + "`" + ` — health overview
+4. ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
+5. ` + "`" + `rimba clean --merged` + "`" + ` — remove merged worktrees
+6. ` + "`" + `rimba sync [task]` + "`" + ` — rebase onto main
+7. ` + "`" + `rimba mcp` + "`" + ` — start MCP server for AI tool integration
+`
+}
+
+// globalClaudeSkillContent returns the user-level content for ~/.claude/skills/rimba/SKILL.md.
+func globalClaudeSkillContent() string {
+	return `---
+name: rimba
+description: Use when user wants to manage git worktrees — creating, listing, syncing, merging, or cleaning up parallel working directories
+---
+
+# rimba — Git Worktree Manager
+
+## Prerequisite
+
+Run ` + "`" + `rimba version` + "`" + ` to check if rimba is installed.
+If not found, **ask the user** if they want to install it. Never install automatically.
+
+` + "```" + `sh
+curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/install.sh | bash
+` + "```" + `
+
+Check for ` + "`" + `.rimba/settings.toml` + "`" + ` in the current repo to confirm rimba is configured for this project.
+
+## Decision Logic
+
+| User wants to... | Run |
+|-------------------|-----|
+| Start a new task | ` + "`" + `rimba add <task>` + "`" + ` |
+| Start a task in a monorepo service | ` + "`" + `rimba add service/task` + "`" + ` |
+| See all worktrees | ` + "`" + `rimba list` + "`" + ` |
+| Check worktree health | ` + "`" + `rimba status` + "`" + ` |
+| Navigate to a worktree | ` + "`" + `cd $(rimba open <task>)` + "`" + ` |
+| Update from source branch | ` + "`" + `rimba sync <task>` + "`" + ` |
+| Finish a feature | ` + "`" + `rimba merge <task>` + "`" + ` |
+| Clean up merged work | ` + "`" + `rimba clean --merged` + "`" + ` |
+| Use MCP server | ` + "`" + `rimba mcp` + "`" + ` |
+`
+}
+
+// globalCursorContent returns the user-level content for ~/.cursor/rules/rimba.mdc.
+func globalCursorContent() string {
+	return `---
+description: rimba git worktree manager commands and workflows
+alwaysApply: true
+---
+
+# rimba — Git Worktree Manager
+
+Check for ` + "`" + `.rimba/settings.toml` + "`" + ` in the current repo to confirm rimba is configured.
+
+## Top Commands
+
+1. ` + "`" + `rimba add <task>` + "`" + ` — create worktree + branch
+2. ` + "`" + `rimba list` + "`" + ` — list all worktrees
+3. ` + "`" + `rimba status` + "`" + ` — health overview
+4. ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
+5. ` + "`" + `rimba clean --merged` + "`" + ` — remove merged worktrees
+6. ` + "`" + `rimba sync [task]` + "`" + ` — rebase onto main
+7. ` + "`" + `rimba mcp` + "`" + ` — start MCP server for AI tool integration
+`
+}
+
+// globalCopilotBlock returns the user-level rimba block for ~/.github/copilot-instructions.md.
+func globalCopilotBlock() string {
+	return `<!-- BEGIN RIMBA -->
+<!-- Managed by rimba — do not edit this block manually -->
+
+## rimba (Git Worktree Manager)
+
+rimba manages parallel git worktrees. Check for ` + "`" + `.rimba/settings.toml` + "`" + ` to confirm it is configured in the current project.
+
+### Key Commands
+
+- ` + "`" + `rimba add <task>` + "`" + ` — create worktree + branch
+- ` + "`" + `rimba list` + "`" + ` / ` + "`" + `rimba status` + "`" + ` — inspect worktrees
+- ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
+- ` + "`" + `rimba clean --merged` + "`" + ` — remove merged worktrees
+- ` + "`" + `rimba mcp` + "`" + ` — start MCP server for AI tool integration
+
+<!-- END RIMBA -->`
+}
+
+// globalCodexBlock returns the user-level rimba block for ~/.codex/AGENTS.md.
+func globalCodexBlock() string {
+	return `<!-- BEGIN RIMBA -->
+<!-- Managed by rimba — do not edit this block manually -->
+
+# rimba — Git Worktree Manager
+
+rimba manages parallel git worktrees so you can work on multiple tasks simultaneously.
+Check for ` + "`" + `.rimba/settings.toml` + "`" + ` in the current repo to confirm it is configured.
+
+Run ` + "`" + `rimba version` + "`" + ` to check if rimba is installed.
+If not found, **ask the user** before installing. Never install automatically.
+
+## Command Reference
+
+| Concern | Commands |
+|---------|----------|
+| Create & navigate | ` + "`" + `rimba add <task>` + "`" + `, ` + "`" + `rimba open <task>` + "`" + ` |
+| Inspect | ` + "`" + `rimba list` + "`" + `, ` + "`" + `rimba status` + "`" + ` |
+| Sync & merge | ` + "`" + `rimba sync [task]` + "`" + `, ` + "`" + `rimba merge <task>` + "`" + ` |
+| Clean up | ` + "`" + `rimba clean --merged` + "`" + `, ` + "`" + `rimba archive <task>` + "`" + ` |
+| AI integration | ` + "`" + `rimba mcp` + "`" + ` (MCP server for AI coding agents) |
+
+<!-- END RIMBA -->`
+}
+
+// globalGeminiBlock returns the user-level rimba block for ~/.gemini/GEMINI.md.
+func globalGeminiBlock() string {
+	return `<!-- BEGIN RIMBA -->
+<!-- Managed by rimba — do not edit this block manually -->
+
+# rimba — Git Worktree Manager
+
+rimba manages parallel git worktrees so you can work on multiple tasks simultaneously.
+Check for ` + "`" + `.rimba/settings.toml` + "`" + ` in the current repo to confirm it is configured.
+
+Run ` + "`" + `rimba version` + "`" + ` to check if rimba is installed.
+If not found, **ask the user** before installing. Never install automatically.
+
+## Command Reference
+
+| Concern | Commands |
+|---------|----------|
+| Create & navigate | ` + "`" + `rimba add <task>` + "`" + `, ` + "`" + `rimba open <task>` + "`" + ` |
+| Inspect | ` + "`" + `rimba list` + "`" + `, ` + "`" + `rimba status` + "`" + ` |
+| Sync & merge | ` + "`" + `rimba sync [task]` + "`" + `, ` + "`" + `rimba merge <task>` + "`" + ` |
+| Clean up | ` + "`" + `rimba clean --merged` + "`" + `, ` + "`" + `rimba archive <task>` + "`" + ` |
+| AI integration | ` + "`" + `rimba mcp` + "`" + ` (MCP server for AI coding agents) |
+
+<!-- END RIMBA -->`
+}
+
+// globalWindsurfBlock returns the user-level rimba block for ~/.codeium/windsurf/memories/global_rules.md.
+func globalWindsurfBlock() string {
+	return `<!-- BEGIN RIMBA -->
+<!-- Managed by rimba — do not edit this block manually -->
+
+## rimba (Git Worktree Manager)
+
+rimba manages parallel git worktrees. Check for ` + "`" + `.rimba/settings.toml` + "`" + ` to confirm it is configured in the current project.
+
+### Key Commands
+
+- ` + "`" + `rimba add <task>` + "`" + ` — create worktree + branch
+- ` + "`" + `rimba list` + "`" + ` / ` + "`" + `rimba status` + "`" + ` — inspect worktrees
+- ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
+- ` + "`" + `rimba clean --merged` + "`" + ` — remove merged worktrees
+- ` + "`" + `rimba mcp` + "`" + ` — start MCP server for AI tool integration
+
+<!-- END RIMBA -->`
+}
+
+// globalRooContent returns the user-level content for ~/.roo/rules/rimba.md.
+func globalRooContent() string {
+	return `# rimba — Git Worktree Manager
+
+rimba manages parallel git worktrees so you can work on multiple tasks simultaneously.
+Check for ` + "`" + `.rimba/settings.toml` + "`" + ` in the current repo to confirm it is configured.
+
+Run ` + "`" + `rimba version` + "`" + ` to check if rimba is installed.
+If not found, ask the user before installing. Never install automatically.
+
+## Top Commands
+
+1. ` + "`" + `rimba add <task>` + "`" + ` — create worktree + branch
+2. ` + "`" + `rimba list` + "`" + ` — list all worktrees
+3. ` + "`" + `rimba status` + "`" + ` — health overview
+4. ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
+5. ` + "`" + `rimba clean --merged` + "`" + ` — remove merged worktrees
+6. ` + "`" + `rimba sync [task]` + "`" + ` — rebase onto main
+7. ` + "`" + `rimba mcp` + "`" + ` — start MCP server for AI tool integration
+`
+}
+
 // claudeSkillContent returns the full content for .claude/skills/rimba/SKILL.md (whole-file, rimba-owned).
 func claudeSkillContent() string {
 	return `---

--- a/tests/e2e/init_test.go
+++ b/tests/e2e/init_test.go
@@ -71,12 +71,12 @@ func TestInitExistingConfigInstallsAgentFiles(t *testing.T) {
 	}
 
 	repo := setupRepo(t)
-	rimbaSuccess(t, repo, "init", "--agent-files")
+	rimbaSuccess(t, repo, "init", "--agents")
 
 	// Re-running init should succeed and update agent files
-	r := rimbaSuccess(t, repo, "init", "--agent-files")
+	r := rimbaSuccess(t, repo, "init", "--agents")
 	assertContains(t, r.Stdout, "already exists")
-	assertContains(t, r.Stdout, "Agent:")
+	assertContains(t, r.Stdout, "rimba")
 }
 
 func TestInitAddsToGitignore(t *testing.T) {
@@ -189,19 +189,95 @@ func TestInitFailsOutsideGitRepo(t *testing.T) {
 	rimbaFail(t, dir, "init")
 }
 
-func TestInitWithAgentFilesFlag(t *testing.T) {
+func TestInitWithAgentsFlag(t *testing.T) {
 	if testing.Short() {
 		t.Skip(skipE2E)
 	}
 
 	repo := setupRepo(t)
-	r := rimbaSuccess(t, repo, "init", "--agent-files")
+	r := rimbaSuccess(t, repo, "init", "--agents")
 
-	assertContains(t, r.Stdout, "Agent:")
+	assertContains(t, r.Stdout, "Installed rimba agent files")
 	assertFileExists(t, filepath.Join(repo, "AGENTS.md"))
 	assertFileExists(t, filepath.Join(repo, ".github", "copilot-instructions.md"))
 	assertFileExists(t, filepath.Join(repo, ".cursor", "rules", "rimba.mdc"))
 	assertFileExists(t, filepath.Join(repo, ".claude", "skills", "rimba", "SKILL.md"))
+	assertFileExists(t, filepath.Join(repo, "GEMINI.md"))
+	assertFileExists(t, filepath.Join(repo, ".windsurf", "rules", "rimba.md"))
+	assertFileExists(t, filepath.Join(repo, ".clinerules", "rimba.md"))
+}
+
+func TestInitAgentsLocalAddsGitignore(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupRepo(t)
+	rimbaSuccess(t, repo, "init", "--agents", "--local")
+
+	// All 7 project spec rel paths should be in .gitignore
+	assertGitignoreContains(t, repo, "AGENTS.md")
+	assertGitignoreContains(t, repo, "GEMINI.md")
+	assertGitignoreContains(t, repo, filepath.Join(".windsurf", "rules", "rimba.md"))
+}
+
+func TestInitAgentsUninstall(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupRepo(t)
+	rimbaSuccess(t, repo, "init", "--agents")
+	r := rimbaSuccess(t, repo, "init", "--agents", "--uninstall")
+
+	assertContains(t, r.Stdout, "Removed rimba agent files")
+	assertFileNotExists(t, filepath.Join(repo, ".cursor", "rules", "rimba.mdc"))
+}
+
+func TestInitGlobalOutsideRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Run from a non-git directory
+	dir := t.TempDir()
+	r := rimbaSuccess(t, dir, "init", "-g")
+
+	assertContains(t, r.Stdout, "Installed rimba agent files (user)")
+	assertFileExists(t, filepath.Join(home, ".claude", "skills", "rimba", "SKILL.md"))
+	assertFileExists(t, filepath.Join(home, ".cursor", "rules", "rimba.mdc"))
+	assertFileExists(t, filepath.Join(home, ".codex", "AGENTS.md"))
+	assertFileExists(t, filepath.Join(home, ".gemini", "GEMINI.md"))
+	assertFileExists(t, filepath.Join(home, ".codeium", "windsurf", "memories", "global_rules.md"))
+	assertFileExists(t, filepath.Join(home, ".roo", "rules", "rimba.md"))
+}
+
+func TestInitGlobalUninstall(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := t.TempDir()
+	rimbaSuccess(t, dir, "init", "-g")
+	r := rimbaSuccess(t, dir, "init", "-g", "--uninstall")
+
+	assertContains(t, r.Stdout, "Removed rimba agent files (user)")
+	assertFileNotExists(t, filepath.Join(home, ".claude", "skills", "rimba", "SKILL.md"))
+}
+
+func TestInitOldAgentFilesFlagFails(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupRepo(t)
+	rimbaFail(t, repo, "init", "--agent-files")
 }
 
 func TestInitSkipsAgentFilesWithoutFlag(t *testing.T) {
@@ -212,7 +288,7 @@ func TestInitSkipsAgentFilesWithoutFlag(t *testing.T) {
 	repo := setupRepo(t)
 	r := rimbaSuccess(t, repo, "init")
 
-	assertNotContains(t, r.Stdout, "Agent:")
+	assertNotContains(t, r.Stdout, "rimba agent files")
 	assertFileNotExists(t, filepath.Join(repo, "AGENTS.md"))
 }
 

--- a/tests/e2e/init_test.go
+++ b/tests/e2e/init_test.go
@@ -249,6 +249,7 @@ func TestInitGlobalOutsideRepo(t *testing.T) {
 	assertContains(t, r.Stdout, "Installed rimba agent files (user)")
 	assertFileExists(t, filepath.Join(home, ".claude", "skills", "rimba", "SKILL.md"))
 	assertFileExists(t, filepath.Join(home, ".cursor", "rules", "rimba.mdc"))
+	assertFileExists(t, filepath.Join(home, ".github", "copilot-instructions.md"))
 	assertFileExists(t, filepath.Join(home, ".codex", "AGENTS.md"))
 	assertFileExists(t, filepath.Join(home, ".gemini", "GEMINI.md"))
 	assertFileExists(t, filepath.Join(home, ".codeium", "windsurf", "memories", "global_rules.md"))


### PR DESCRIPTION
## Summary
- Replace `--agent-files` flag with `-g` (user level), `--agents` (project-team), and `--agents --local` (project-local, gitignored) — a 3-tier install system matching git-config precedence semantics
- Expand supported AI agents from 4 to 7: adds Codex, Gemini CLI, Windsurf, and Cline/Roo at both user and project levels
- Add `--uninstall` flag for all three tiers; `-g` works outside a git repository; `MarkFlagsMutuallyExclusive` enforces `-g`/`--agents` can't be combined

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] 16 E2E init tests: `TestInitWithAgentsFlag`, `TestInitAgentsLocalAddsGitignore`, `TestInitAgentsUninstall`, `TestInitGlobalOutsideRepo`, `TestInitGlobalUninstall`, `TestInitOldAgentFilesFlagFails`, and existing init tests updated
- [x] Coverage 97.0% (threshold 97%)

Closes #121