### PR TITLE
[refactor] Introduce resolver.TaskAndType helper to de-duplicate display sites

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -260,8 +260,7 @@ func filterDirtyWorktrees(r git.Runner, s *spinner.Spinner, worktrees []resolver
 func printExecResults(cmd *cobra.Command, p *termcolor.Painter, results []executor.Result, prefixes []string) {
 	out := cmd.OutOrStdout()
 	for _, r := range results {
-		_, matchedPrefix := resolver.PureTaskFromBranch(r.Target.Branch, prefixes)
-		typeName := strings.TrimSuffix(matchedPrefix, "/")
+		_, typeName := resolver.TaskAndType(r.Target.Branch, prefixes)
 
 		taskLabel := r.Target.Task
 		if c := typeColor(typeName); c != "" {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -190,8 +190,7 @@ func listArchivedBranches(cmd *cobra.Command, r git.Runner, mainBranch string) e
 	if isJSON(cmd) {
 		items := make([]output.ListArchivedItem, 0, len(archived))
 		for _, b := range archived {
-			task, matchedPrefix := resolver.PureTaskFromBranch(b, prefixes)
-			typeName := strings.TrimSuffix(matchedPrefix, "/")
+			task, typeName := resolver.TaskAndType(b, prefixes)
 			items = append(items, output.ListArchivedItem{Task: task, Type: typeName, Branch: b})
 		}
 		return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
@@ -213,8 +212,7 @@ func listArchivedBranches(cmd *cobra.Command, r git.Runner, mainBranch string) e
 	)
 
 	for _, b := range archived {
-		task, matchedPrefix := resolver.PureTaskFromBranch(b, prefixes)
-		typeName := strings.TrimSuffix(matchedPrefix, "/")
+		task, typeName := resolver.TaskAndType(b, prefixes)
 
 		typeCell := typeName
 		if c := typeColor(typeName); c != "" {

--- a/cmd/merge_plan.go
+++ b/cmd/merge_plan.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/conflict"
@@ -68,8 +67,7 @@ var mergePlanCmd = &cobra.Command{
 		)
 
 		for _, step := range steps {
-			task, prefix := resolver.PureTaskFromBranch(step.Branch, prefixes)
-			typeName := strings.TrimSuffix(prefix, "/")
+			task, typeName := resolver.TaskAndType(step.Branch, prefixes)
 
 			branchCell := task
 			if c := typeColor(typeName); c != "" {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -267,8 +266,7 @@ func buildCLIStatusSummary(results []statusEntry, staleThreshold time.Time) cliS
 
 // buildStatusRow formats a single worktree row for the status table.
 func buildStatusRow(r statusEntry, prefixes []string, staleThreshold time.Time, p *termcolor.Painter, detail bool) []string {
-	task, matchedPrefix := resolver.PureTaskFromBranch(r.entry.Branch, prefixes)
-	typeName := strings.TrimSuffix(matchedPrefix, "/")
+	task, typeName := resolver.TaskAndType(r.entry.Branch, prefixes)
 
 	taskCell := "  " + task
 	typeCell := typeName
@@ -328,8 +326,7 @@ func writeStatusJSON(cmd *cobra.Command, results []statusEntry, staleDays int, f
 			summary.Behind++
 		}
 
-		task, matchedPrefix := resolver.PureTaskFromBranch(r.entry.Branch, prefixes)
-		typeName := strings.TrimSuffix(matchedPrefix, "/")
+		task, typeName := resolver.TaskAndType(r.entry.Branch, prefixes)
 
 		item := output.StatusItem{
 			Task:      task,

--- a/internal/mcp/tool_list.go
+++ b/internal/mcp/tool_list.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
@@ -99,8 +98,7 @@ func handleListArchived(r git.Runner, hctx *HandlerContext) (*mcp.CallToolResult
 	prefixes := resolver.AllPrefixes()
 	items := make([]listArchivedItem, 0, len(archived))
 	for _, b := range archived {
-		task, matchedPrefix := resolver.PureTaskFromBranch(b, prefixes)
-		typeName := strings.TrimSuffix(matchedPrefix, "/")
+		task, typeName := resolver.TaskAndType(b, prefixes)
 		items = append(items, listArchivedItem{Task: task, Type: typeName, Branch: b})
 	}
 

--- a/internal/mcp/tool_status.go
+++ b/internal/mcp/tool_status.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/lugassawan/rimba/internal/git"
@@ -107,8 +106,7 @@ func buildStatusResult(results []statusCollectedEntry, staleThreshold time.Time,
 
 // buildStatusItem constructs a statusItem from a collected entry.
 func buildStatusItem(r statusCollectedEntry, staleThreshold time.Time, prefixes []string) statusItem {
-	task, matchedPrefix := resolver.PureTaskFromBranch(r.entry.Branch, prefixes)
-	typeName := strings.TrimSuffix(matchedPrefix, "/")
+	task, typeName := resolver.TaskAndType(r.entry.Branch, prefixes)
 
 	item := statusItem{
 		Task:   task,

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -90,6 +90,15 @@ func PureTaskFromBranch(branch string, prefixes []string) (task, matchedPrefix s
 	return t, p
 }
 
+// TaskAndType extracts the task and a display-friendly type name (matched
+// prefix without the trailing "/"). Use this for display/serialization
+// callers; use PureTaskFromBranch when you need the raw prefix token
+// (e.g. for branch reconstruction or emptiness checks).
+func TaskAndType(branch string, prefixes []string) (task, typeName string) {
+	t, p := PureTaskFromBranch(branch, prefixes)
+	return t, strings.TrimSuffix(p, "/")
+}
+
 // WorktreeInfo holds parsed information about a worktree.
 type WorktreeInfo struct {
 	Path    string

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -334,6 +334,33 @@ func TestFindAllBranchesForTask(t *testing.T) {
 	}
 }
 
+func TestTaskAndType(t *testing.T) {
+	prefixes := resolver.AllPrefixes()
+
+	const svcAuthAPI = "auth-api"
+
+	tests := []struct {
+		branch       string
+		wantTask     string
+		wantTypeName string
+	}{
+		{"foo", "foo", ""},
+		{featurePrefix + "foo", "foo", "feature"},
+		{bugfixPrefix + "login-fix", "login-fix", "bugfix"},
+		{svcAuthAPI + "/" + featurePrefix + taskLogin, taskLogin, "feature"},
+		{"", "", ""},
+	}
+	for _, tt := range tests {
+		task, typeName := resolver.TaskAndType(tt.branch, prefixes)
+		if task != tt.wantTask {
+			t.Errorf("TaskAndType(%q) task = %q, want %q", tt.branch, task, tt.wantTask)
+		}
+		if typeName != tt.wantTypeName {
+			t.Errorf("TaskAndType(%q) typeName = %q, want %q", tt.branch, typeName, tt.wantTypeName)
+		}
+	}
+}
+
 func TestAllPrefixes(t *testing.T) {
 	prefixes := resolver.AllPrefixes()
 	if len(prefixes) != 6 {


### PR DESCRIPTION
## Summary
- Add `resolver.TaskAndType(branch, prefixes) (task, typeName string)` wrapping `PureTaskFromBranch` + slash-trim in one place
- Migrate 7 verified display/serialization call sites (`cmd/status.go` ×2, `cmd/list.go` ×2, `cmd/merge_plan.go` ×1, `cmd/exec.go` ×1, `internal/mcp/tool_list.go` ×1, `internal/mcp/tool_status.go` ×1) to the new helper
- Remove now-unused `strings` import from `cmd/status.go`, `cmd/merge_plan.go`, `internal/mcp/tool_list.go`, `internal/mcp/tool_status.go`

## Test Plan
- [x] Unit tests pass (`go test ./...` — 1584/1584)
- [x] Linter passes (`go vet ./...` — 0 issues)
- [x] New `TestTaskAndType` table-driven test covers no-prefix, plain-prefix, monorepo-prefix, and empty-branch cases
- [x] `git grep PureTaskFromBranch` confirms only genuinely non-display sites (prefix discarded or used for emptiness check) remain on the old API

Closes #140