### PR TITLE
[feat] Create worktree from GitHub PR (rimba add pr:<num>)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -75,15 +75,7 @@ var addCmd = &cobra.Command{
 			}
 
 			s.Stop()
-			out := cmd.OutOrStdout()
-			fmt.Fprintf(out, "Created worktree for PR #%d\n", prNum)
-			fmt.Fprintf(out, "  Branch: %s\n", result.Branch)
-			fmt.Fprintf(out, "  Path:   %s\n", result.Path)
-			if len(result.Copied) > 0 {
-				fmt.Fprintf(out, "  Copied: %v\n", result.Copied)
-			}
-			printInstallResults(out, result.DepsResults)
-			printHookResultsList(out, result.HookResults)
+			printWorktreeResult(cmd, fmt.Sprintf("Created worktree for PR #%d", prNum), result)
 			return nil
 		}
 
@@ -135,26 +127,29 @@ var addCmd = &cobra.Command{
 
 		s.Stop()
 
-		out := cmd.OutOrStdout()
+		header := fmt.Sprintf("Created worktree for task %q", task)
 		if result.Service != "" {
-			fmt.Fprintf(out, "Created worktree for task %q (service: %s)\n", task, result.Service)
-		} else {
-			fmt.Fprintf(out, "Created worktree for task %q\n", task)
+			header = fmt.Sprintf("Created worktree for task %q (service: %s)", task, result.Service)
 		}
-		fmt.Fprintf(out, "  Branch: %s\n", result.Branch)
-		fmt.Fprintf(out, "  Path:   %s\n", result.Path)
-		if len(result.Copied) > 0 {
-			fmt.Fprintf(out, "  Copied: %v\n", result.Copied)
-		}
-		if len(result.Skipped) > 0 {
-			fmt.Fprintf(out, "  Skipped (not found): %v\n", result.Skipped)
-		}
-
-		printInstallResults(out, result.DepsResults)
-		printHookResultsList(out, result.HookResults)
+		printWorktreeResult(cmd, header, result)
 
 		return nil
 	},
+}
+
+func printWorktreeResult(cmd *cobra.Command, header string, result operations.AddResult) {
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, header)
+	fmt.Fprintf(out, "  Branch: %s\n", result.Branch)
+	fmt.Fprintf(out, "  Path:   %s\n", result.Path)
+	if len(result.Copied) > 0 {
+		fmt.Fprintf(out, "  Copied: %v\n", result.Copied)
+	}
+	if len(result.Skipped) > 0 {
+		fmt.Fprintf(out, "  Skipped (not found): %v\n", result.Skipped)
+	}
+	printInstallResults(out, result.DepsResults)
+	printHookResultsList(out, result.HookResults)
 }
 
 func init() {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -41,21 +41,21 @@ var addCmd = &cobra.Command{
 			return err
 		}
 
+		skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
+		skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
+
+		var configModules []config.ModuleConfig
+		if cfg.Deps != nil {
+			configModules = cfg.Deps.Modules
+		}
+
+		s := spinner.New(spinnerOpts(cmd))
+		defer s.Stop()
+
 		// pr:<num> shorthand — create worktree from a GitHub PR.
 		if m := prArgRe.FindStringSubmatch(args[0]); m != nil {
 			prNum, _ := strconv.Atoi(m[1])
 			taskOverride, _ := cmd.Flags().GetString(flagTask)
-
-			s := spinner.New(spinnerOpts(cmd))
-			defer s.Stop()
-
-			var configModules []config.ModuleConfig
-			if cfg.Deps != nil {
-				configModules = cfg.Deps.Modules
-			}
-
-			skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
-			skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
 
 			result, err := operations.AddPRWorktree(cmd.Context(), r, gh.Default(), operations.AddPRParams{
 				PRNumber:      prNum,
@@ -107,22 +107,11 @@ var addCmd = &cobra.Command{
 			source = cfg.DefaultSource
 		}
 
-		skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
-		skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
-
 		hint.New(cmd, hintPainter(cmd)).
 			Add(flagSkipDeps, hintSkipDeps).
 			Add(flagSkipHooks, hintSkipHooks).
 			Add(flagSource, hintSource).
 			Show()
-
-		s := spinner.New(spinnerOpts(cmd))
-		defer s.Stop()
-
-		var configModules []config.ModuleConfig
-		if cfg.Deps != nil {
-			configModules = cfg.Deps.Modules
-		}
 
 		s.Start("Creating worktree...")
 		result, err := operations.AddWorktree(r, operations.AddParams{

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,8 +3,11 @@ package cmd
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
+	"strconv"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/hint"
 	"github.com/lugassawan/rimba/internal/operations"
@@ -15,14 +18,17 @@ import (
 
 const (
 	flagSource = "source"
+	flagTask   = "task"
 
 	hintSource = "Branch from a specific source instead of the default branch"
 )
 
+var prArgRe = regexp.MustCompile(`^pr:(\d+)$`)
+
 var addCmd = &cobra.Command{
-	Use:   "add <task> or add <service>/<task>",
-	Short: "Create a new worktree for a task",
-	Long:  "Create a worktree, copy files, install dependencies, and run hooks.\nUse <service>/<task> to scope to a specific service in a monorepo.",
+	Use:   "add <task|pr:<num>> or add <service>/<task>",
+	Short: "Create a new worktree for a task or GitHub PR",
+	Long:  "Create a worktree, copy files, install dependencies, and run hooks.\nUse <service>/<task> to scope to a specific service in a monorepo.\nUse pr:<num> to create a worktree from a GitHub PR's head branch.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.FromContext(cmd.Context())
@@ -32,6 +38,53 @@ var addCmd = &cobra.Command{
 		repoRoot, err := git.MainRepoRoot(r)
 		if err != nil {
 			return err
+		}
+
+		// pr:<num> shorthand — create worktree from a GitHub PR.
+		if m := prArgRe.FindStringSubmatch(args[0]); m != nil {
+			prNum, _ := strconv.Atoi(m[1])
+			taskOverride, _ := cmd.Flags().GetString(flagTask)
+
+			s := spinner.New(spinnerOpts(cmd))
+			defer s.Stop()
+			s.Start("Fetching PR metadata...")
+
+			var configModules []config.ModuleConfig
+			if cfg.Deps != nil {
+				configModules = cfg.Deps.Modules
+			}
+
+			skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
+			skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
+
+			result, err := operations.AddPRWorktree(cmd.Context(), r, gh.Default(), operations.AddPRParams{
+				PRNumber:      prNum,
+				TaskOverride:  taskOverride,
+				RepoRoot:      repoRoot,
+				WorktreeDir:   filepath.Join(repoRoot, cfg.WorktreeDir),
+				CopyFiles:     cfg.CopyFiles,
+				SkipDeps:      skipDeps,
+				AutoDetect:    cfg.IsAutoDetectDeps(),
+				ConfigModules: configModules,
+				SkipHooks:     skipHooks,
+				PostCreate:    cfg.PostCreate,
+				Concurrency:   cfg.DepsConcurrency(),
+			}, func(msg string) { s.Update(msg) })
+			if err != nil {
+				return err
+			}
+
+			s.Stop()
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "Created worktree for PR #%d\n", prNum)
+			fmt.Fprintf(out, "  Branch: %s\n", result.Branch)
+			fmt.Fprintf(out, "  Path:   %s\n", result.Path)
+			if len(result.Copied) > 0 {
+				fmt.Fprintf(out, "  Copied: %v\n", result.Copied)
+			}
+			printInstallResults(out, result.DepsResults)
+			printHookResultsList(out, result.HookResults)
+			return nil
 		}
 
 		service, task := operations.ResolveTaskInput(args[0], repoRoot)
@@ -114,6 +167,7 @@ var addCmd = &cobra.Command{
 func init() {
 	addPrefixFlags(addCmd)
 	addCmd.Flags().StringP(flagSource, "s", "", "Source branch to create worktree from (default from config)")
+	addCmd.Flags().String(flagTask, "", "Override auto-derived task name (pr:<num> mode only)")
 	addCmd.Flags().Bool(flagSkipDeps, false, "Skip dependency detection and installation")
 	addCmd.Flags().Bool(flagSkipHooks, false, "Skip post-create hooks")
 	_ = addCmd.RegisterFlagCompletionFunc(flagSource, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -47,7 +48,6 @@ var addCmd = &cobra.Command{
 
 			s := spinner.New(spinnerOpts(cmd))
 			defer s.Stop()
-			s.Start("Fetching PR metadata...")
 
 			var configModules []config.ModuleConfig
 			if cfg.Deps != nil {
@@ -85,6 +85,10 @@ var addCmd = &cobra.Command{
 			printInstallResults(out, result.DepsResults)
 			printHookResultsList(out, result.HookResults)
 			return nil
+		}
+
+		if cmd.Flags().Changed(flagTask) {
+			return errors.New("--task requires a pr:<num> argument")
 		}
 
 		service, task := operations.ResolveTaskInput(args[0], repoRoot)

--- a/internal/gh/pr_meta.go
+++ b/internal/gh/pr_meta.go
@@ -1,0 +1,53 @@
+package gh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// PRMeta holds the metadata needed to check out a PR's head branch.
+type PRMeta struct {
+	Number            int
+	Title             string
+	HeadRefName       string
+	HeadRepoOwner     string
+	HeadRepoName      string
+	IsCrossRepository bool
+}
+
+type prViewResponse struct {
+	Number         int    `json:"number"`
+	Title          string `json:"title"`
+	HeadRefName    string `json:"headRefName"`
+	HeadRepository struct {
+		Name string `json:"name"`
+	} `json:"headRepository"`
+	HeadRepositoryOwner struct {
+		Login string `json:"login"`
+	} `json:"headRepositoryOwner"`
+	IsCrossRepository bool `json:"isCrossRepository"`
+}
+
+// FetchPRMeta retrieves metadata for the given PR number using the gh CLI.
+func FetchPRMeta(ctx context.Context, r Runner, num int) (PRMeta, error) {
+	out, err := r.Run(ctx, "pr", "view", strconv.Itoa(num),
+		"--json", "number,title,headRefName,headRepository,headRepositoryOwner,isCrossRepository",
+	)
+	if err != nil {
+		return PRMeta{}, fmt.Errorf("fetch PR #%d: %w", num, err)
+	}
+	var resp prViewResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return PRMeta{}, fmt.Errorf("parse PR #%d metadata: %w", num, err)
+	}
+	return PRMeta{
+		Number:            resp.Number,
+		Title:             resp.Title,
+		HeadRefName:       resp.HeadRefName,
+		HeadRepoOwner:     resp.HeadRepositoryOwner.Login,
+		HeadRepoName:      resp.HeadRepository.Name,
+		IsCrossRepository: resp.IsCrossRepository,
+	}, nil
+}

--- a/internal/gh/pr_meta.go
+++ b/internal/gh/pr_meta.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 )
+
+// safeNameRe matches strings safe to embed in git remote names and URLs.
+var safeNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 // PRMeta holds the metadata needed to check out a PR's head branch.
 type PRMeta struct {
@@ -42,12 +46,29 @@ func FetchPRMeta(ctx context.Context, r Runner, num int) (PRMeta, error) {
 	if err := json.Unmarshal(out, &resp); err != nil {
 		return PRMeta{}, fmt.Errorf("parse PR #%d metadata: %w", num, err)
 	}
+	if resp.HeadRefName == "" {
+		return PRMeta{}, fmt.Errorf("PR #%d: missing headRefName in response", num)
+	}
+	owner := resp.HeadRepositoryOwner.Login
+	repoName := resp.HeadRepository.Name
+	if owner == "" {
+		return PRMeta{}, fmt.Errorf("PR #%d: missing headRepositoryOwner in response", num)
+	}
+	if repoName == "" {
+		return PRMeta{}, fmt.Errorf("PR #%d: missing headRepository in response", num)
+	}
+	if !safeNameRe.MatchString(owner) {
+		return PRMeta{}, fmt.Errorf("PR #%d: unsafe headRepositoryOwner %q", num, owner)
+	}
+	if !safeNameRe.MatchString(repoName) {
+		return PRMeta{}, fmt.Errorf("PR #%d: unsafe headRepository.name %q", num, repoName)
+	}
 	return PRMeta{
 		Number:            resp.Number,
 		Title:             resp.Title,
 		HeadRefName:       resp.HeadRefName,
-		HeadRepoOwner:     resp.HeadRepositoryOwner.Login,
-		HeadRepoName:      resp.HeadRepository.Name,
+		HeadRepoOwner:     owner,
+		HeadRepoName:      repoName,
 		IsCrossRepository: resp.IsCrossRepository,
 	}, nil
 }

--- a/internal/gh/pr_meta_test.go
+++ b/internal/gh/pr_meta_test.go
@@ -1,0 +1,113 @@
+package gh
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+const sameRepoPRJSON = `{
+  "number": 42,
+  "title": "Fix login redirect",
+  "headRefName": "fix-login-redirect",
+  "headRepository": {"name": "rimba"},
+  "headRepositoryOwner": {"login": "lugassawan"},
+  "isCrossRepository": false
+}`
+
+const crossForkPRJSON = `{
+  "number": 99,
+  "title": "Add OAuth support",
+  "headRefName": "feat-oauth",
+  "headRepository": {"name": "rimba"},
+  "headRepositoryOwner": {"login": "contributor"},
+  "isCrossRepository": true
+}`
+
+func TestFetchPRMetaSameRepo(t *testing.T) {
+	r := &mockRunner{
+		run: func(_ context.Context, args ...string) ([]byte, error) {
+			return []byte(sameRepoPRJSON), nil
+		},
+	}
+	meta, err := FetchPRMeta(context.Background(), r, 42)
+	if err != nil {
+		t.Fatalf("FetchPRMeta: %v", err)
+	}
+	if meta.Number != 42 {
+		t.Errorf("Number = %d, want 42", meta.Number)
+	}
+	if meta.Title != "Fix login redirect" {
+		t.Errorf("Title = %q, want %q", meta.Title, "Fix login redirect")
+	}
+	if meta.HeadRefName != "fix-login-redirect" {
+		t.Errorf("HeadRefName = %q, want %q", meta.HeadRefName, "fix-login-redirect")
+	}
+	if meta.HeadRepoOwner != "lugassawan" {
+		t.Errorf("HeadRepoOwner = %q, want %q", meta.HeadRepoOwner, "lugassawan")
+	}
+	if meta.IsCrossRepository {
+		t.Error("IsCrossRepository should be false for same-repo PR")
+	}
+}
+
+func TestFetchPRMetaCrossFork(t *testing.T) {
+	r := &mockRunner{
+		run: func(_ context.Context, args ...string) ([]byte, error) {
+			return []byte(crossForkPRJSON), nil
+		},
+	}
+	meta, err := FetchPRMeta(context.Background(), r, 99)
+	if err != nil {
+		t.Fatalf("FetchPRMeta: %v", err)
+	}
+	if !meta.IsCrossRepository {
+		t.Error("IsCrossRepository should be true for cross-fork PR")
+	}
+	if meta.HeadRepoOwner != "contributor" {
+		t.Errorf("HeadRepoOwner = %q, want %q", meta.HeadRepoOwner, "contributor")
+	}
+	if meta.HeadRepoName != "rimba" {
+		t.Errorf("HeadRepoName = %q, want %q", meta.HeadRepoName, "rimba")
+	}
+}
+
+func TestFetchPRMetaRunnerError(t *testing.T) {
+	r := &mockRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return nil, errors.New("PR not found")
+		},
+	}
+	_, err := FetchPRMeta(context.Background(), r, 999)
+	if err == nil {
+		t.Fatal("expected error when runner fails")
+	}
+	assertContains(t, err, "fetch PR #999")
+}
+
+func TestFetchPRMetaInvalidJSON(t *testing.T) {
+	r := &mockRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return []byte("not json"), nil
+		},
+	}
+	_, err := FetchPRMeta(context.Background(), r, 1)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	assertContains(t, err, "parse PR #1")
+}
+
+func TestFetchPRMetaArgsIncludeNumber(t *testing.T) {
+	var capturedArgs []string
+	r := &mockRunner{
+		run: func(_ context.Context, args ...string) ([]byte, error) {
+			capturedArgs = args
+			return []byte(sameRepoPRJSON), nil
+		},
+	}
+	_, _ = FetchPRMeta(context.Background(), r, 42)
+	if len(capturedArgs) < 3 || capturedArgs[1] != "view" || capturedArgs[2] != "42" {
+		t.Errorf("expected args to include 'view 42', got %v", capturedArgs)
+	}
+}

--- a/internal/gh/pr_meta_test.go
+++ b/internal/gh/pr_meta_test.go
@@ -98,6 +98,54 @@ func TestFetchPRMetaInvalidJSON(t *testing.T) {
 	assertContains(t, err, "parse PR #1")
 }
 
+func TestFetchPRMetaEmptyFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		wantErr string
+	}{
+		{
+			name:    "empty response",
+			json:    `{}`,
+			wantErr: "missing headRefName",
+		},
+		{
+			name:    "missing owner",
+			json:    `{"headRefName":"main","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":""}}`,
+			wantErr: "missing headRepositoryOwner",
+		},
+		{
+			name:    "missing repo name",
+			json:    `{"headRefName":"main","headRepository":{"name":""},"headRepositoryOwner":{"login":"alice"}}`,
+			wantErr: "missing headRepository",
+		},
+		{
+			name:    "unsafe owner characters",
+			json:    `{"headRefName":"main","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"alice;rm -rf /"}}`,
+			wantErr: "unsafe headRepositoryOwner",
+		},
+		{
+			name:    "unsafe repo name characters",
+			json:    `{"headRefName":"main","headRepository":{"name":"repo$(whoami)"},"headRepositoryOwner":{"login":"alice"}}`,
+			wantErr: "unsafe headRepository.name",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &mockRunner{
+				run: func(_ context.Context, _ ...string) ([]byte, error) {
+					return []byte(tt.json), nil
+				},
+			}
+			_, err := FetchPRMeta(context.Background(), r, 1)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			assertContains(t, err, tt.wantErr)
+		})
+	}
+}
+
 func TestFetchPRMetaArgsIncludeNumber(t *testing.T) {
 	var capturedArgs []string
 	r := &mockRunner{

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -1,0 +1,13 @@
+package git
+
+// RemoteExists reports whether a remote with the given name is configured.
+func RemoteExists(r Runner, name string) bool {
+	_, err := r.Run("remote", "get-url", name)
+	return err == nil
+}
+
+// AddRemote adds a new remote with the given name and URL.
+func AddRemote(r Runner, name, url string) error {
+	_, err := r.Run("remote", "add", name, url)
+	return err
+}

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -1,0 +1,61 @@
+package git
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRemoteExistsTrue(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "https://github.com/owner/repo.git", nil
+		},
+	}
+	if !RemoteExists(r, "origin") {
+		t.Error("expected remote to exist")
+	}
+}
+
+func TestRemoteExistsFalse(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("no such remote 'gh-fork-bob'")
+		},
+	}
+	if RemoteExists(r, "gh-fork-bob") {
+		t.Error("expected remote to not exist")
+	}
+}
+
+func TestAddRemote(t *testing.T) {
+	var captured []string
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			captured = args
+			return "", nil
+		},
+	}
+	if err := AddRemote(r, "gh-fork-alice", "https://github.com/alice/repo.git"); err != nil {
+		t.Fatalf("AddRemote: %v", err)
+	}
+	want := []string{"remote", "add", "gh-fork-alice", "https://github.com/alice/repo.git"}
+	if len(captured) != len(want) {
+		t.Fatalf("args = %v, want %v", captured, want)
+	}
+	for i, w := range want {
+		if captured[i] != w {
+			t.Errorf("args[%d] = %q, want %q", i, captured[i], w)
+		}
+	}
+}
+
+func TestAddRemoteError(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("remote already exists")
+		},
+	}
+	if err := AddRemote(r, "origin", "https://github.com/x/y.git"); err == nil {
+		t.Fatal("expected error from AddRemote")
+	}
+}

--- a/internal/operations/add_pr_worktree.go
+++ b/internal/operations/add_pr_worktree.go
@@ -1,0 +1,104 @@
+package operations
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/errhint"
+	"github.com/lugassawan/rimba/internal/gh"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/progress"
+	"github.com/lugassawan/rimba/internal/resolver"
+)
+
+// AddPRParams holds the inputs for creating a worktree from a GitHub PR.
+type AddPRParams struct {
+	PRNumber     int
+	TaskOverride string // empty = derive from PR title
+
+	RepoRoot      string
+	WorktreeDir   string
+	CopyFiles     []string
+	SkipDeps      bool
+	AutoDetect    bool
+	ConfigModules []config.ModuleConfig
+	SkipHooks     bool
+	PostCreate    []string
+	Concurrency   int
+}
+
+// AddPRWorktree creates a worktree from a GitHub PR's head branch.
+// For cross-fork PRs it adds a fork remote (gh-fork-<owner>) if absent,
+// then delegates to AddWorktree for copy-files, deps, and hooks.
+func AddPRWorktree(
+	ctx context.Context,
+	gitR git.Runner,
+	ghR gh.Runner,
+	params AddPRParams,
+	onProgress progress.Func,
+) (AddResult, error) {
+	if err := gh.CheckAuth(ctx, ghR); err != nil {
+		return AddResult{}, err
+	}
+
+	progress.Notify(onProgress, fmt.Sprintf("Fetching PR #%d metadata...", params.PRNumber))
+	meta, err := gh.FetchPRMeta(ctx, ghR, params.PRNumber)
+	if err != nil {
+		return AddResult{}, errhint.WithFix(err, "verify PR number and repo access")
+	}
+
+	task := params.TaskOverride
+	if task == "" {
+		task = "review/" + strconv.Itoa(meta.Number) + "-" + resolver.Slugify(meta.Title)
+	}
+
+	source, err := resolveSource(gitR, meta, onProgress)
+	if err != nil {
+		return AddResult{}, err
+	}
+
+	return AddWorktree(gitR, AddParams{
+		Task:          task,
+		Source:        source,
+		RepoRoot:      params.RepoRoot,
+		WorktreeDir:   params.WorktreeDir,
+		CopyFiles:     params.CopyFiles,
+		SkipDeps:      params.SkipDeps,
+		AutoDetect:    params.AutoDetect,
+		ConfigModules: params.ConfigModules,
+		SkipHooks:     params.SkipHooks,
+		PostCreate:    params.PostCreate,
+		Concurrency:   params.Concurrency,
+	}, onProgress)
+}
+
+// resolveSource fetches the appropriate remote ref and returns the source ref
+// for use with git worktree add -b <branch> <path> <source>.
+func resolveSource(gitR git.Runner, meta gh.PRMeta, onProgress progress.Func) (string, error) {
+	if !meta.IsCrossRepository {
+		progress.Notify(onProgress, "Fetching origin...")
+		if err := git.Fetch(gitR, "origin"); err != nil {
+			return "", errhint.WithFix(err, "check network connectivity")
+		}
+		return "origin/" + meta.HeadRefName, nil
+	}
+
+	remoteName := "gh-fork-" + meta.HeadRepoOwner
+	remoteURL := "https://github.com/" + meta.HeadRepoOwner + "/" + meta.HeadRepoName + ".git"
+
+	if !git.RemoteExists(gitR, remoteName) {
+		progress.Notify(onProgress, fmt.Sprintf("Adding fork remote %s...", remoteName))
+		if err := git.AddRemote(gitR, remoteName, remoteURL); err != nil {
+			return "", errhint.WithFix(err, "check network and fork visibility")
+		}
+	}
+
+	progress.Notify(onProgress, fmt.Sprintf("Fetching %s...", remoteName))
+	if err := git.Fetch(gitR, remoteName); err != nil {
+		return "", errhint.WithFix(err, "check network and fork visibility")
+	}
+
+	return remoteName + "/" + meta.HeadRefName, nil
+}

--- a/internal/operations/add_pr_worktree_test.go
+++ b/internal/operations/add_pr_worktree_test.go
@@ -12,7 +12,10 @@ import (
 )
 
 const (
-	ghArgAuth = "auth"
+	ghArgAuth       = "auth"
+	gitCmdFetch     = "fetch"
+	gitCmdRemote    = "remote"
+	gitSubcmdGetURL = "get-url"
 
 	sameRepoPRJSON = `{
   "number": 42,
@@ -59,21 +62,21 @@ func makePRGitRunner(_ string, crossFork bool) *mockRunner {
 	return &mockRunner{
 		run: func(args ...string) (string, error) {
 			switch {
-			case len(args) > 0 && args[0] == "fetch":
+			case len(args) > 0 && args[0] == gitCmdFetch:
 				return "", nil
-			case len(args) > 0 && args[0] == "remote":
-				if args[1] == "get-url" {
+			case len(args) > 0 && args[0] == gitCmdRemote:
+				if args[1] == gitSubcmdGetURL {
 					if crossFork {
 						return "", errors.New("no such remote") // remote doesn't exist yet
 					}
 					return "https://github.com/owner/repo.git", nil
 				}
-				if args[1] == "add" {
+				if args[1] == gitSubcmdAdd {
 					return "", nil
 				}
-			case len(args) > 0 && args[0] == "rev-parse":
+			case len(args) > 0 && args[0] == cmdRevParse:
 				return "", errors.New("not found") // branch doesn't exist
-			case len(args) > 0 && args[0] == "worktree" && len(args) > 1 && args[1] == "add":
+			case len(args) > 0 && args[0] == gitCmdWorktree && len(args) > 1 && args[1] == gitSubcmdAdd:
 				_ = os.MkdirAll(args[2], 0o755)
 				return "", nil
 			}
@@ -178,6 +181,168 @@ func TestAddPRWorktreeAuthFailure(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "gh auth login") {
 		t.Errorf("expected auth hint, got: %v", err)
+	}
+}
+
+func TestAddPRWorktreeFetchPRMetaFailure(t *testing.T) {
+	ghR := &mockGhRunner{
+		run: func(_ context.Context, args ...string) ([]byte, error) {
+			if len(args) > 0 && args[0] == ghArgAuth {
+				return []byte("Logged in"), nil
+			}
+			return nil, errors.New("PR not found")
+		},
+	}
+	gitR := &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", nil },
+		runInDir: noopRunInDir,
+	}
+
+	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{PRNumber: 999}, nil)
+	if err == nil {
+		t.Fatal("expected error from FetchPRMeta failure")
+	}
+	if !strings.Contains(err.Error(), "verify PR number") {
+		t.Errorf("expected 'verify PR number' hint, got: %v", err)
+	}
+}
+
+func TestAddPRWorktreeSameRepoFetchFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	wtDir := filepath.Join(tmpDir, ".worktrees")
+
+	ghR := newGhAuthOK(sameRepoPRJSON)
+	gitR := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitCmdFetch {
+				return "", errors.New("network unreachable")
+			}
+			if len(args) > 0 && args[0] == cmdRevParse {
+				return "", errors.New("not found")
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
+		PRNumber:    42,
+		RepoRoot:    tmpDir,
+		WorktreeDir: wtDir,
+		SkipDeps:    true,
+		SkipHooks:   true,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error from fetch failure")
+	}
+	if !strings.Contains(err.Error(), "network connectivity") {
+		t.Errorf("expected 'network connectivity' hint, got: %v", err)
+	}
+}
+
+func TestAddPRWorktreeCrossForkAddRemoteFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	wtDir := filepath.Join(tmpDir, ".worktrees")
+
+	ghR := newGhAuthOK(crossForkPRJSON)
+	gitR := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitCmdRemote {
+				if args[1] == gitSubcmdGetURL {
+					return "", errors.New("no such remote")
+				}
+				if args[1] == gitSubcmdAdd {
+					return "", errors.New("remote add failed")
+				}
+			}
+			if len(args) > 0 && args[0] == cmdRevParse {
+				return "", errors.New("not found")
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
+		PRNumber:    99,
+		RepoRoot:    tmpDir,
+		WorktreeDir: wtDir,
+		SkipDeps:    true,
+		SkipHooks:   true,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error from AddRemote failure")
+	}
+	if !strings.Contains(err.Error(), "fork visibility") {
+		t.Errorf("expected 'fork visibility' hint, got: %v", err)
+	}
+}
+
+func TestAddPRWorktreeCrossForkFetchFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	wtDir := filepath.Join(tmpDir, ".worktrees")
+
+	ghR := newGhAuthOK(crossForkPRJSON)
+	gitR := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitCmdRemote {
+				if args[1] == gitSubcmdGetURL {
+					return "", errors.New("no such remote")
+				}
+				if args[1] == gitSubcmdAdd {
+					return "", nil
+				}
+			}
+			if len(args) > 0 && args[0] == gitCmdFetch {
+				return "", errors.New("network unreachable")
+			}
+			if len(args) > 0 && args[0] == cmdRevParse {
+				return "", errors.New("not found")
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
+		PRNumber:    99,
+		RepoRoot:    tmpDir,
+		WorktreeDir: wtDir,
+		SkipDeps:    true,
+		SkipHooks:   true,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error from fork fetch failure")
+	}
+	if !strings.Contains(err.Error(), "fork visibility") {
+		t.Errorf("expected 'fork visibility' hint, got: %v", err)
+	}
+}
+
+func TestAddPRWorktreeResolveSourceFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	wtDir := filepath.Join(tmpDir, ".worktrees")
+
+	ghR := newGhAuthOK(sameRepoPRJSON)
+	gitR := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitCmdFetch {
+				return "", errors.New("fetch error")
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
+		PRNumber:    42,
+		RepoRoot:    tmpDir,
+		WorktreeDir: wtDir,
+		SkipDeps:    true,
+		SkipHooks:   true,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error from resolveSource failure")
 	}
 }
 

--- a/internal/operations/add_pr_worktree_test.go
+++ b/internal/operations/add_pr_worktree_test.go
@@ -1,0 +1,207 @@
+package operations
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/progress"
+)
+
+const (
+	ghArgAuth = "auth"
+
+	sameRepoPRJSON = `{
+  "number": 42,
+  "title": "Fix login redirect",
+  "headRefName": "fix-login-redirect",
+  "headRepository": {"name": "rimba"},
+  "headRepositoryOwner": {"login": "lugassawan"},
+  "isCrossRepository": false
+}`
+
+	crossForkPRJSON = `{
+  "number": 99,
+  "title": "Add OAuth support",
+  "headRefName": "feat-oauth",
+  "headRepository": {"name": "rimba"},
+  "headRepositoryOwner": {"login": "contributor"},
+  "isCrossRepository": true
+}`
+)
+
+// mockGhRunner implements gh.Runner for testing.
+type mockGhRunner struct {
+	run func(ctx context.Context, args ...string) ([]byte, error)
+}
+
+func (m *mockGhRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	return m.run(ctx, args...)
+}
+
+func newGhAuthOK(prJSON string) *mockGhRunner {
+	return &mockGhRunner{
+		run: func(_ context.Context, args ...string) ([]byte, error) {
+			if len(args) > 0 && args[0] == ghArgAuth {
+				return []byte("Logged in"), nil
+			}
+			return []byte(prJSON), nil
+		},
+	}
+}
+
+// makePRGitRunner returns a mockRunner for the happy-path PR add.
+// It simulates: fetch succeeds, BranchExists=false, worktree add creates dir, remote helpers.
+func makePRGitRunner(_ string, crossFork bool) *mockRunner {
+	return &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case len(args) > 0 && args[0] == "fetch":
+				return "", nil
+			case len(args) > 0 && args[0] == "remote":
+				if args[1] == "get-url" {
+					if crossFork {
+						return "", errors.New("no such remote") // remote doesn't exist yet
+					}
+					return "https://github.com/owner/repo.git", nil
+				}
+				if args[1] == "add" {
+					return "", nil
+				}
+			case len(args) > 0 && args[0] == "rev-parse":
+				return "", errors.New("not found") // branch doesn't exist
+			case len(args) > 0 && args[0] == "worktree" && len(args) > 1 && args[1] == "add":
+				_ = os.MkdirAll(args[2], 0o755)
+				return "", nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+}
+
+func TestAddPRWorktreeSameRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	wtDir := filepath.Join(tmpDir, ".worktrees")
+
+	ghR := newGhAuthOK(sameRepoPRJSON)
+	gitR := makePRGitRunner(tmpDir, false)
+
+	result, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
+		PRNumber:    42,
+		RepoRoot:    tmpDir,
+		WorktreeDir: wtDir,
+		SkipDeps:    true,
+		SkipHooks:   true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("AddPRWorktree: %v", err)
+	}
+	if result.Branch != "review/42-fix-login-redirect" {
+		t.Errorf("Branch = %q, want %q", result.Branch, "review/42-fix-login-redirect")
+	}
+	if result.Source != "origin/fix-login-redirect" {
+		t.Errorf("Source = %q, want %q", result.Source, "origin/fix-login-redirect")
+	}
+}
+
+func TestAddPRWorktreeCrossFork(t *testing.T) {
+	tmpDir := t.TempDir()
+	wtDir := filepath.Join(tmpDir, ".worktrees")
+
+	ghR := newGhAuthOK(crossForkPRJSON)
+	gitR := makePRGitRunner(tmpDir, true)
+
+	result, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
+		PRNumber:    99,
+		RepoRoot:    tmpDir,
+		WorktreeDir: wtDir,
+		SkipDeps:    true,
+		SkipHooks:   true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("AddPRWorktree: %v", err)
+	}
+	if result.Branch != "review/99-add-oauth-support" {
+		t.Errorf("Branch = %q, want %q", result.Branch, "review/99-add-oauth-support")
+	}
+	if result.Source != "gh-fork-contributor/feat-oauth" {
+		t.Errorf("Source = %q, want %q", result.Source, "gh-fork-contributor/feat-oauth")
+	}
+}
+
+func TestAddPRWorktreeTaskOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	wtDir := filepath.Join(tmpDir, ".worktrees")
+
+	ghR := newGhAuthOK(sameRepoPRJSON)
+	gitR := makePRGitRunner(tmpDir, false)
+
+	result, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
+		PRNumber:     42,
+		TaskOverride: "my-review",
+		RepoRoot:     tmpDir,
+		WorktreeDir:  wtDir,
+		SkipDeps:     true,
+		SkipHooks:    true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("AddPRWorktree: %v", err)
+	}
+	if result.Branch != "my-review" {
+		t.Errorf("Branch = %q, want %q", result.Branch, "my-review")
+	}
+}
+
+func TestAddPRWorktreeAuthFailure(t *testing.T) {
+	ghR := &mockGhRunner{
+		run: func(_ context.Context, args ...string) ([]byte, error) {
+			if len(args) > 0 && args[0] == ghArgAuth {
+				return nil, errors.New("not authenticated")
+			}
+			return nil, nil
+		},
+	}
+	gitR := &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", nil },
+		runInDir: noopRunInDir,
+	}
+
+	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
+		PRNumber: 42,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error from auth failure")
+	}
+	if !strings.Contains(err.Error(), "gh auth login") {
+		t.Errorf("expected auth hint, got: %v", err)
+	}
+}
+
+func TestAddPRWorktreeProgressCallbacks(t *testing.T) {
+	tmpDir := t.TempDir()
+	wtDir := filepath.Join(tmpDir, ".worktrees")
+
+	ghR := newGhAuthOK(sameRepoPRJSON)
+	gitR := makePRGitRunner(tmpDir, false)
+
+	var messages []string
+	onProgress := progress.Func(func(msg string) { messages = append(messages, msg) })
+
+	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
+		PRNumber:    42,
+		RepoRoot:    tmpDir,
+		WorktreeDir: wtDir,
+		SkipDeps:    true,
+		SkipHooks:   true,
+	}, onProgress)
+	if err != nil {
+		t.Fatalf("AddPRWorktree: %v", err)
+	}
+	if len(messages) == 0 {
+		t.Error("expected progress messages, got none")
+	}
+}

--- a/internal/resolver/slug.go
+++ b/internal/resolver/slug.go
@@ -16,8 +16,8 @@ func Slugify(s string) string {
 	if slug == "" {
 		return "pr"
 	}
-	if len(slug) > 50 {
-		slug = strings.TrimRight(slug[:50], "-")
+	if runes := []rune(slug); len(runes) > 50 {
+		slug = strings.TrimRight(string(runes[:50]), "-")
 	}
 	return slug
 }

--- a/internal/resolver/slug.go
+++ b/internal/resolver/slug.go
@@ -1,0 +1,23 @@
+package resolver
+
+import (
+	"regexp"
+	"strings"
+)
+
+var nonAlphanumRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// Slugify converts s into a lowercase, hyphen-separated branch-safe string.
+// Non-alphanumeric runs are collapsed to a single "-", edges are trimmed,
+// and the result is capped at 50 characters. Returns "pr" for empty input.
+func Slugify(s string) string {
+	slug := nonAlphanumRe.ReplaceAllString(strings.ToLower(s), "-")
+	slug = strings.Trim(slug, "-")
+	if slug == "" {
+		return "pr"
+	}
+	if len(slug) > 50 {
+		slug = strings.TrimRight(slug[:50], "-")
+	}
+	return slug
+}

--- a/internal/resolver/slug_test.go
+++ b/internal/resolver/slug_test.go
@@ -1,0 +1,36 @@
+package resolver
+
+import "testing"
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Fix: login redirect!", "fix-login-redirect"},
+		{"Add OAuth2 support", "add-oauth2-support"},
+		{"  leading/trailing spaces  ", "leading-trailing-spaces"},
+		{"múltiple unicøde chars", "m-ltiple-unic-de-chars"},
+		{"already-fine", "already-fine"},
+		{"UPPERCASE TITLE", "uppercase-title"},
+		{"dots.and.dots", "dots-and-dots"},
+		{"consecutive---dashes", "consecutive-dashes"},
+		{"", "pr"},
+		{"   ", "pr"},
+		{"---", "pr"},
+		// Long title capped at 50 chars, no trailing dash
+		{"This is a very long pull request title that should be trimmed at fifty chars exactly", "this-is-a-very-long-pull-request-title-that-should"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := Slugify(tt.input)
+			if got != tt.want {
+				t.Errorf("Slugify(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+			if len(got) > 50 {
+				t.Errorf("Slugify(%q) len=%d > 50", tt.input, len(got))
+			}
+		})
+	}
+}

--- a/internal/resolver/slug_test.go
+++ b/internal/resolver/slug_test.go
@@ -20,6 +20,8 @@ func TestSlugify(t *testing.T) {
 		{"---", "pr"},
 		// Long title capped at 50 chars, no trailing dash
 		{"This is a very long pull request title that should be trimmed at fifty chars exactly", "this-is-a-very-long-pull-request-title-that-should"},
+		// 60-char ASCII slug truncated to 50 runes
+		{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 	}
 
 	for _, tt := range tests {

--- a/tests/e2e/add_pr_test.go
+++ b/tests/e2e/add_pr_test.go
@@ -1,0 +1,293 @@
+package e2e_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+// ghPRViewStubScript is a `gh` stub that handles auth + pr view for add-pr tests.
+// PR metadata is read from $GH_STUB_DIR/pr_view_<num>.json.
+const ghPRViewStubScript = `#!/bin/sh
+case "$1" in
+  auth)
+    if [ -f "$GH_STUB_DIR/unauth" ]; then
+      echo "not logged in" >&2
+      exit 1
+    fi
+    echo "Logged in"
+    exit 0
+    ;;
+  pr)
+    if [ "$2" = "view" ]; then
+      num="$3"
+      f="$GH_STUB_DIR/pr_view_$num.json"
+      if [ -f "$f" ]; then
+        cat "$f"
+        exit 0
+      fi
+      echo "PR not found" >&2
+      exit 1
+    fi
+    ;;
+esac
+echo "unexpected gh invocation: $*" >&2
+exit 2
+`
+
+// stubGhPRView installs the PR-view-capable gh stub and returns dir + env.
+func stubGhPRView(t *testing.T) (dir string, env []string) {
+	t.Helper()
+	dir = t.TempDir()
+	path := filepath.Join(dir, "gh")
+	if err := os.WriteFile(path, []byte(ghPRViewStubScript), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	env = []string{"PATH=" + dir + string(os.PathListSeparator) + os.Getenv("PATH")}
+	return dir, env
+}
+
+// writeStubPRView writes canned JSON for a specific PR number.
+func writeStubPRView(t *testing.T, stubDir string, num int, content string) {
+	t.Helper()
+	p := filepath.Join(stubDir, "pr_view_"+itoa(num)+".json")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write pr_view stub: %v", err)
+	}
+}
+
+// itoa converts an int to a string without importing strconv at file scope.
+func itoa(n int) string {
+	s := ""
+	if n == 0 {
+		return "0"
+	}
+	for n > 0 {
+		s = string(rune('0'+n%10)) + s
+		n /= 10
+	}
+	return s
+}
+
+// setupRepoWithRemoteAndBranch creates a bare origin, a clone with rimba
+// initialised, and a named branch pushed to origin (simulating a PR head ref).
+func setupRepoWithRemoteAndBranch(t *testing.T, branchName string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	bareDir := filepath.Join(dir, "origin.git")
+	if err := os.MkdirAll(bareDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitBare(t, bareDir, "init", "--bare", "-b", "main")
+
+	repo := filepath.Join(dir, "repo")
+	cmd := exec.Command("git", "clone", bareDir, repo)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clone: %s: %v", out, err)
+	}
+	testutil.GitCmd(t, repo, "config", "user.email", "test@test.com")
+	testutil.GitCmd(t, repo, "config", "user.name", "Test")
+
+	testutil.CreateFile(t, repo, "README.md", "# Test\n")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "initial commit")
+	testutil.GitCmd(t, repo, "push", "-u", "origin", "main")
+
+	// Create the PR head branch and push to origin.
+	testutil.GitCmd(t, repo, "checkout", "-b", branchName)
+	testutil.CreateFile(t, repo, branchName+".txt", "pr content\n")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "pr commit")
+	testutil.GitCmd(t, repo, "push", "origin", branchName)
+	testutil.GitCmd(t, repo, "checkout", "main")
+
+	rimbaSuccess(t, repo, "init")
+
+	return repo
+}
+
+func TestAddPRWorktreeSameRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupRepoWithRemoteAndBranch(t, "fix-login-redirect")
+
+	stubDir, env := stubGhPRView(t)
+	env = append(env, "GH_STUB_DIR="+stubDir)
+	writeStubPRView(t, stubDir, 42, `{
+		"number": 42,
+		"title": "Fix login redirect",
+		"headRefName": "fix-login-redirect",
+		"headRepository": {"name": "rimba"},
+		"headRepositoryOwner": {"login": "lugassawan"},
+		"isCrossRepository": false
+	}`)
+
+	r := rimbaWithEnv(t, repo, env, "add", "pr:42", "--skip-deps", "--skip-hooks")
+	if r.ExitCode != 0 {
+		t.Fatalf("exit=%d\nstdout: %s\nstderr: %s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+
+	assertContains(t, r.Stdout, "Created worktree for PR #42")
+	assertContains(t, r.Stdout, "review/42-fix-login-redirect")
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := "review/42-fix-login-redirect"
+	wtPath := resolver.WorktreePath(wtDir, branch)
+	assertFileExists(t, wtPath)
+}
+
+func TestAddPRWorktreeTaskOverride(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupRepoWithRemoteAndBranch(t, "fix-login-redirect")
+
+	stubDir, env := stubGhPRView(t)
+	env = append(env, "GH_STUB_DIR="+stubDir)
+	writeStubPRView(t, stubDir, 42, `{
+		"number": 42,
+		"title": "Fix login redirect",
+		"headRefName": "fix-login-redirect",
+		"headRepository": {"name": "rimba"},
+		"headRepositoryOwner": {"login": "lugassawan"},
+		"isCrossRepository": false
+	}`)
+
+	r := rimbaWithEnv(t, repo, env, "add", "pr:42", "--task", "my-review", "--skip-deps", "--skip-hooks")
+	if r.ExitCode != 0 {
+		t.Fatalf("exit=%d\nstdout: %s\nstderr: %s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+
+	assertContains(t, r.Stdout, "my-review")
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	wtPath := resolver.WorktreePath(wtDir, "my-review")
+	assertFileExists(t, wtPath)
+}
+
+func TestAddPRWorktreeGhUnauthenticated(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+
+	stubDir, env := stubGhPRView(t)
+	env = append(env, "GH_STUB_DIR="+stubDir)
+
+	// Create the "unauth" file to make the stub fail auth status.
+	if err := os.WriteFile(filepath.Join(stubDir, "unauth"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write unauth: %v", err)
+	}
+
+	r := rimbaWithEnv(t, repo, env, "add", "pr:42", "--skip-deps", "--skip-hooks")
+	if r.ExitCode == 0 {
+		t.Fatal("expected non-zero exit when gh is not authenticated")
+	}
+	if !strings.Contains(r.Stderr, "gh auth login") {
+		t.Errorf("expected 'gh auth login' hint in error, got:\n%s", r.Stderr)
+	}
+}
+
+func TestAddPRWorktreeCrossFork(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	dir := t.TempDir()
+
+	// Set up main bare origin + clone.
+	bareOriginDir := filepath.Join(dir, "origin.git")
+	if err := os.MkdirAll(bareOriginDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitBare(t, bareOriginDir, "init", "--bare", "-b", "main")
+
+	repo := filepath.Join(dir, "repo")
+	cloneCmd := exec.Command("git", "clone", bareOriginDir, repo)
+	if out, err := cloneCmd.CombinedOutput(); err != nil {
+		t.Fatalf("clone: %s: %v", out, err)
+	}
+	testutil.GitCmd(t, repo, "config", "user.email", "test@test.com")
+	testutil.GitCmd(t, repo, "config", "user.name", "Test")
+	testutil.CreateFile(t, repo, "README.md", "# Test\n")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "initial commit")
+	testutil.GitCmd(t, repo, "push", "-u", "origin", "main")
+	rimbaSuccess(t, repo, "init")
+
+	// Set up a bare "fork" repo with feat-oauth branch.
+	bareForkDir := filepath.Join(dir, "fork.git")
+	if err := os.MkdirAll(bareForkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitBare(t, bareForkDir, "init", "--bare", "-b", "main")
+	// Clone the fork, add a branch, push it.
+	forkClone := filepath.Join(dir, "fork-clone")
+	cloneFork := exec.Command("git", "clone", bareForkDir, forkClone)
+	if out, err := cloneFork.CombinedOutput(); err != nil {
+		t.Fatalf("clone fork: %s: %v", out, err)
+	}
+	testutil.GitCmd(t, forkClone, "config", "user.email", "test@test.com")
+	testutil.GitCmd(t, forkClone, "config", "user.name", "Test")
+	testutil.CreateFile(t, forkClone, "README.md", "# Fork\n")
+	testutil.GitCmd(t, forkClone, "add", ".")
+	testutil.GitCmd(t, forkClone, "commit", "-m", "fork initial")
+	testutil.GitCmd(t, forkClone, "push", "-u", "origin", "main")
+	testutil.GitCmd(t, forkClone, "checkout", "-b", "feat-oauth")
+	testutil.CreateFile(t, forkClone, "oauth.txt", "oauth\n")
+	testutil.GitCmd(t, forkClone, "add", ".")
+	testutil.GitCmd(t, forkClone, "commit", "-m", "add oauth")
+	testutil.GitCmd(t, forkClone, "push", "origin", "feat-oauth")
+
+	// Redirect the exact fork remote URL to the local bare fork via url.insteadOf.
+	// The remote URL AddPRWorktree constructs is "https://github.com/<owner>/<repo>.git".
+	forkURL := "file://" + bareForkDir
+	githubExact := "https://github.com/test-fork/rimba.git"
+	testutil.GitCmd(t, repo, "config", "url."+forkURL+".insteadOf", githubExact)
+
+	stubDir, env := stubGhPRView(t)
+	env = append(env, "GH_STUB_DIR="+stubDir)
+	writeStubPRView(t, stubDir, 99, `{
+		"number": 99,
+		"title": "Add OAuth support",
+		"headRefName": "feat-oauth",
+		"headRepository": {"name": "rimba"},
+		"headRepositoryOwner": {"login": "test-fork"},
+		"isCrossRepository": true
+	}`)
+
+	r := rimbaWithEnv(t, repo, env, "add", "pr:99", "--skip-deps", "--skip-hooks")
+	if r.ExitCode != 0 {
+		t.Fatalf("exit=%d\nstdout: %s\nstderr: %s", r.ExitCode, r.Stdout, r.Stderr)
+	}
+
+	assertContains(t, r.Stdout, "Created worktree for PR #99")
+	assertContains(t, r.Stdout, "review/99-add-oauth-support")
+
+	// Verify fork remote was added.
+	remoteOut, err := exec.Command("git", "-C", repo, "remote", "-v").Output()
+	if err != nil {
+		t.Fatalf("git remote -v: %v", err)
+	}
+	if !strings.Contains(string(remoteOut), "gh-fork-test-fork") {
+		t.Errorf("expected gh-fork-test-fork remote, got:\n%s", remoteOut)
+	}
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	wtPath := resolver.WorktreePath(wtDir, "review/99-add-oauth-support")
+	assertFileExists(t, wtPath)
+}

--- a/tests/e2e/add_pr_test.go
+++ b/tests/e2e/add_pr_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -55,23 +56,10 @@ func stubGhPRView(t *testing.T) (dir string, env []string) {
 // writeStubPRView writes canned JSON for a specific PR number.
 func writeStubPRView(t *testing.T, stubDir string, num int, content string) {
 	t.Helper()
-	p := filepath.Join(stubDir, "pr_view_"+itoa(num)+".json")
+	p := filepath.Join(stubDir, "pr_view_"+strconv.Itoa(num)+".json")
 	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
 		t.Fatalf("write pr_view stub: %v", err)
 	}
-}
-
-// itoa converts an int to a string without importing strconv at file scope.
-func itoa(n int) string {
-	s := ""
-	if n == 0 {
-		return "0"
-	}
-	for n > 0 {
-		s = string(rune('0'+n%10)) + s
-		n /= 10
-	}
-	return s
 }
 
 // setupRepoWithRemoteAndBranch creates a bare origin, a clone with rimba


### PR DESCRIPTION
## Summary

- Add `pr:<num>` positional argument to `rimba add` that creates a worktree from a GitHub PR's head branch
- For cross-fork PRs, automatically adds the fork as a `gh-fork-<owner>` remote and tracks its ref
- Default task name is `review/<num>-<slugified-title>`; override with `--task`
- Validates PR metadata fields and rejects unsafe characters to prevent git config injection

## Test Plan

- [x] Unit tests pass (`make test`) — 1578 passed in 26 packages
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2E: same-repo PR — `rimba add pr:<N>` creates worktree tracking `origin/<headRef>`
- [x] E2E: cross-fork PR — creates `gh-fork-<owner>` remote, worktree tracks fork ref
- [x] E2E: `--task my-review` overrides auto-derived branch name
- [x] Error path: missing gh auth surfaces `errhint` "To fix: gh auth login" message
- [x] Guard: `--task` without `pr:<num>` returns clear error

Closes #123