### PR TITLE
[refactor] Introduce PostCreateOptions and split add RunE (#141)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -26,6 +26,8 @@ const (
 
 var prArgRe = regexp.MustCompile(`^pr:(\d+)$`)
 
+var newGHRunner = gh.Default
+
 var addCmd = &cobra.Command{
 	Use:   "add <task|pr:<num>> or add <service>/<task>",
 	Short: "Create a new worktree for a task or GitHub PR",
@@ -50,7 +52,7 @@ var addCmd = &cobra.Command{
 
 		if m := prArgRe.FindStringSubmatch(args[0]); m != nil {
 			prNum, _ := strconv.Atoi(m[1])
-			return runAddPR(cmd, r, prNum, postOpts, s)
+			return runAddPR(cmd, r, newGHRunner(), prNum, postOpts, s)
 		}
 
 		if cmd.Flags().Changed(flagTask) {
@@ -61,10 +63,10 @@ var addCmd = &cobra.Command{
 	},
 }
 
-func runAddPR(cmd *cobra.Command, r git.Runner, prNum int, postOpts operations.PostCreateOptions, s *spinner.Spinner) error {
+func runAddPR(cmd *cobra.Command, r git.Runner, ghR gh.Runner, prNum int, postOpts operations.PostCreateOptions, s *spinner.Spinner) error {
 	taskOverride, _ := cmd.Flags().GetString(flagTask)
 
-	result, err := operations.AddPRWorktree(cmd.Context(), r, gh.Default(), operations.AddPRParams{
+	result, err := operations.AddPRWorktree(cmd.Context(), r, ghR, operations.AddPRParams{
 		PRNumber:          prNum,
 		TaskOverride:      taskOverride,
 		PostCreateOptions: postOpts,

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -43,11 +43,7 @@ var addCmd = &cobra.Command{
 
 		skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
 		skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
-
-		var configModules []config.ModuleConfig
-		if cfg.Deps != nil {
-			configModules = cfg.Deps.Modules
-		}
+		postOpts := buildPostCreateOptions(cfg, repoRoot, skipDeps, skipHooks)
 
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
@@ -58,19 +54,9 @@ var addCmd = &cobra.Command{
 			taskOverride, _ := cmd.Flags().GetString(flagTask)
 
 			result, err := operations.AddPRWorktree(cmd.Context(), r, gh.Default(), operations.AddPRParams{
-				PRNumber:     prNum,
-				TaskOverride: taskOverride,
-				PostCreateOptions: operations.PostCreateOptions{
-					RepoRoot:      repoRoot,
-					WorktreeDir:   filepath.Join(repoRoot, cfg.WorktreeDir),
-					CopyFiles:     cfg.CopyFiles,
-					SkipDeps:      skipDeps,
-					AutoDetect:    cfg.IsAutoDetectDeps(),
-					ConfigModules: configModules,
-					SkipHooks:     skipHooks,
-					PostCreate:    cfg.PostCreate,
-					Concurrency:   cfg.DepsConcurrency(),
-				},
+				PRNumber:          prNum,
+				TaskOverride:      taskOverride,
+				PostCreateOptions: postOpts,
 			}, func(msg string) { s.Update(msg) })
 			if err != nil {
 				return err
@@ -109,21 +95,11 @@ var addCmd = &cobra.Command{
 
 		s.Start("Creating worktree...")
 		result, err := operations.AddWorktree(r, operations.AddParams{
-			Task:    task,
-			Service: service,
-			Prefix:  prefix,
-			Source:  source,
-			PostCreateOptions: operations.PostCreateOptions{
-				RepoRoot:      repoRoot,
-				WorktreeDir:   filepath.Join(repoRoot, cfg.WorktreeDir),
-				CopyFiles:     cfg.CopyFiles,
-				SkipDeps:      skipDeps,
-				AutoDetect:    cfg.IsAutoDetectDeps(),
-				ConfigModules: configModules,
-				SkipHooks:     skipHooks,
-				PostCreate:    cfg.PostCreate,
-				Concurrency:   cfg.DepsConcurrency(),
-			},
+			Task:              task,
+			Service:           service,
+			Prefix:            prefix,
+			Source:            source,
+			PostCreateOptions: postOpts,
 		}, func(msg string) { s.Update(msg) })
 		if err != nil {
 			return err
@@ -154,6 +130,24 @@ func printWorktreeResult(cmd *cobra.Command, header string, result operations.Ad
 	}
 	printInstallResults(out, result.DepsResults)
 	printHookResultsList(out, result.HookResults)
+}
+
+func buildPostCreateOptions(cfg *config.Config, repoRoot string, skipDeps, skipHooks bool) operations.PostCreateOptions {
+	var configModules []config.ModuleConfig
+	if cfg.Deps != nil {
+		configModules = cfg.Deps.Modules
+	}
+	return operations.PostCreateOptions{
+		RepoRoot:      repoRoot,
+		WorktreeDir:   filepath.Join(repoRoot, cfg.WorktreeDir),
+		CopyFiles:     cfg.CopyFiles,
+		SkipDeps:      skipDeps,
+		AutoDetect:    cfg.IsAutoDetectDeps(),
+		ConfigModules: configModules,
+		SkipHooks:     skipHooks,
+		PostCreate:    cfg.PostCreate,
+		Concurrency:   cfg.DepsConcurrency(),
+	}
 }
 
 func init() {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -48,73 +48,80 @@ var addCmd = &cobra.Command{
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
 
-		// pr:<num> shorthand — create worktree from a GitHub PR.
 		if m := prArgRe.FindStringSubmatch(args[0]); m != nil {
 			prNum, _ := strconv.Atoi(m[1])
-			taskOverride, _ := cmd.Flags().GetString(flagTask)
-
-			result, err := operations.AddPRWorktree(cmd.Context(), r, gh.Default(), operations.AddPRParams{
-				PRNumber:          prNum,
-				TaskOverride:      taskOverride,
-				PostCreateOptions: postOpts,
-			}, func(msg string) { s.Update(msg) })
-			if err != nil {
-				return err
-			}
-
-			s.Stop()
-			printWorktreeResult(cmd, fmt.Sprintf("Created worktree for PR #%d", prNum), result)
-			return nil
+			return runAddPR(cmd, r, prNum, postOpts, s)
 		}
 
 		if cmd.Flags().Changed(flagTask) {
 			return errors.New("--task requires a pr:<num> argument")
 		}
 
-		service, task := operations.ResolveTaskInput(args[0], repoRoot)
-		prefix := resolvedPrefixString(cmd)
+		return runAddTask(cmd, r, args[0], cfg, repoRoot, postOpts, s)
+	},
+}
 
-		if !hasExplicitPrefixFlag(cmd) {
-			if candidate, _ := resolver.SplitServiceInput(args[0]); resolver.ValidPrefixType(candidate) {
-				if p, ok := resolver.PrefixString(resolver.PrefixType(candidate)); ok {
-					prefix = p
-				}
+func runAddPR(cmd *cobra.Command, r git.Runner, prNum int, postOpts operations.PostCreateOptions, s *spinner.Spinner) error {
+	taskOverride, _ := cmd.Flags().GetString(flagTask)
+
+	result, err := operations.AddPRWorktree(cmd.Context(), r, gh.Default(), operations.AddPRParams{
+		PRNumber:          prNum,
+		TaskOverride:      taskOverride,
+		PostCreateOptions: postOpts,
+	}, func(msg string) { s.Update(msg) })
+	if err != nil {
+		return err
+	}
+
+	s.Stop()
+	printWorktreeResult(cmd, fmt.Sprintf("Created worktree for PR #%d", prNum), result)
+	return nil
+}
+
+func runAddTask(cmd *cobra.Command, r git.Runner, arg string, cfg *config.Config, repoRoot string, postOpts operations.PostCreateOptions, s *spinner.Spinner) error {
+	service, task := operations.ResolveTaskInput(arg, repoRoot)
+	prefix := resolvedPrefixString(cmd)
+
+	if !hasExplicitPrefixFlag(cmd) {
+		if candidate, _ := resolver.SplitServiceInput(arg); resolver.ValidPrefixType(candidate) {
+			if p, ok := resolver.PrefixString(resolver.PrefixType(candidate)); ok {
+				prefix = p
 			}
 		}
+	}
 
-		source, _ := cmd.Flags().GetString(flagSource)
-		if source == "" {
-			source = cfg.DefaultSource
-		}
+	source, _ := cmd.Flags().GetString(flagSource)
+	if source == "" {
+		source = cfg.DefaultSource
+	}
 
-		hint.New(cmd, hintPainter(cmd)).
-			Add(flagSkipDeps, hintSkipDeps).
-			Add(flagSkipHooks, hintSkipHooks).
-			Add(flagSource, hintSource).
-			Show()
+	hint.New(cmd, hintPainter(cmd)).
+		Add(flagSkipDeps, hintSkipDeps).
+		Add(flagSkipHooks, hintSkipHooks).
+		Add(flagSource, hintSource).
+		Show()
 
-		s.Start("Creating worktree...")
-		result, err := operations.AddWorktree(r, operations.AddParams{
-			Task:              task,
-			Service:           service,
-			Prefix:            prefix,
-			Source:            source,
-			PostCreateOptions: postOpts,
-		}, func(msg string) { s.Update(msg) })
-		if err != nil {
-			return err
-		}
+	s.Start("Creating worktree...")
+	result, err := operations.AddWorktree(r, operations.AddParams{
+		Task:              task,
+		Service:           service,
+		Prefix:            prefix,
+		Source:            source,
+		PostCreateOptions: postOpts,
+	}, func(msg string) { s.Update(msg) })
+	if err != nil {
+		return err
+	}
 
-		s.Stop()
+	s.Stop()
 
-		header := fmt.Sprintf("Created worktree for task %q", task)
-		if result.Service != "" {
-			header = fmt.Sprintf("Created worktree for task %q (service: %s)", task, result.Service)
-		}
-		printWorktreeResult(cmd, header, result)
+	header := fmt.Sprintf("Created worktree for task %q", task)
+	if result.Service != "" {
+		header = fmt.Sprintf("Created worktree for task %q (service: %s)", task, result.Service)
+	}
+	printWorktreeResult(cmd, header, result)
 
-		return nil
-	},
+	return nil
 }
 
 func printWorktreeResult(cmd *cobra.Command, header string, result operations.AddResult) {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -58,17 +58,19 @@ var addCmd = &cobra.Command{
 			taskOverride, _ := cmd.Flags().GetString(flagTask)
 
 			result, err := operations.AddPRWorktree(cmd.Context(), r, gh.Default(), operations.AddPRParams{
-				PRNumber:      prNum,
-				TaskOverride:  taskOverride,
-				RepoRoot:      repoRoot,
-				WorktreeDir:   filepath.Join(repoRoot, cfg.WorktreeDir),
-				CopyFiles:     cfg.CopyFiles,
-				SkipDeps:      skipDeps,
-				AutoDetect:    cfg.IsAutoDetectDeps(),
-				ConfigModules: configModules,
-				SkipHooks:     skipHooks,
-				PostCreate:    cfg.PostCreate,
-				Concurrency:   cfg.DepsConcurrency(),
+				PRNumber:     prNum,
+				TaskOverride: taskOverride,
+				PostCreateOptions: operations.PostCreateOptions{
+					RepoRoot:      repoRoot,
+					WorktreeDir:   filepath.Join(repoRoot, cfg.WorktreeDir),
+					CopyFiles:     cfg.CopyFiles,
+					SkipDeps:      skipDeps,
+					AutoDetect:    cfg.IsAutoDetectDeps(),
+					ConfigModules: configModules,
+					SkipHooks:     skipHooks,
+					PostCreate:    cfg.PostCreate,
+					Concurrency:   cfg.DepsConcurrency(),
+				},
 			}, func(msg string) { s.Update(msg) })
 			if err != nil {
 				return err
@@ -107,19 +109,21 @@ var addCmd = &cobra.Command{
 
 		s.Start("Creating worktree...")
 		result, err := operations.AddWorktree(r, operations.AddParams{
-			Task:          task,
-			Service:       service,
-			Prefix:        prefix,
-			Source:        source,
-			RepoRoot:      repoRoot,
-			WorktreeDir:   filepath.Join(repoRoot, cfg.WorktreeDir),
-			CopyFiles:     cfg.CopyFiles,
-			SkipDeps:      skipDeps,
-			AutoDetect:    cfg.IsAutoDetectDeps(),
-			ConfigModules: configModules,
-			SkipHooks:     skipHooks,
-			PostCreate:    cfg.PostCreate,
-			Concurrency:   cfg.DepsConcurrency(),
+			Task:    task,
+			Service: service,
+			Prefix:  prefix,
+			Source:  source,
+			PostCreateOptions: operations.PostCreateOptions{
+				RepoRoot:      repoRoot,
+				WorktreeDir:   filepath.Join(repoRoot, cfg.WorktreeDir),
+				CopyFiles:     cfg.CopyFiles,
+				SkipDeps:      skipDeps,
+				AutoDetect:    cfg.IsAutoDetectDeps(),
+				ConfigModules: configModules,
+				SkipHooks:     skipHooks,
+				PostCreate:    cfg.PostCreate,
+				Concurrency:   cfg.DepsConcurrency(),
+			},
 		}, func(msg string) { s.Update(msg) })
 		if err != nil {
 			return err

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,58 @@ import (
 
 	"github.com/lugassawan/rimba/internal/config"
 )
+
+const (
+	prCmdAuth = "auth"
+	prCmdPR   = "pr"
+
+	sameRepoPRJSON = `{
+  "number": 42,
+  "title": "Fix login redirect",
+  "headRefName": "fix-login-redirect",
+  "headRepository": {"name": "rimba"},
+  "headRepositoryOwner": {"login": "lugassawan"},
+  "isCrossRepository": false
+}`
+)
+
+// makeWorktreeGitRunner builds a mockRunner that simulates a successful worktree creation.
+// Handles: git common-dir, show-toplevel, fetch, rev-parse (branch absent), worktree add.
+func makeWorktreeGitRunner(repoDir string) *mockRunner {
+	return &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[1] == cmdGitCommonDir:
+				return filepath.Join(repoDir, ".git"), nil
+			case len(args) >= 2 && args[1] == cmdShowToplevel:
+				return repoDir, nil
+			case len(args) >= 1 && args[0] == cmdFetch:
+				return "", nil
+			case len(args) >= 1 && args[0] == cmdRevParse:
+				return "", errGitFailed
+			case len(args) >= 1 && args[0] == cmdWorktreeTest:
+				if len(args) >= 2 && args[1] == gitSubcmdWorktreeAdd {
+					_ = os.MkdirAll(args[4], 0o755)
+				}
+				return "", nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+}
+
+// makeOKGhRunner builds a mockGhRunner that returns a successful auth and the given PR JSON.
+func makeOKGhRunner(prJSON string) *mockGhRunner {
+	return &mockGhRunner{
+		run: func(_ context.Context, args ...string) ([]byte, error) {
+			if len(args) > 0 && args[0] == prCmdAuth {
+				return []byte("Logged in"), nil
+			}
+			return []byte(prJSON), nil
+		},
+	}
+}
 
 func TestAddSuccess(t *testing.T) {
 	repoDir := t.TempDir()
@@ -140,5 +193,143 @@ func TestAddWithSource(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "Created worktree") {
 		t.Errorf("output = %q, want 'Created worktree'", buf.String())
+	}
+}
+
+func TestAddPRCmd(t *testing.T) {
+	repoDir := t.TempDir()
+	wtDir := filepath.Join(repoDir, ".worktrees")
+	_ = os.MkdirAll(wtDir, 0755)
+	cfg := &config.Config{
+		WorktreeDir: ".worktrees",
+		Deps:        &config.DepsConfig{Modules: []config.ModuleConfig{{Dir: "frontend", Install: "npm install"}}},
+	}
+
+	fakeGhDir := t.TempDir()
+	fakeGh := filepath.Join(fakeGhDir, "gh")
+	_ = os.WriteFile(fakeGh, []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	t.Setenv("PATH", fakeGhDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	restoreGH := overrideGHRunner(makeOKGhRunner(sameRepoPRJSON))
+	defer restoreGH()
+	restoreRunner := overrideNewRunner(makeWorktreeGitRunner(repoDir))
+	defer restoreRunner()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().StringP(flagSource, "s", "", "")
+	cmd.Flags().Bool(flagSkipDeps, false, "")
+	cmd.Flags().Bool(flagSkipHooks, false, "")
+	cmd.Flags().String(flagTask, "", "")
+	addPrefixFlags(cmd)
+	_ = cmd.Flags().Set(flagSkipDeps, "true")
+	_ = cmd.Flags().Set(flagSkipHooks, "true")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := addCmd.RunE(cmd, []string{"pr:42"})
+	if err != nil {
+		t.Fatalf("addCmd.RunE pr:42: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "PR #42") {
+		t.Errorf("output = %q, want 'PR #42'", out)
+	}
+}
+
+func TestAddPRCmdError(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{WorktreeDir: ".worktrees"}
+
+	fakeGhDir := t.TempDir()
+	fakeGh := filepath.Join(fakeGhDir, "gh")
+	_ = os.WriteFile(fakeGh, []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	t.Setenv("PATH", fakeGhDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ghR := &mockGhRunner{
+		run: func(_ context.Context, _ ...string) ([]byte, error) {
+			return nil, errors.New("gh: not authenticated")
+		},
+	}
+	restoreGH := overrideGHRunner(ghR)
+	defer restoreGH()
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdGitCommonDir {
+				return filepath.Join(repoDir, ".git"), nil
+			}
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restoreRunner := overrideNewRunner(r)
+	defer restoreRunner()
+
+	cmd, _ := newTestCmd()
+	cmd.Flags().StringP(flagSource, "s", "", "")
+	cmd.Flags().Bool(flagSkipDeps, false, "")
+	cmd.Flags().Bool(flagSkipHooks, false, "")
+	cmd.Flags().String(flagTask, "", "")
+	addPrefixFlags(cmd)
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := addCmd.RunE(cmd, []string{"pr:42"})
+	if err == nil {
+		t.Fatal("expected error from PR add with auth failure")
+	}
+}
+
+func TestAddWithFeaturePrefix(t *testing.T) {
+	repoDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(repoDir, ".worktrees"), 0755)
+	cfg := &config.Config{WorktreeDir: ".worktrees"}
+
+	restore := overrideNewRunner(makeWorktreeGitRunner(repoDir))
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().StringP(flagSource, "s", "", "")
+	cmd.Flags().Bool(flagSkipDeps, false, "")
+	cmd.Flags().Bool(flagSkipHooks, false, "")
+	addPrefixFlags(cmd)
+	_ = cmd.Flags().Set(flagSkipDeps, "true")
+	_ = cmd.Flags().Set(flagSkipHooks, "true")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := addCmd.RunE(cmd, []string{"feature/my-task"})
+	if err != nil {
+		t.Fatalf("addCmd.RunE feature/my-task: %v", err)
+	}
+	if !strings.Contains(buf.String(), "my-task") {
+		t.Errorf("output = %q, want 'my-task'", buf.String())
+	}
+}
+
+func TestAddWithService(t *testing.T) {
+	repoDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(repoDir, "api"), 0o755)
+	_ = os.MkdirAll(filepath.Join(repoDir, ".worktrees"), 0755)
+	cfg := &config.Config{WorktreeDir: ".worktrees"}
+
+	restore := overrideNewRunner(makeWorktreeGitRunner(repoDir))
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().StringP(flagSource, "s", "", "")
+	cmd.Flags().Bool(flagSkipDeps, false, "")
+	cmd.Flags().Bool(flagSkipHooks, false, "")
+	addPrefixFlags(cmd)
+	_ = cmd.Flags().Set(flagSkipDeps, "true")
+	_ = cmd.Flags().Set(flagSkipHooks, "true")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := addCmd.RunE(cmd, []string{"api/my-task"})
+	if err != nil {
+		t.Fatalf("addCmd.RunE api/my-task: %v", err)
+	}
+	if !strings.Contains(buf.String(), "service: api") {
+		t.Errorf("output = %q, want 'service: api'", buf.String())
 	}
 }

--- a/cmd/mock_runner_test.go
+++ b/cmd/mock_runner_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 
+	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/spf13/cobra"
 )
@@ -47,6 +49,7 @@ const (
 	cmdDiff               = "diff"
 	cmdFetch              = "fetch"
 	cmdRemove             = "remove"
+	gitSubcmdWorktreeAdd  = "add"
 	cmdSymbolicRef        = "symbolic-ref"
 	cmdStatus             = "status"
 	refsRemotesOriginMain = "refs/remotes/origin/main"
@@ -109,4 +112,20 @@ func overrideNewRunner(r git.Runner) func() {
 	orig := newRunner
 	newRunner = func() git.Runner { return r }
 	return func() { newRunner = orig }
+}
+
+// mockGhRunner implements gh.Runner with a configurable closure for testing.
+type mockGhRunner struct {
+	run func(ctx context.Context, args ...string) ([]byte, error)
+}
+
+func (m *mockGhRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	return m.run(ctx, args...)
+}
+
+// overrideGHRunner temporarily replaces the newGHRunner function for testing.
+func overrideGHRunner(r gh.Runner) func() {
+	orig := newGHRunner
+	newGHRunner = func() gh.Runner { return r }
+	return func() { newGHRunner = orig }
 }

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -20,7 +20,7 @@ func TestRestoreSuccess(t *testing.T) {
 				return "main\nfeature/restored-task", nil
 			case args[0] == cmdWorktreeTest && args[1] == cmdList:
 				return wtRepo + headMainBlock, nil
-			case args[0] == cmdWorktreeTest && args[1] == "add":
+			case args[0] == cmdWorktreeTest && args[1] == gitSubcmdWorktreeAdd:
 				return "", nil
 			}
 			return "", nil

--- a/internal/mcp/tool_add.go
+++ b/internal/mcp/tool_add.go
@@ -69,19 +69,21 @@ func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 		}
 
 		result, err := operations.AddWorktree(hctx.Runner, operations.AddParams{
-			Task:          task,
-			Service:       service,
-			Prefix:        prefix,
-			Source:        source,
-			RepoRoot:      hctx.RepoRoot,
-			WorktreeDir:   filepath.Join(hctx.RepoRoot, cfg.WorktreeDir),
-			CopyFiles:     cfg.CopyFiles,
-			SkipDeps:      req.GetBool("skip_deps", false),
-			AutoDetect:    cfg.IsAutoDetectDeps(),
-			ConfigModules: configModules,
-			SkipHooks:     req.GetBool("skip_hooks", false),
-			PostCreate:    cfg.PostCreate,
-			Concurrency:   cfg.DepsConcurrency(),
+			Task:    task,
+			Service: service,
+			Prefix:  prefix,
+			Source:  source,
+			PostCreateOptions: operations.PostCreateOptions{
+				RepoRoot:      hctx.RepoRoot,
+				WorktreeDir:   filepath.Join(hctx.RepoRoot, cfg.WorktreeDir),
+				CopyFiles:     cfg.CopyFiles,
+				SkipDeps:      req.GetBool("skip_deps", false),
+				AutoDetect:    cfg.IsAutoDetectDeps(),
+				ConfigModules: configModules,
+				SkipHooks:     req.GetBool("skip_hooks", false),
+				PostCreate:    cfg.PostCreate,
+				Concurrency:   cfg.DepsConcurrency(),
+			},
 		}, nil)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil

--- a/internal/operations/add.go
+++ b/internal/operations/add.go
@@ -12,12 +12,8 @@ import (
 	"github.com/lugassawan/rimba/internal/resolver"
 )
 
-// AddParams holds the inputs for creating a new worktree.
-type AddParams struct {
-	Task          string
-	Service       string
-	Prefix        string // e.g. "feature/"
-	Source        string // source branch
+// PostCreateOptions holds the post-create knobs shared by AddParams and AddPRParams.
+type PostCreateOptions struct {
 	RepoRoot      string
 	WorktreeDir   string // absolute path to worktree directory
 	CopyFiles     []string
@@ -27,6 +23,15 @@ type AddParams struct {
 	SkipHooks     bool
 	PostCreate    []string // hook commands
 	Concurrency   int      // max parallel module installs; 0 = Manager default
+}
+
+// AddParams holds the inputs for creating a new worktree.
+type AddParams struct {
+	Task    string
+	Service string
+	Prefix  string // e.g. "feature/"
+	Source  string // source branch
+	PostCreateOptions
 }
 
 // AddResult holds the outcome of creating a worktree.

--- a/internal/operations/add_pr_worktree.go
+++ b/internal/operations/add_pr_worktree.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/git"
@@ -17,16 +16,7 @@ import (
 type AddPRParams struct {
 	PRNumber     int
 	TaskOverride string // empty = derive from PR title
-
-	RepoRoot      string
-	WorktreeDir   string
-	CopyFiles     []string
-	SkipDeps      bool
-	AutoDetect    bool
-	ConfigModules []config.ModuleConfig
-	SkipHooks     bool
-	PostCreate    []string
-	Concurrency   int
+	PostCreateOptions
 }
 
 // AddPRWorktree creates a worktree from a GitHub PR's head branch.
@@ -60,17 +50,9 @@ func AddPRWorktree(
 	}
 
 	return AddWorktree(gitR, AddParams{
-		Task:          task,
-		Source:        source,
-		RepoRoot:      params.RepoRoot,
-		WorktreeDir:   params.WorktreeDir,
-		CopyFiles:     params.CopyFiles,
-		SkipDeps:      params.SkipDeps,
-		AutoDetect:    params.AutoDetect,
-		ConfigModules: params.ConfigModules,
-		SkipHooks:     params.SkipHooks,
-		PostCreate:    params.PostCreate,
-		Concurrency:   params.Concurrency,
+		Task:              task,
+		Source:            source,
+		PostCreateOptions: params.PostCreateOptions,
 	}, onProgress)
 }
 

--- a/internal/operations/add_pr_worktree_test.go
+++ b/internal/operations/add_pr_worktree_test.go
@@ -94,11 +94,13 @@ func TestAddPRWorktreeSameRepo(t *testing.T) {
 	gitR := makePRGitRunner(tmpDir, false)
 
 	result, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
-		PRNumber:    42,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    true,
-		SkipHooks:   true,
+		PRNumber: 42,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err != nil {
 		t.Fatalf("AddPRWorktree: %v", err)
@@ -119,11 +121,13 @@ func TestAddPRWorktreeCrossFork(t *testing.T) {
 	gitR := makePRGitRunner(tmpDir, true)
 
 	result, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
-		PRNumber:    99,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    true,
-		SkipHooks:   true,
+		PRNumber: 99,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err != nil {
 		t.Fatalf("AddPRWorktree: %v", err)
@@ -146,10 +150,12 @@ func TestAddPRWorktreeTaskOverride(t *testing.T) {
 	result, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
 		PRNumber:     42,
 		TaskOverride: "my-review",
-		RepoRoot:     tmpDir,
-		WorktreeDir:  wtDir,
-		SkipDeps:     true,
-		SkipHooks:    true,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err != nil {
 		t.Fatalf("AddPRWorktree: %v", err)
@@ -226,11 +232,13 @@ func TestAddPRWorktreeSameRepoFetchFails(t *testing.T) {
 	}
 
 	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
-		PRNumber:    42,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    true,
-		SkipHooks:   true,
+		PRNumber: 42,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected error from fetch failure")
@@ -264,11 +272,13 @@ func TestAddPRWorktreeCrossForkAddRemoteFails(t *testing.T) {
 	}
 
 	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
-		PRNumber:    99,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    true,
-		SkipHooks:   true,
+		PRNumber: 99,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected error from AddRemote failure")
@@ -305,11 +315,13 @@ func TestAddPRWorktreeCrossForkFetchFails(t *testing.T) {
 	}
 
 	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
-		PRNumber:    99,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    true,
-		SkipHooks:   true,
+		PRNumber: 99,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected error from fork fetch failure")
@@ -335,11 +347,13 @@ func TestAddPRWorktreeResolveSourceFailure(t *testing.T) {
 	}
 
 	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
-		PRNumber:    42,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    true,
-		SkipHooks:   true,
+		PRNumber: 42,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected error from resolveSource failure")
@@ -357,11 +371,13 @@ func TestAddPRWorktreeProgressCallbacks(t *testing.T) {
 	onProgress := progress.Func(func(msg string) { messages = append(messages, msg) })
 
 	_, err := AddPRWorktree(context.Background(), gitR, ghR, AddPRParams{
-		PRNumber:    42,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    true,
-		SkipHooks:   true,
+		PRNumber: 42,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, onProgress)
 	if err != nil {
 		t.Fatalf("AddPRWorktree: %v", err)

--- a/internal/operations/add_test.go
+++ b/internal/operations/add_test.go
@@ -31,13 +31,15 @@ func TestAddWorktreeSuccess(t *testing.T) {
 	}
 
 	result, err := AddWorktree(r, AddParams{
-		Task:        "login",
-		Prefix:      "feature/",
-		Source:      branchMain,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    true,
-		SkipHooks:   true,
+		Task:   "login",
+		Prefix: "feature/",
+		Source: branchMain,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -69,12 +71,14 @@ func TestAddWorktreeBranchExists(t *testing.T) {
 	}
 
 	_, err := AddWorktree(r, AddParams{
-		Task:        "login",
-		Prefix:      "feature/",
-		Source:      branchMain,
-		WorktreeDir: "/tmp/wt",
-		SkipDeps:    true,
-		SkipHooks:   true,
+		Task:   "login",
+		Prefix: "feature/",
+		Source: branchMain,
+		PostCreateOptions: PostCreateOptions{
+			WorktreeDir: "/tmp/wt",
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected error for existing branch")
@@ -101,13 +105,15 @@ func TestAddWorktreePathExists(t *testing.T) {
 	}
 
 	_, err := AddWorktree(r, AddParams{
-		Task:        "login",
-		Prefix:      "feature/",
-		Source:      branchMain,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    true,
-		SkipHooks:   true,
+		Task:   "login",
+		Prefix: "feature/",
+		Source: branchMain,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected error for existing path")
@@ -132,12 +138,14 @@ func TestAddWorktreeCreateFails(t *testing.T) {
 	}
 
 	_, err := AddWorktree(r, AddParams{
-		Task:        "login",
-		Prefix:      "feature/",
-		Source:      branchMain,
-		WorktreeDir: "/tmp/nonexistent-wt",
-		SkipDeps:    true,
-		SkipHooks:   true,
+		Task:   "login",
+		Prefix: "feature/",
+		Source: branchMain,
+		PostCreateOptions: PostCreateOptions{
+			WorktreeDir: "/tmp/nonexistent-wt",
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err == nil {
 		t.Fatal("expected error")
@@ -169,13 +177,15 @@ func TestAddWorktreeProgressCallbacks(t *testing.T) {
 	onProgress := progress.Func(func(msg string) { messages = append(messages, msg) })
 
 	_, err := AddWorktree(r, AddParams{
-		Task:        "login",
-		Prefix:      "feature/",
-		Source:      branchMain,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    true,
-		SkipHooks:   true,
+		Task:   "login",
+		Prefix: "feature/",
+		Source: branchMain,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   true,
+		},
 	}, onProgress)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -208,14 +218,16 @@ func TestAddWorktreeWithDeps(t *testing.T) {
 	}
 
 	result, err := AddWorktree(r, AddParams{
-		Task:        "login",
-		Prefix:      "feature/",
-		Source:      branchMain,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    false, // exercise deps path
-		AutoDetect:  false,
-		SkipHooks:   true,
+		Task:   "login",
+		Prefix: "feature/",
+		Source: branchMain,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    false,
+			AutoDetect:  false,
+			SkipHooks:   true,
+		},
 	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -245,14 +257,16 @@ func TestAddWorktreeWithHooks(t *testing.T) {
 	}
 
 	result, err := AddWorktree(r, AddParams{
-		Task:        "login",
-		Prefix:      "feature/",
-		Source:      branchMain,
-		RepoRoot:    tmpDir,
-		WorktreeDir: wtDir,
-		SkipDeps:    true,
-		SkipHooks:   false, // exercise hooks path
-		PostCreate:  []string{"echo hello"},
+		Task:   "login",
+		Prefix: "feature/",
+		Source: branchMain,
+		PostCreateOptions: PostCreateOptions{
+			RepoRoot:    tmpDir,
+			WorktreeDir: wtDir,
+			SkipDeps:    true,
+			SkipHooks:   false,
+			PostCreate:  []string{"echo hello"},
+		},
 	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary
- Introduce `operations.PostCreateOptions` parameter object (Fowler *Introduce Parameter Object*) carrying the 9 post-create fields shared by `AddParams` and `AddPRParams`; embed anonymously in both so promoted-field access is unchanged throughout.
- Collapse the 12-line field-by-field copy in `internal/operations/add_pr_worktree.go` to a single struct-literal line: `PostCreateOptions: params.PostCreateOptions`.
- Extract `buildPostCreateOptions`, `runAddPR`, `runAddTask` from `cmd/add.go:RunE`; shrink `RunE` from ~100 lines to a 28-line dispatcher.
- Update `internal/mcp/tool_add.go` for parity. No user-visible behavior change.

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] End-to-end PR flow passes (`make test-e2e`)

Closes #141