### PR TITLE
[feat] Register rimba MCP server in agent configs during init -g

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -65,9 +65,9 @@ directory is already personal.`,
 				return fmt.Errorf("resolve home directory: %w", err)
 			}
 			if uninstall {
-				return runAgentOp(cmd, home, "user", agentfile.UninstallGlobal, "Removed")
+				return runInstall(cmd, home, "user", "Removed", agentfile.UninstallGlobal, agentfile.UnregisterMCPGlobal)
 			}
-			return runAgentOp(cmd, home, "user", agentfile.InstallGlobal, "Installed")
+			return runInstall(cmd, home, "user", "Installed", agentfile.InstallGlobal, agentfile.RegisterMCPGlobal)
 		}
 
 		r := newRunner()
@@ -186,35 +186,56 @@ directory is already personal.`,
 		if agents {
 			if uninstall {
 				if local {
-					return runAgentOp(cmd, repoRoot, "project-local", agentfile.UninstallLocal, "Removed")
+					return runInstall(cmd, repoRoot, "project-local", "Removed", agentfile.UninstallLocal, nil)
 				}
-				return runAgentOp(cmd, repoRoot, "project", agentfile.UninstallProject, "Removed")
+				return runInstall(cmd, repoRoot, "project", "Removed", agentfile.UninstallProject, agentfile.UnregisterMCPProject)
 			}
 			if local {
-				return runAgentOp(cmd, repoRoot, "project-local", agentfile.InstallLocal, "Installed")
+				return runInstall(cmd, repoRoot, "project-local", "Installed", agentfile.InstallLocal, nil)
 			}
-			return runAgentOp(cmd, repoRoot, "project", agentfile.InstallProject, "Installed")
+			return runInstall(cmd, repoRoot, "project", "Installed", agentfile.InstallProject, agentfile.RegisterMCPProject)
 		}
 
 		return nil
 	},
 }
 
-// runAgentOp runs fn(dir) and prints results to cmd output.
-func runAgentOp(cmd *cobra.Command, dir, tier string, fn func(string) ([]agentfile.Result, error), verb string) error {
-	results, err := fn(dir)
+// runInstall runs installFn(dir) and optionally mcpFn(dir), then prints results.
+// mcpFn may be nil (local tier skips MCP registration).
+func runInstall(
+	cmd *cobra.Command,
+	dir, tier, verb string,
+	installFn func(string) ([]agentfile.Result, error),
+	mcpFn func(string) ([]agentfile.Result, error),
+) error {
+	files, err := installFn(dir)
 	if err != nil {
 		return fmt.Errorf("agent files: %w", err)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "%s rimba agent files (%s):\n", verb, tier)
-	for _, res := range results {
-		relPath := res.RelPath
-		if tier == "user" {
-			relPath = "~/" + relPath
+	var mcps []agentfile.Result
+	if mcpFn != nil {
+		mcps, err = mcpFn(dir)
+		if err != nil {
+			return fmt.Errorf("mcp servers: %w", err)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "  %s (%s)\n", relPath, res.Action)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "%s rimba (%s):\n", verb, tier)
+	printSection(cmd, "Agent files", tier, files)
+	if len(mcps) > 0 {
+		printSection(cmd, "MCP server", tier, mcps)
 	}
 	return nil
+}
+
+func printSection(cmd *cobra.Command, title, tier string, results []agentfile.Result) {
+	fmt.Fprintf(cmd.OutOrStdout(), "  %s:\n", title)
+	for _, r := range results {
+		p := r.RelPath
+		if tier == "user" {
+			p = "~/" + p
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "    %s (%s)\n", p, r.Action)
+	}
 }
 
 func init() {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -186,11 +186,13 @@ directory is already personal.`,
 		if agents {
 			if uninstall {
 				if local {
+					// local tier installs gitignored personal files; MCP registration skipped
 					return runInstall(cmd, repoRoot, "project-local", "Removed", agentfile.UninstallLocal, nil)
 				}
 				return runInstall(cmd, repoRoot, "project", "Removed", agentfile.UninstallProject, agentfile.UnregisterMCPProject)
 			}
 			if local {
+				// local tier installs gitignored personal files; MCP registration skipped
 				return runInstall(cmd, repoRoot, "project-local", "Installed", agentfile.InstallLocal, nil)
 			}
 			return runInstall(cmd, repoRoot, "project", "Installed", agentfile.InstallProject, agentfile.RegisterMCPProject)
@@ -220,7 +222,9 @@ func runInstall(
 		}
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "%s rimba (%s):\n", verb, tier)
-	printSection(cmd, "Agent files", tier, files)
+	if len(files) > 0 {
+		printSection(cmd, "Agent files", tier, files)
+	}
 	if len(mcps) > 0 {
 		printSection(cmd, "MCP server", tier, mcps)
 	}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -748,6 +748,37 @@ func TestInitAgentsLocalSkipsMCP(t *testing.T) {
 	}
 }
 
+func TestInitGlobalMCPErrorPropagated(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Write malformed JSON to settings.json — triggers patchJSON error
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("not json"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	r := &mockRunner{
+		run:      func(...string) (string, error) { return "", errors.New("not a git repo") },
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	cmd.Flags().Bool(flagGlobal, true, "")
+	err := initCmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error for malformed MCP config, got nil")
+	}
+	if !strings.Contains(err.Error(), "mcp servers") {
+		t.Errorf("error should mention 'mcp servers', got: %v", err)
+	}
+}
+
 func TestInitPersonalFreshInit(t *testing.T) {
 	repoDir := t.TempDir()
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -517,6 +518,233 @@ func TestInitFlagValidationErrors(t *testing.T) {
 				t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantErr)
 			}
 		})
+	}
+}
+
+// --- MCP registration tests ---
+
+func TestInitGlobalRegistersMCP(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Pre-seed .claude/settings.json so MCP registration doesn't skip it
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("{}\n"), 0600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+
+	r := &mockRunner{
+		run:      func(...string) (string, error) { return "", errors.New("not a git repo") },
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().Bool(flagGlobal, true, "")
+	if err := initCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("initCmd.RunE: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Agent files:") {
+		t.Errorf("output should contain 'Agent files:', got:\n%s", out)
+	}
+	if !strings.Contains(out, "MCP server:") {
+		t.Errorf("output should contain 'MCP server:', got:\n%s", out)
+	}
+	if !strings.Contains(out, filepath.Join(".claude", "settings.json")) {
+		t.Errorf("output should mention settings.json, got:\n%s", out)
+	}
+	if !strings.Contains(out, "registered") {
+		t.Errorf("output should say 'registered', got:\n%s", out)
+	}
+
+	// Verify the file was patched
+	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse settings.json: %v", err)
+	}
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers missing in settings.json")
+	}
+	entry, ok := servers["rimba"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers.rimba missing")
+	}
+	if entry["command"] != "rimba" {
+		t.Errorf("command = %v, want rimba", entry["command"])
+	}
+}
+
+func TestInitGlobalMCPSkippedWhenNoConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	r := &mockRunner{
+		run:      func(...string) (string, error) { return "", errors.New("not a git repo") },
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().Bool(flagGlobal, true, "")
+	if err := initCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("initCmd.RunE: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "skipped") {
+		t.Errorf("output should contain 'skipped' for absent config files, got:\n%s", out)
+	}
+}
+
+func TestInitGlobalUninstallRemovesMCP(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("{}\n"), 0600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+
+	r := &mockRunner{
+		run:      func(...string) (string, error) { return "", errors.New("not a git repo") },
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	// Install
+	cmd1, _ := newTestCmd()
+	cmd1.Flags().Bool(flagGlobal, true, "")
+	if err := initCmd.RunE(cmd1, nil); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Uninstall
+	cmd2, buf := newTestCmd()
+	cmd2.Flags().Bool(flagGlobal, true, "")
+	cmd2.Flags().Bool(flagUninstall, true, "")
+	if err := initCmd.RunE(cmd2, nil); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "unregistered") {
+		t.Errorf("output should say 'unregistered', got:\n%s", out)
+	}
+
+	// rimba key should be gone
+	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if servers, ok := cfg["mcpServers"].(map[string]any); ok {
+		if _, found := servers["rimba"]; found {
+			t.Error("rimba key should be removed after uninstall")
+		}
+	}
+}
+
+func TestInitAgentsMCPRegistration(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// Pre-seed .mcp.json so registration doesn't skip
+	if err := os.WriteFile(filepath.Join(repoDir, ".mcp.json"), []byte("{}\n"), 0600); err != nil {
+		t.Fatalf("write .mcp.json: %v", err)
+	}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().Bool(flagAgents, true, "")
+	if err := initCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("initCmd.RunE: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "MCP server:") {
+		t.Errorf("output should contain 'MCP server:', got:\n%s", out)
+	}
+	if !strings.Contains(out, ".mcp.json") {
+		t.Errorf("output should mention .mcp.json, got:\n%s", out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(repoDir, ".mcp.json"))
+	if err != nil {
+		t.Fatalf("read .mcp.json: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse .mcp.json: %v", err)
+	}
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers missing in .mcp.json")
+	}
+	if _, ok := servers["rimba"]; !ok {
+		t.Error("mcpServers.rimba should be registered in .mcp.json")
+	}
+}
+
+func TestInitAgentsLocalSkipsMCP(t *testing.T) {
+	repoDir := t.TempDir()
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().Bool(flagAgents, true, "")
+	cmd.Flags().Bool(flagLocal, true, "")
+	if err := initCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("initCmd.RunE: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "MCP server:") {
+		t.Errorf("--agents --local should not output 'MCP server:' section, got:\n%s", out)
 	}
 }
 

--- a/internal/agentfile/agentfile.go
+++ b/internal/agentfile/agentfile.go
@@ -14,10 +14,14 @@ const (
 	BeginMarker = "<!-- BEGIN RIMBA -->"
 	EndMarker   = "<!-- END RIMBA -->"
 
-	actionCreated = "created"
-	actionUpdated = "updated"
-	actionRemoved = "removed"
-	actionSkipped = "skipped"
+	actionCreated         = "created"
+	actionUpdated         = "updated"
+	actionRemoved         = "removed"
+	actionSkipped         = "skipped"
+	actionRegistered      = "registered"
+	actionUnregistered    = "unregistered"
+	actionUnchanged       = "unchanged"
+	actionSkippedNoConfig = "skipped — no config"
 )
 
 // FileKind distinguishes installation strategies.

--- a/internal/agentfile/mcpreg.go
+++ b/internal/agentfile/mcpreg.go
@@ -40,6 +40,8 @@ func GlobalMCPSpecs() []MCPSpec {
 }
 
 // ProjectMCPSpecs returns the MCP config files patched at project level (repo root).
+// .cursor/mcp.json here is repo-root-relative (Cursor workspace MCP), distinct from
+// the global ~/.cursor/mcp.json patched by GlobalMCPSpecs.
 func ProjectMCPSpecs() []MCPSpec {
 	return []MCPSpec{
 		{RelPath: ".mcp.json", Format: mcpJSON, ContainerKey: "mcpServers"},

--- a/internal/agentfile/mcpreg.go
+++ b/internal/agentfile/mcpreg.go
@@ -40,8 +40,7 @@ func GlobalMCPSpecs() []MCPSpec {
 }
 
 // ProjectMCPSpecs returns the MCP config files patched at project level (repo root).
-// .cursor/mcp.json here is repo-root-relative (Cursor workspace MCP), distinct from
-// the global ~/.cursor/mcp.json patched by GlobalMCPSpecs.
+// .cursor/mcp.json is repo-root-relative (workspace MCP), distinct from ~/.cursor/mcp.json.
 func ProjectMCPSpecs() []MCPSpec {
 	return []MCPSpec{
 		{RelPath: ".mcp.json", Format: mcpJSON, ContainerKey: "mcpServers"},
@@ -50,7 +49,6 @@ func ProjectMCPSpecs() []MCPSpec {
 }
 
 // RegisterMCPGlobal patches all user-level MCP config files to add the rimba server entry.
-// Files that do not exist are skipped with actionSkippedNoConfig.
 func RegisterMCPGlobal(homeDir string) ([]Result, error) {
 	return registerMCPSpecs(homeDir, GlobalMCPSpecs())
 }
@@ -117,8 +115,6 @@ func desiredEntry() map[string]any {
 	}
 }
 
-// patchJSON reads path, merges or removes the rimba entry under containerKey, and writes back.
-// remove=false registers, remove=true unregisters.
 func patchJSON(path, containerKey string, remove bool) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -164,7 +160,6 @@ func removeFromJSON(path, containerKey string, cfg map[string]any) (string, erro
 	return actionUnregistered, writeJSON(path, cfg)
 }
 
-// patchTOML reads path, merges or removes the rimba entry under containerKey, and writes back.
 func patchTOML(path, containerKey string, remove bool) (string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/agentfile/mcpreg.go
+++ b/internal/agentfile/mcpreg.go
@@ -1,0 +1,227 @@
+package agentfile
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+const mcpServerName = "rimba"
+
+type mcpFormat int
+
+const (
+	mcpJSON mcpFormat = iota
+	mcpTOML
+)
+
+// MCPSpec describes a single agent MCP config file to patch.
+type MCPSpec struct {
+	RelPath      string    // relative to baseDir (homeDir or repoRoot)
+	Format       mcpFormat // mcpJSON or mcpTOML
+	ContainerKey string    // "mcpServers" for JSON agents, "mcp_servers" for Codex TOML
+}
+
+// GlobalMCPSpecs returns the MCP config files patched at user level (~/).
+func GlobalMCPSpecs() []MCPSpec {
+	return []MCPSpec{
+		{RelPath: filepath.Join(".claude", "settings.json"), Format: mcpJSON, ContainerKey: "mcpServers"},
+		{RelPath: filepath.Join(".cursor", "mcp.json"), Format: mcpJSON, ContainerKey: "mcpServers"},
+		{RelPath: filepath.Join(".codeium", "windsurf", "mcp_config.json"), Format: mcpJSON, ContainerKey: "mcpServers"},
+		{RelPath: filepath.Join(".codex", "config.toml"), Format: mcpTOML, ContainerKey: "mcp_servers"},
+		{RelPath: filepath.Join(".gemini", "settings.json"), Format: mcpJSON, ContainerKey: "mcpServers"},
+		{RelPath: filepath.Join(".roo", "mcp.json"), Format: mcpJSON, ContainerKey: "mcpServers"},
+	}
+}
+
+// ProjectMCPSpecs returns the MCP config files patched at project level (repo root).
+func ProjectMCPSpecs() []MCPSpec {
+	return []MCPSpec{
+		{RelPath: ".mcp.json", Format: mcpJSON, ContainerKey: "mcpServers"},
+		{RelPath: filepath.Join(".cursor", "mcp.json"), Format: mcpJSON, ContainerKey: "mcpServers"},
+	}
+}
+
+// RegisterMCPGlobal patches all user-level MCP config files to add the rimba server entry.
+// Files that do not exist are skipped with actionSkippedNoConfig.
+func RegisterMCPGlobal(homeDir string) ([]Result, error) {
+	return registerMCPSpecs(homeDir, GlobalMCPSpecs())
+}
+
+// UnregisterMCPGlobal removes the rimba server entry from all user-level MCP config files.
+func UnregisterMCPGlobal(homeDir string) ([]Result, error) {
+	return unregisterMCPSpecs(homeDir, GlobalMCPSpecs())
+}
+
+// RegisterMCPProject patches project-level MCP config files to add the rimba server entry.
+func RegisterMCPProject(repoRoot string) ([]Result, error) {
+	return registerMCPSpecs(repoRoot, ProjectMCPSpecs())
+}
+
+// UnregisterMCPProject removes the rimba server entry from project-level MCP config files.
+func UnregisterMCPProject(repoRoot string) ([]Result, error) {
+	return unregisterMCPSpecs(repoRoot, ProjectMCPSpecs())
+}
+
+func registerMCPSpecs(baseDir string, specs []MCPSpec) ([]Result, error) {
+	results := make([]Result, 0, len(specs))
+	for _, spec := range specs {
+		path := filepath.Join(baseDir, spec.RelPath)
+		var action string
+		var err error
+		switch spec.Format {
+		case mcpJSON:
+			action, err = patchJSON(path, spec.ContainerKey, false)
+		case mcpTOML:
+			action, err = patchTOML(path, spec.ContainerKey, false)
+		}
+		if err != nil {
+			return results, err
+		}
+		results = append(results, Result{RelPath: spec.RelPath, Action: action})
+	}
+	return results, nil
+}
+
+func unregisterMCPSpecs(baseDir string, specs []MCPSpec) ([]Result, error) {
+	results := make([]Result, 0, len(specs))
+	for _, spec := range specs {
+		path := filepath.Join(baseDir, spec.RelPath)
+		var action string
+		var err error
+		switch spec.Format {
+		case mcpJSON:
+			action, err = patchJSON(path, spec.ContainerKey, true)
+		case mcpTOML:
+			action, err = patchTOML(path, spec.ContainerKey, true)
+		}
+		if err != nil {
+			return results, err
+		}
+		results = append(results, Result{RelPath: spec.RelPath, Action: action})
+	}
+	return results, nil
+}
+
+func desiredEntry() map[string]any {
+	return map[string]any{
+		"command": mcpServerName,
+		"args":    []any{"mcp"},
+	}
+}
+
+// patchJSON reads path, merges or removes the rimba entry under containerKey, and writes back.
+// remove=false registers, remove=true unregisters.
+func patchJSON(path, containerKey string, remove bool) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return actionSkippedNoConfig, nil
+		}
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return "", fmt.Errorf("parse %s: %w", path, err)
+	}
+	if remove {
+		return removeFromJSON(path, containerKey, cfg)
+	}
+	return addToJSON(path, containerKey, cfg)
+}
+
+func addToJSON(path, containerKey string, cfg map[string]any) (string, error) {
+	servers, _ := cfg[containerKey].(map[string]any)
+	if servers == nil {
+		servers = map[string]any{}
+	}
+	desired := desiredEntry()
+	if reflect.DeepEqual(servers[mcpServerName], desired) {
+		return actionUnchanged, nil
+	}
+	servers[mcpServerName] = desired
+	cfg[containerKey] = servers
+	return actionRegistered, writeJSON(path, cfg)
+}
+
+func removeFromJSON(path, containerKey string, cfg map[string]any) (string, error) {
+	servers, _ := cfg[containerKey].(map[string]any)
+	if servers == nil {
+		return actionUnchanged, nil
+	}
+	if _, present := servers[mcpServerName]; !present {
+		return actionUnchanged, nil
+	}
+	delete(servers, mcpServerName)
+	cfg[containerKey] = servers
+	return actionUnregistered, writeJSON(path, cfg)
+}
+
+// patchTOML reads path, merges or removes the rimba entry under containerKey, and writes back.
+func patchTOML(path, containerKey string, remove bool) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return actionSkippedNoConfig, nil
+		}
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	var cfg map[string]any
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return "", fmt.Errorf("parse %s: %w", path, err)
+	}
+	if remove {
+		return removeFromTOML(path, containerKey, cfg)
+	}
+	return addToTOML(path, containerKey, cfg)
+}
+
+func addToTOML(path, containerKey string, cfg map[string]any) (string, error) {
+	servers, _ := cfg[containerKey].(map[string]any)
+	if servers == nil {
+		servers = map[string]any{}
+	}
+	// TOML library decodes args as []any, matching desiredEntry() shape.
+	desired := desiredEntry()
+	if reflect.DeepEqual(servers[mcpServerName], desired) {
+		return actionUnchanged, nil
+	}
+	servers[mcpServerName] = desired
+	cfg[containerKey] = servers
+	return actionRegistered, writeTOML(path, cfg)
+}
+
+func removeFromTOML(path, containerKey string, cfg map[string]any) (string, error) {
+	servers, _ := cfg[containerKey].(map[string]any)
+	if servers == nil {
+		return actionUnchanged, nil
+	}
+	if _, present := servers[mcpServerName]; !present {
+		return actionUnchanged, nil
+	}
+	delete(servers, mcpServerName)
+	cfg[containerKey] = servers
+	return actionUnregistered, writeTOML(path, cfg)
+}
+
+func writeJSON(path string, cfg map[string]any) error {
+	out, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", path, err)
+	}
+	out = append(out, '\n')
+	return os.WriteFile(path, out, 0600)
+}
+
+func writeTOML(path string, cfg map[string]any) error {
+	out, err := toml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", path, err)
+	}
+	return os.WriteFile(path, out, 0600)
+}

--- a/internal/agentfile/mcpreg_test.go
+++ b/internal/agentfile/mcpreg_test.go
@@ -278,6 +278,67 @@ func TestRegisterMCPProjectSkipsAbsentFiles(t *testing.T) {
 	}
 }
 
+func TestUnregisterMCPGlobalTOMLCodex(t *testing.T) {
+	home := t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Seed with rimba and other entries
+	content := "[mcp_servers.rimba]\ncommand = \"rimba\"\nargs = [\"mcp\"]\n[mcp_servers.other]\ncommand = \"x\"\nargs = []\n"
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(content), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	results, err := UnregisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("UnregisterMCPGlobal: %v", err)
+	}
+
+	codexResult := findResult(t, results, filepath.Join(".codex", "config.toml"))
+	if codexResult.Action != actionUnregistered {
+		t.Errorf("action = %q, want %q", codexResult.Action, actionUnregistered)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexDir, "config.toml"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var cfg map[string]any
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("toml unmarshal: %v", err)
+	}
+	servers, ok := cfg["mcp_servers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcp_servers should still exist")
+	}
+	if _, found := servers[mcpServerName]; found {
+		t.Error("rimba entry should have been removed from TOML config")
+	}
+	if _, found := servers["other"]; !found {
+		t.Error("other entry should be preserved in TOML config")
+	}
+}
+
+func TestPatchTOMLMalformedReturnsError(t *testing.T) {
+	home := t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte("not = [valid toml\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := RegisterMCPGlobal(home)
+	if err == nil {
+		t.Error("expected error for malformed TOML, got nil")
+	}
+	if !strings.Contains(err.Error(), "config.toml") {
+		t.Errorf("error should mention config.toml, got: %v", err)
+	}
+}
+
 func TestPatchJSONMalformedReturnsError(t *testing.T) {
 	home := t.TempDir()
 	claudeDir := filepath.Join(home, ".claude")
@@ -333,6 +394,107 @@ func TestUnregisterMCPProjectRemovesRimba(t *testing.T) {
 	}
 	if _, found := servers[mcpServerName]; found {
 		t.Error("rimba should have been removed")
+	}
+}
+
+func TestRegisterMCPGlobalTOMLNoExistingSection(t *testing.T) {
+	home := t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// TOML file with no mcp_servers section — triggers addToTOML nil branch
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte("[settings]\nfoo = \"bar\"\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	results, err := RegisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("RegisterMCPGlobal: %v", err)
+	}
+
+	codexResult := findResult(t, results, filepath.Join(".codex", "config.toml"))
+	if codexResult.Action != actionRegistered {
+		t.Errorf("action = %q, want %q", codexResult.Action, actionRegistered)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexDir, "config.toml"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var cfg map[string]any
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("toml unmarshal: %v", err)
+	}
+	servers, ok := cfg["mcp_servers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcp_servers should have been created")
+	}
+	if _, ok := servers[mcpServerName]; !ok {
+		t.Error("rimba entry should have been added")
+	}
+}
+
+func TestUnregisterMCPGlobalTOMLSkipsWhenNoSection(t *testing.T) {
+	home := t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// TOML file with no mcp_servers section — triggers removeFromTOML nil branch
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte("[settings]\nfoo = \"bar\"\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	results, err := UnregisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("UnregisterMCPGlobal: %v", err)
+	}
+
+	codexResult := findResult(t, results, filepath.Join(".codex", "config.toml"))
+	if codexResult.Action != actionUnchanged {
+		t.Errorf("action = %q, want %q", codexResult.Action, actionUnchanged)
+	}
+}
+
+func TestUnregisterMCPGlobalTOMLSkipsWhenKeyMissing(t *testing.T) {
+	home := t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// mcp_servers section exists but no rimba key
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte("[mcp_servers.other]\ncommand = \"x\"\nargs = []\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	results, err := UnregisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("UnregisterMCPGlobal: %v", err)
+	}
+
+	codexResult := findResult(t, results, filepath.Join(".codex", "config.toml"))
+	if codexResult.Action != actionUnchanged {
+		t.Errorf("action = %q, want %q", codexResult.Action, actionUnchanged)
+	}
+}
+
+func TestUnregisterMCPGlobalMalformedTOMLReturnsError(t *testing.T) {
+	home := t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte("not = [valid toml\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := UnregisterMCPGlobal(home)
+	if err == nil {
+		t.Error("expected error for malformed TOML on unregister, got nil")
+	}
+	if !strings.Contains(err.Error(), "config.toml") {
+		t.Errorf("error should mention config.toml, got: %v", err)
 	}
 }
 

--- a/internal/agentfile/mcpreg_test.go
+++ b/internal/agentfile/mcpreg_test.go
@@ -137,6 +137,16 @@ func TestRegisterMCPGlobalTOMLCodex(t *testing.T) {
 	if entry["command"] != mcpServerName {
 		t.Errorf("command = %v, want %s", entry["command"], mcpServerName)
 	}
+
+	// Idempotency: second registration must return actionUnchanged for TOML
+	results2, err := RegisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("second RegisterMCPGlobal: %v", err)
+	}
+	codexResult2 := findResult(t, results2, filepath.Join(".codex", "config.toml"))
+	if codexResult2.Action != actionUnchanged {
+		t.Errorf("second register (TOML): action = %q, want %q", codexResult2.Action, actionUnchanged)
+	}
 }
 
 // --- UnregisterMCPGlobal tests ---

--- a/internal/agentfile/mcpreg_test.go
+++ b/internal/agentfile/mcpreg_test.go
@@ -1,0 +1,384 @@
+package agentfile
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// --- RegisterMCPGlobal tests ---
+
+func TestRegisterMCPGlobalPatchesExistingJSON(t *testing.T) {
+	home := t.TempDir()
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seedJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]any{"theme": "dark"})
+
+	results, err := RegisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("RegisterMCPGlobal: %v", err)
+	}
+
+	claudeResult := findResult(t, results, filepath.Join(".claude", "settings.json"))
+	if claudeResult.Action != actionRegistered {
+		t.Errorf("action = %q, want %q", claudeResult.Action, actionRegistered)
+	}
+
+	cfg := readJSONFile(t, filepath.Join(claudeDir, "settings.json"))
+	if cfg["theme"] != "dark" {
+		t.Error("existing 'theme' key was not preserved")
+	}
+	assertRimbaJSONEntry(t, cfg)
+}
+
+func TestRegisterMCPGlobalSkipsAbsentFiles(t *testing.T) {
+	home := t.TempDir()
+
+	results, err := RegisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("RegisterMCPGlobal: %v", err)
+	}
+
+	if len(results) != len(GlobalMCPSpecs()) {
+		t.Fatalf("len(results) = %d, want %d", len(results), len(GlobalMCPSpecs()))
+	}
+	for _, r := range results {
+		if r.Action != actionSkippedNoConfig {
+			t.Errorf("%s: action = %q, want %q", r.RelPath, r.Action, actionSkippedNoConfig)
+		}
+	}
+
+	entries, _ := os.ReadDir(home)
+	if len(entries) != 0 {
+		t.Errorf("home dir should be empty but has %d entries", len(entries))
+	}
+}
+
+func TestRegisterMCPGlobalIdempotent(t *testing.T) {
+	home := t.TempDir()
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seedJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]any{})
+
+	if _, err := RegisterMCPGlobal(home); err != nil {
+		t.Fatalf("first RegisterMCPGlobal: %v", err)
+	}
+	firstContents, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	results, err := RegisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("second RegisterMCPGlobal: %v", err)
+	}
+	claudeResult := findResult(t, results, filepath.Join(".claude", "settings.json"))
+	if claudeResult.Action != actionUnchanged {
+		t.Errorf("second register: action = %q, want %q", claudeResult.Action, actionUnchanged)
+	}
+
+	secondContents, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(firstContents) != string(secondContents) {
+		t.Error("file changed on idempotent re-registration")
+	}
+}
+
+func TestRegisterMCPGlobalTOMLCodex(t *testing.T) {
+	home := t.TempDir()
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	existing := "[mcp_servers.other]\ncommand = \"x\"\nargs = []\n"
+	if err := os.WriteFile(filepath.Join(codexDir, "config.toml"), []byte(existing), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	results, err := RegisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("RegisterMCPGlobal: %v", err)
+	}
+
+	codexResult := findResult(t, results, filepath.Join(".codex", "config.toml"))
+	if codexResult.Action != actionRegistered {
+		t.Errorf("action = %q, want %q", codexResult.Action, actionRegistered)
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexDir, "config.toml"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var cfg map[string]any
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("toml unmarshal: %v", err)
+	}
+	servers, ok := cfg["mcp_servers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcp_servers missing or wrong type")
+	}
+	if _, ok := servers["other"]; !ok {
+		t.Error("existing 'other' entry was removed")
+	}
+	entry, ok := servers[mcpServerName].(map[string]any)
+	if !ok {
+		t.Fatal("mcp_servers.rimba missing or wrong type")
+	}
+	if entry["command"] != mcpServerName {
+		t.Errorf("command = %v, want %s", entry["command"], mcpServerName)
+	}
+}
+
+// --- UnregisterMCPGlobal tests ---
+
+func TestUnregisterMCPGlobalRemovesOnlyRimba(t *testing.T) {
+	home := t.TempDir()
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seedJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]any{
+		"mcpServers": map[string]any{
+			mcpServerName: map[string]any{"command": mcpServerName, "args": []any{"mcp"}},
+			"other":       map[string]any{"command": "other-tool", "args": []any{}},
+		},
+	})
+
+	results, err := UnregisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("UnregisterMCPGlobal: %v", err)
+	}
+
+	claudeResult := findResult(t, results, filepath.Join(".claude", "settings.json"))
+	if claudeResult.Action != actionUnregistered {
+		t.Errorf("action = %q, want %q", claudeResult.Action, actionUnregistered)
+	}
+
+	cfg := readJSONFile(t, filepath.Join(claudeDir, "settings.json"))
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers should still be present")
+	}
+	if _, found := servers[mcpServerName]; found {
+		t.Error("rimba entry should have been removed")
+	}
+	if _, found := servers["other"]; !found {
+		t.Error("other entry should be preserved")
+	}
+}
+
+func TestUnregisterMCPGlobalSkipsAbsent(t *testing.T) {
+	home := t.TempDir()
+
+	results, err := UnregisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("UnregisterMCPGlobal: %v", err)
+	}
+
+	for _, r := range results {
+		if r.Action != actionSkippedNoConfig {
+			t.Errorf("%s: action = %q, want %q", r.RelPath, r.Action, actionSkippedNoConfig)
+		}
+	}
+}
+
+func TestUnregisterMCPGlobalSkipsWhenKeyMissing(t *testing.T) {
+	home := t.TempDir()
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seedJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]any{"theme": "dark"})
+
+	results, err := UnregisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("UnregisterMCPGlobal: %v", err)
+	}
+
+	claudeResult := findResult(t, results, filepath.Join(".claude", "settings.json"))
+	if claudeResult.Action != actionUnchanged {
+		t.Errorf("action = %q, want %q", claudeResult.Action, actionUnchanged)
+	}
+}
+
+// --- RegisterMCPProject tests ---
+
+func TestRegisterMCPProjectPatchesDotMcpJson(t *testing.T) {
+	repoRoot := t.TempDir()
+	seedJSON(t, filepath.Join(repoRoot, ".mcp.json"), map[string]any{})
+	cursorDir := filepath.Join(repoRoot, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seedJSON(t, filepath.Join(cursorDir, "mcp.json"), map[string]any{
+		"mcpServers": map[string]any{
+			"other": map[string]any{"command": "other", "args": []any{}},
+		},
+	})
+
+	results, err := RegisterMCPProject(repoRoot)
+	if err != nil {
+		t.Fatalf("RegisterMCPProject: %v", err)
+	}
+
+	if len(results) != len(ProjectMCPSpecs()) {
+		t.Fatalf("len(results) = %d, want %d", len(results), len(ProjectMCPSpecs()))
+	}
+	for _, r := range results {
+		if r.Action != actionRegistered {
+			t.Errorf("%s: action = %q, want %q", r.RelPath, r.Action, actionRegistered)
+		}
+	}
+
+	assertRimbaJSONEntry(t, readJSONFile(t, filepath.Join(repoRoot, ".mcp.json")))
+
+	cursorCfg := readJSONFile(t, filepath.Join(cursorDir, "mcp.json"))
+	assertRimbaJSONEntry(t, cursorCfg)
+	servers, ok := cursorCfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers missing in .cursor/mcp.json")
+	}
+	if _, ok := servers["other"]; !ok {
+		t.Error(".cursor/mcp.json: 'other' entry was removed")
+	}
+}
+
+func TestRegisterMCPProjectSkipsAbsentFiles(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	results, err := RegisterMCPProject(repoRoot)
+	if err != nil {
+		t.Fatalf("RegisterMCPProject: %v", err)
+	}
+
+	for _, r := range results {
+		if r.Action != actionSkippedNoConfig {
+			t.Errorf("%s: action = %q, want %q", r.RelPath, r.Action, actionSkippedNoConfig)
+		}
+	}
+}
+
+func TestPatchJSONMalformedReturnsError(t *testing.T) {
+	home := t.TempDir()
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("not json {{{"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := RegisterMCPGlobal(home)
+	if err == nil {
+		t.Error("expected error for malformed JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "settings.json") {
+		t.Errorf("error should mention the file path, got: %v", err)
+	}
+}
+
+// --- UnregisterMCPProject tests ---
+
+func TestUnregisterMCPProjectRemovesRimba(t *testing.T) {
+	repoRoot := t.TempDir()
+	seedJSON(t, filepath.Join(repoRoot, ".mcp.json"), map[string]any{
+		"mcpServers": map[string]any{
+			mcpServerName: map[string]any{"command": mcpServerName, "args": []any{"mcp"}},
+		},
+	})
+
+	results, err := UnregisterMCPProject(repoRoot)
+	if err != nil {
+		t.Fatalf("UnregisterMCPProject: %v", err)
+	}
+
+	var mcpResult *Result
+	for i := range results {
+		if results[i].RelPath == ".mcp.json" {
+			mcpResult = &results[i]
+			break
+		}
+	}
+	if mcpResult == nil {
+		t.Fatal("no result for .mcp.json")
+	}
+	if mcpResult.Action != actionUnregistered {
+		t.Errorf("action = %q, want %q", mcpResult.Action, actionUnregistered)
+	}
+
+	cfg := readJSONFile(t, filepath.Join(repoRoot, ".mcp.json"))
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers should still exist")
+	}
+	if _, found := servers[mcpServerName]; found {
+		t.Error("rimba should have been removed")
+	}
+}
+
+// --- helpers ---
+
+func seedJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func readJSONFile(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var v map[string]any
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return v
+}
+
+func assertRimbaJSONEntry(t *testing.T, cfg map[string]any) {
+	t.Helper()
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("mcpServers key missing or wrong type")
+	}
+	entry, ok := servers[mcpServerName].(map[string]any)
+	if !ok {
+		t.Fatalf("mcpServers.%s missing or wrong type", mcpServerName)
+	}
+	if entry["command"] != mcpServerName {
+		t.Errorf("command = %v, want %s", entry["command"], mcpServerName)
+	}
+	args, ok := entry["args"].([]any)
+	if !ok || len(args) != 1 || args[0] != "mcp" {
+		t.Errorf("args = %v, want [mcp]", entry["args"])
+	}
+}
+
+func findResult(t *testing.T, results []Result, relPath string) Result {
+	t.Helper()
+	for _, r := range results {
+		if r.RelPath == relPath {
+			return r
+		}
+	}
+	t.Fatalf("no result for %s", relPath)
+	return Result{}
+}

--- a/tests/e2e/init_test.go
+++ b/tests/e2e/init_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -197,7 +198,7 @@ func TestInitWithAgentsFlag(t *testing.T) {
 	repo := setupRepo(t)
 	r := rimbaSuccess(t, repo, "init", "--agents")
 
-	assertContains(t, r.Stdout, "Installed rimba agent files")
+	assertContains(t, r.Stdout, "Installed rimba (project)")
 	assertFileExists(t, filepath.Join(repo, "AGENTS.md"))
 	assertFileExists(t, filepath.Join(repo, ".github", "copilot-instructions.md"))
 	assertFileExists(t, filepath.Join(repo, ".cursor", "rules", "rimba.mdc"))
@@ -230,7 +231,7 @@ func TestInitAgentsUninstall(t *testing.T) {
 	rimbaSuccess(t, repo, "init", "--agents")
 	r := rimbaSuccess(t, repo, "init", "--agents", "--uninstall")
 
-	assertContains(t, r.Stdout, "Removed rimba agent files")
+	assertContains(t, r.Stdout, "Removed rimba (project)")
 	assertFileNotExists(t, filepath.Join(repo, ".cursor", "rules", "rimba.mdc"))
 }
 
@@ -246,7 +247,7 @@ func TestInitGlobalOutsideRepo(t *testing.T) {
 	dir := t.TempDir()
 	r := rimbaSuccess(t, dir, "init", "-g")
 
-	assertContains(t, r.Stdout, "Installed rimba agent files (user)")
+	assertContains(t, r.Stdout, "Installed rimba (user)")
 	assertFileExists(t, filepath.Join(home, ".claude", "skills", "rimba", "SKILL.md"))
 	assertFileExists(t, filepath.Join(home, ".cursor", "rules", "rimba.mdc"))
 	assertFileExists(t, filepath.Join(home, ".github", "copilot-instructions.md"))
@@ -268,7 +269,7 @@ func TestInitGlobalUninstall(t *testing.T) {
 	rimbaSuccess(t, dir, "init", "-g")
 	r := rimbaSuccess(t, dir, "init", "-g", "--uninstall")
 
-	assertContains(t, r.Stdout, "Removed rimba agent files (user)")
+	assertContains(t, r.Stdout, "Removed rimba (user)")
 	assertFileNotExists(t, filepath.Join(home, ".claude", "skills", "rimba", "SKILL.md"))
 }
 
@@ -389,6 +390,93 @@ func assertGitignoreNotContains(t *testing.T, repo, entry string) {
 		if strings.TrimSpace(line) == entry {
 			t.Errorf("expected .gitignore NOT to contain %q, got:\n%s", entry, string(data))
 			return
+		}
+	}
+}
+
+// --- MCP registration e2e tests ---
+
+func TestInitGlobalWithMCPConfigs(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Pre-seed .claude/settings.json and .cursor/mcp.json
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{"theme":"dark"}`+"\n"), 0600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+
+	dir := t.TempDir()
+	r := rimbaSuccess(t, dir, "init", "-g")
+
+	assertContains(t, r.Stdout, "MCP server:")
+	assertContains(t, r.Stdout, "registered")
+
+	// Verify settings.json was patched and existing key preserved
+	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse settings.json: %v", err)
+	}
+	if cfg["theme"] != "dark" {
+		t.Error("existing 'theme' key was not preserved")
+	}
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers missing in settings.json after init -g")
+	}
+	entry, ok := servers["rimba"].(map[string]any)
+	if !ok {
+		t.Fatal("mcpServers.rimba missing")
+	}
+	if entry["command"] != "rimba" {
+		t.Errorf("command = %v, want rimba", entry["command"])
+	}
+}
+
+func TestInitGlobalUninstallWithMCP(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("{}\n"), 0600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+
+	dir := t.TempDir()
+	rimbaSuccess(t, dir, "init", "-g")
+	r := rimbaSuccess(t, dir, "init", "-g", "--uninstall")
+
+	assertContains(t, r.Stdout, "unregistered")
+
+	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse settings.json: %v", err)
+	}
+	if servers, ok := cfg["mcpServers"].(map[string]any); ok {
+		if _, found := servers["rimba"]; found {
+			t.Error("rimba key should be removed after uninstall")
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `internal/agentfile/mcpreg.go` with JSON/TOML patch-only-if-exists registration of `rimba mcp` as an MCP server across 6 user-level configs (Claude, Cursor, Windsurf, Codex/TOML, Gemini, Roo) and 2 project-level configs (`.mcp.json`, `.cursor/mcp.json`)
- Wires `RegisterMCPGlobal`/`UnregisterMCPGlobal` into `rimba init -g` and `RegisterMCPProject`/`UnregisterMCPProject` into `rimba init --agents`; local tier (`--agents --local`) skips MCP intentionally
- Refactors `cmd/init.go` output to a sectioned format: `Installed rimba (user):` with `Agent files:` and `MCP server:` subsections; never creates agent config files that don't already exist

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] 11 unit tests in `internal/agentfile/mcpreg_test.go`: register/skip-absent/idempotent for JSON, TOML Codex idempotency, unregister-preserves-others, project-level patching, malformed JSON error
- [x] 5 integration tests in `cmd/init_test.go`: `-g` registers MCP, skips when no config, uninstall removes, `--agents` registers in `.mcp.json`, `--agents --local` produces no MCP section
- [x] 2 e2e tests in `tests/e2e/init_test.go`: pre-seed settings.json → verify registered + existing key preserved; install+uninstall → verify key removed
- [x] Updated existing e2e assertions to new sectioned output format

Closes #122