### PR TITLE
[feat] Hint to refresh agent files after rimba update (#135)

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -116,6 +116,9 @@ var updateCmd = &cobra.Command{
 
 		fmt.Fprintf(cmd.OutOrStdout(), "Updated successfully: %s\n", strings.TrimSpace(string(out)))
 
+		home, repoRoot := resolvePostUpdateTipPaths()
+		printAgentRefreshTips(cmd, home, repoRoot)
+
 		// Print migration guidance if installed to a different location
 		if installedBinary != currentBinary {
 			fmt.Fprintf(cmd.OutOrStdout(), "\nTo complete migration, remove the old binary:\n  sudo rm %s\n", currentBinary)

--- a/cmd/update_agent_hint.go
+++ b/cmd/update_agent_hint.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lugassawan/rimba/internal/agentfile"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/spf13/cobra"
+)
+
+// printAgentRefreshTips emits one tip per tier that has rimba-installed files on
+// disk, suggesting the rimba init incantation to refresh them after a binary update.
+// Silent when RIMBA_QUIET is set, no files are installed, or a path is empty.
+func printAgentRefreshTips(cmd *cobra.Command, home string, repoRoot string) {
+	if _, ok := os.LookupEnv("RIMBA_QUIET"); ok {
+		return
+	}
+	w := cmd.ErrOrStderr()
+	if home != "" && anyInstalled(agentfile.StatusGlobal(home)) {
+		fmt.Fprintln(w, "  Tip: agent files installed at user level — run `rimba init -g` to refresh for this version.")
+	}
+	if repoRoot != "" && anyInstalled(agentfile.StatusProject(repoRoot)) {
+		fmt.Fprintln(w, "  Tip: agent files installed in this repo — run `rimba init --agents` to refresh for this version.")
+	}
+}
+
+func anyInstalled(statuses []agentfile.FileStatus) bool {
+	for _, fs := range statuses {
+		if fs.Installed {
+			return true
+		}
+	}
+	return false
+}
+
+// resolvePostUpdateTipPaths returns (homeDir, repoRoot) for post-update tip emission.
+// Returns empty strings for unresolvable tiers so callers skip the corresponding tip.
+func resolvePostUpdateTipPaths() (string, string) {
+	home, _ := os.UserHomeDir()
+	var repoRoot string
+	if root, err := git.RepoRoot(newRunner()); err == nil {
+		repoRoot = root
+	}
+	return home, repoRoot
+}

--- a/cmd/update_agent_hint_test.go
+++ b/cmd/update_agent_hint_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -140,5 +141,43 @@ func TestAgentRefreshTipsEmptyPaths(t *testing.T) {
 
 	if buf.Len() != 0 {
 		t.Errorf("expected empty output for empty paths, got %q", buf.String())
+	}
+}
+
+func TestResolvePostUpdateTipPathsOutsideRepo(t *testing.T) {
+	restore := overrideNewRunner(&mockRunner{
+		run:      func(_ ...string) (string, error) { return "", errors.New("not a git repo") },
+		runInDir: noopRunInDir,
+	})
+	defer restore()
+
+	home, repoRoot := resolvePostUpdateTipPaths()
+	if home == "" {
+		t.Error("expected non-empty home dir")
+	}
+	if repoRoot != "" {
+		t.Errorf("expected empty repoRoot outside git repo, got %q", repoRoot)
+	}
+}
+
+func TestResolvePostUpdateTipPathsInsideRepo(t *testing.T) {
+	dir := t.TempDir()
+	restore := overrideNewRunner(&mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return dir, nil
+			}
+			return "", errors.New("unexpected git call")
+		},
+		runInDir: noopRunInDir,
+	})
+	defer restore()
+
+	home, repoRoot := resolvePostUpdateTipPaths()
+	if home == "" {
+		t.Error("expected non-empty home dir")
+	}
+	if repoRoot != dir {
+		t.Errorf("repoRoot = %q, want %q", repoRoot, dir)
 	}
 }

--- a/cmd/update_agent_hint_test.go
+++ b/cmd/update_agent_hint_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/agentfile"
+)
+
+func TestAnyInstalled(t *testing.T) {
+	tests := []struct {
+		name     string
+		statuses []agentfile.FileStatus
+		want     bool
+	}{
+		{"empty slice", nil, false},
+		{"none installed", []agentfile.FileStatus{{RelPath: "a", Installed: false}}, false},
+		{"one installed", []agentfile.FileStatus{{RelPath: "a", Installed: true}}, true},
+		{"mixed, last installed", []agentfile.FileStatus{{RelPath: "a", Installed: false}, {RelPath: "b", Installed: true}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := anyInstalled(tt.statuses); got != tt.want {
+				t.Errorf("anyInstalled(%v) = %v, want %v", tt.statuses, got, tt.want)
+			}
+		})
+	}
+}
+
+// createUserTierFile creates the sentinel KindWhole file that StatusGlobal detects.
+func createUserTierFile(t *testing.T, homeDir string) {
+	t.Helper()
+	path := filepath.Join(homeDir, ".claude", "skills", "rimba", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte("skill"), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// createProjectTierFile creates the sentinel KindBlock file that StatusProject detects.
+// AGENTS.md must contain both BEGIN and END RIMBA markers to register as installed.
+func createProjectTierFile(t *testing.T, repoRoot string) {
+	t.Helper()
+	path := filepath.Join(repoRoot, "AGENTS.md")
+	content := agentfile.BeginMarker + "\n" + agentfile.EndMarker
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestAgentRefreshTipsUserInstalled(t *testing.T) {
+	home := t.TempDir()
+	createUserTierFile(t, home)
+	cmd, buf := newTestCmd()
+
+	printAgentRefreshTips(cmd, home, "")
+
+	out := buf.String()
+	if !strings.Contains(out, "user level") {
+		t.Errorf("output missing 'user level': %q", out)
+	}
+	if !strings.Contains(out, "rimba init -g") {
+		t.Errorf("output missing 'rimba init -g': %q", out)
+	}
+	if strings.Contains(out, "in this repo") {
+		t.Errorf("unexpected project tip with empty repoRoot: %q", out)
+	}
+}
+
+func TestAgentRefreshTipsProjectInstalled(t *testing.T) {
+	repo := t.TempDir()
+	createProjectTierFile(t, repo)
+	cmd, buf := newTestCmd()
+
+	printAgentRefreshTips(cmd, "", repo)
+
+	out := buf.String()
+	if !strings.Contains(out, "in this repo") {
+		t.Errorf("output missing 'in this repo': %q", out)
+	}
+	if !strings.Contains(out, "rimba init --agents") {
+		t.Errorf("output missing 'rimba init --agents': %q", out)
+	}
+	if strings.Contains(out, "user level") {
+		t.Errorf("unexpected user tip with empty home: %q", out)
+	}
+}
+
+func TestAgentRefreshTipsBothInstalled(t *testing.T) {
+	home := t.TempDir()
+	repo := t.TempDir()
+	createUserTierFile(t, home)
+	createProjectTierFile(t, repo)
+	cmd, buf := newTestCmd()
+
+	printAgentRefreshTips(cmd, home, repo)
+
+	out := buf.String()
+	if !strings.Contains(out, "user level") {
+		t.Errorf("output missing 'user level': %q", out)
+	}
+	if !strings.Contains(out, "in this repo") {
+		t.Errorf("output missing 'in this repo': %q", out)
+	}
+}
+
+func TestAgentRefreshTipsNothingInstalled(t *testing.T) {
+	cmd, buf := newTestCmd()
+
+	printAgentRefreshTips(cmd, t.TempDir(), t.TempDir())
+
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output when nothing installed, got %q", buf.String())
+	}
+}
+
+func TestAgentRefreshTipsRimbaQuiet(t *testing.T) {
+	t.Setenv("RIMBA_QUIET", "1")
+	home := t.TempDir()
+	repo := t.TempDir()
+	createUserTierFile(t, home)
+	createProjectTierFile(t, repo)
+	cmd, buf := newTestCmd()
+
+	printAgentRefreshTips(cmd, home, repo)
+
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output with RIMBA_QUIET=1, got %q", buf.String())
+	}
+}
+
+func TestAgentRefreshTipsEmptyPaths(t *testing.T) {
+	cmd, buf := newTestCmd()
+
+	printAgentRefreshTips(cmd, "", "")
+
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output for empty paths, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- After a successful binary update, check whether user-tier or project-tier agent files are installed on disk
- If installed, print a one-line tip to stderr pointing at `rimba init -g` (user) or `rimba init --agents` (project)
- Silent when `RIMBA_QUIET` is set, nothing is installed, or paths are unresolvable — zero noise for users who don't use the agent feature

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Unit tests cover: user-tier tip, project-tier tip, both tiers, nothing installed, `RIMBA_QUIET=1` suppression, empty paths, `anyInstalled` table

Closes #135