### PR TITLE
[refactor] Introduce initMode type and split RunE into dispatchers (#142)

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,6 +21,14 @@ const (
 	flagUninstall = "uninstall"
 )
 
+type installTier string
+
+const (
+	tierUser         installTier = "user"
+	tierProject      installTier = "project"
+	tierProjectLocal installTier = "project-local"
+)
+
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize rimba in the current repository",
@@ -182,14 +190,14 @@ func runInitMigrate(cmd *cobra.Command, repoRoot, dirPath, legacyPath, gitignore
 func runInitAgents(cmd *cobra.Command, repoRoot string, local, uninstall bool) error {
 	if uninstall {
 		if local {
-			return runInstall(cmd, repoRoot, "project-local", "Removed", agentfile.UninstallLocal, nil)
+			return runInstall(cmd, repoRoot, tierProjectLocal, "Removed", agentfile.UninstallLocal, nil)
 		}
-		return runInstall(cmd, repoRoot, "project", "Removed", agentfile.UninstallProject, agentfile.UnregisterMCPProject)
+		return runInstall(cmd, repoRoot, tierProject, "Removed", agentfile.UninstallProject, agentfile.UnregisterMCPProject)
 	}
 	if local {
-		return runInstall(cmd, repoRoot, "project-local", "Installed", agentfile.InstallLocal, nil)
+		return runInstall(cmd, repoRoot, tierProjectLocal, "Installed", agentfile.InstallLocal, nil)
 	}
-	return runInstall(cmd, repoRoot, "project", "Installed", agentfile.InstallProject, agentfile.RegisterMCPProject)
+	return runInstall(cmd, repoRoot, tierProject, "Installed", agentfile.InstallProject, agentfile.RegisterMCPProject)
 }
 
 func runInitGlobal(cmd *cobra.Command, uninstall bool) error {
@@ -198,16 +206,18 @@ func runInitGlobal(cmd *cobra.Command, uninstall bool) error {
 		return fmt.Errorf("resolve home directory: %w", err)
 	}
 	if uninstall {
-		return runInstall(cmd, home, "user", "Removed", agentfile.UninstallGlobal, agentfile.UnregisterMCPGlobal)
+		return runInstall(cmd, home, tierUser, "Removed", agentfile.UninstallGlobal, agentfile.UnregisterMCPGlobal)
 	}
-	return runInstall(cmd, home, "user", "Installed", agentfile.InstallGlobal, agentfile.RegisterMCPGlobal)
+	return runInstall(cmd, home, tierUser, "Installed", agentfile.InstallGlobal, agentfile.RegisterMCPGlobal)
 }
 
 // runInstall runs installFn(dir) and optionally mcpFn(dir), then prints results.
 // mcpFn may be nil (local tier skips MCP registration).
 func runInstall(
 	cmd *cobra.Command,
-	dir, tier, verb string,
+	dir string,
+	tier installTier,
+	verb string,
 	installFn func(string) ([]agentfile.Result, error),
 	mcpFn func(string) ([]agentfile.Result, error),
 ) error {
@@ -232,11 +242,11 @@ func runInstall(
 	return nil
 }
 
-func printSection(cmd *cobra.Command, title, tier string, results []agentfile.Result) {
+func printSection(cmd *cobra.Command, title string, tier installTier, results []agentfile.Result) {
 	fmt.Fprintf(cmd.OutOrStdout(), "  %s:\n", title)
 	for _, r := range results {
 		p := r.RelPath
-		if tier == "user" {
+		if tier == tierUser {
 			p = "~/" + p
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "    %s (%s)\n", p, r.Action)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -39,35 +38,14 @@ config file. In personal mode, settings.local.toml is not created since the whol
 directory is already personal.`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		global, _ := cmd.Flags().GetBool(flagGlobal)
-		agents, _ := cmd.Flags().GetBool(flagAgents)
-		local, _ := cmd.Flags().GetBool(flagLocal)
-		uninstall, _ := cmd.Flags().GetBool(flagUninstall)
-
-		// Flag validation
-		if local && !agents {
-			return errhint.WithFix(
-				errors.New("--local requires --agents"),
-				"run: rimba init --agents --local",
-			)
-		}
-		if uninstall && !global && !agents {
-			return errhint.WithFix(
-				errors.New("--uninstall requires -g or --agents"),
-				"run: rimba init -g --uninstall  OR  rimba init --agents --uninstall",
-			)
+		m := initModeFromFlags(cmd)
+		if err := m.validate(); err != nil {
+			return err
 		}
 
 		// Global (-g) branch: no repo required.
-		if global {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("resolve home directory: %w", err)
-			}
-			if uninstall {
-				return runInstall(cmd, home, "user", "Removed", agentfile.UninstallGlobal, agentfile.UnregisterMCPGlobal)
-			}
-			return runInstall(cmd, home, "user", "Installed", agentfile.InstallGlobal, agentfile.RegisterMCPGlobal)
+		if m.global {
+			return runInitGlobal(cmd, m.uninstall)
 		}
 
 		r := newRunner()
@@ -95,111 +73,134 @@ directory is already personal.`,
 			fmt.Fprintf(cmd.OutOrStdout(), "Config %s already exists, skipping config creation\n", dirPath)
 
 		case fileExists(legacyPath):
-			// Migrate from legacy .rimba.toml → .rimba/ directory
-			if err := os.MkdirAll(dirPath, 0750); err != nil {
-				return errhint.WithFix(
-					fmt.Errorf("failed to create config directory: %w", err),
-					"check directory permissions for .rimba/ in the repo root",
-				)
+			if err := runInitMigrate(cmd, repoRoot, dirPath, legacyPath, gitignoreEntry, personal); err != nil {
+				return err
 			}
-
-			if err := os.Rename(legacyPath, filepath.Join(dirPath, config.TeamFile)); err != nil {
-				return fmt.Errorf("failed to move legacy config: %w", err)
-			}
-
-			if !personal {
-				if err := os.WriteFile(filepath.Join(dirPath, config.LocalFile), nil, 0600); err != nil {
-					return fmt.Errorf("failed to create local config: %w", err)
-				}
-			}
-
-			_, _ = fileutil.RemoveGitignoreEntry(repoRoot, config.FileName)
-
-			if _, err := fileutil.EnsureGitignore(repoRoot, gitignoreEntry); err != nil {
-				return fmt.Errorf("failed to update .gitignore: %w", err)
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "Migrated rimba config in %s\n", repoRoot)
-			fmt.Fprintf(cmd.OutOrStdout(), "  Moved:     %s → %s\n", config.FileName, filepath.Join(config.DirName, config.TeamFile))
-			if !personal {
-				fmt.Fprintf(cmd.OutOrStdout(), "  Created:   %s\n", filepath.Join(config.DirName, config.LocalFile))
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "  Gitignore: updated (%s → %s)\n", config.FileName, gitignoreEntry)
 
 		default:
-			// Fresh init
-			repoName, err := git.RepoName(r)
-			if err != nil {
+			if err := runInitFresh(cmd, r, repoRoot, dirPath, gitignoreEntry, personal); err != nil {
 				return err
-			}
-
-			defaultBranch, err := git.DefaultBranch(r)
-			if err != nil {
-				return err
-			}
-
-			// Write minimal config — only copy_files (everything else auto-derived)
-			cfg := &config.Config{
-				CopyFiles: config.DefaultCopyFiles(),
-			}
-
-			if err := os.MkdirAll(dirPath, 0750); err != nil {
-				return errhint.WithFix(
-					fmt.Errorf("failed to create config directory: %w", err),
-					"check directory permissions for .rimba/ in the repo root",
-				)
-			}
-
-			if err := config.Save(filepath.Join(dirPath, config.TeamFile), cfg); err != nil {
-				return err
-			}
-
-			if !personal {
-				if err := os.WriteFile(filepath.Join(dirPath, config.LocalFile), nil, 0600); err != nil {
-					return fmt.Errorf("failed to create local config: %w", err)
-				}
-			}
-
-			// Create the worktree directory using convention
-			wtDir := filepath.Join(repoRoot, config.DefaultWorktreeDir(repoName))
-			if err := os.MkdirAll(wtDir, 0750); err != nil {
-				return fmt.Errorf("failed to create worktree directory: %w", err)
-			}
-
-			added, err := fileutil.EnsureGitignore(repoRoot, gitignoreEntry)
-			if err != nil {
-				return fmt.Errorf("failed to update .gitignore: %w", err)
-			}
-
-			fmt.Fprintf(cmd.OutOrStdout(), "Initialized rimba in %s\n", repoRoot)
-			fmt.Fprintf(cmd.OutOrStdout(), "  Config:       %s\n", filepath.Join(dirPath, config.TeamFile))
-			fmt.Fprintf(cmd.OutOrStdout(), "  Worktree dir: %s\n", wtDir)
-			fmt.Fprintf(cmd.OutOrStdout(), "  Source:       %s\n", defaultBranch)
-			if added {
-				fmt.Fprintf(cmd.OutOrStdout(), "  Gitignore:    %s added to .gitignore\n", gitignoreEntry)
-			} else {
-				fmt.Fprintf(cmd.OutOrStdout(), "  Gitignore:    %s (already in .gitignore)\n", gitignoreEntry)
 			}
 		}
 
 		// Project-level agent files
-		if agents {
-			if uninstall {
-				if local {
-					// local tier installs gitignored personal files; MCP registration skipped
-					return runInstall(cmd, repoRoot, "project-local", "Removed", agentfile.UninstallLocal, nil)
-				}
-				return runInstall(cmd, repoRoot, "project", "Removed", agentfile.UninstallProject, agentfile.UnregisterMCPProject)
-			}
-			if local {
-				// local tier installs gitignored personal files; MCP registration skipped
-				return runInstall(cmd, repoRoot, "project-local", "Installed", agentfile.InstallLocal, nil)
-			}
-			return runInstall(cmd, repoRoot, "project", "Installed", agentfile.InstallProject, agentfile.RegisterMCPProject)
+		if m.agents {
+			return runInitAgents(cmd, repoRoot, m.local, m.uninstall)
 		}
 
 		return nil
 	},
+}
+
+func runInitFresh(cmd *cobra.Command, r git.Runner, repoRoot, dirPath, gitignoreEntry string, personal bool) error {
+	repoName, err := git.RepoName(r)
+	if err != nil {
+		return err
+	}
+
+	defaultBranch, err := git.DefaultBranch(r)
+	if err != nil {
+		return err
+	}
+
+	cfg := &config.Config{
+		CopyFiles: config.DefaultCopyFiles(),
+	}
+
+	if err := os.MkdirAll(dirPath, 0750); err != nil {
+		return errhint.WithFix(
+			fmt.Errorf("failed to create config directory: %w", err),
+			"check directory permissions for .rimba/ in the repo root",
+		)
+	}
+
+	if err := config.Save(filepath.Join(dirPath, config.TeamFile), cfg); err != nil {
+		return err
+	}
+
+	if !personal {
+		if err := os.WriteFile(filepath.Join(dirPath, config.LocalFile), nil, 0600); err != nil {
+			return fmt.Errorf("failed to create local config: %w", err)
+		}
+	}
+
+	wtDir := filepath.Join(repoRoot, config.DefaultWorktreeDir(repoName))
+	if err := os.MkdirAll(wtDir, 0750); err != nil {
+		return fmt.Errorf("failed to create worktree directory: %w", err)
+	}
+
+	added, err := fileutil.EnsureGitignore(repoRoot, gitignoreEntry)
+	if err != nil {
+		return fmt.Errorf("failed to update .gitignore: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Initialized rimba in %s\n", repoRoot)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Config:       %s\n", filepath.Join(dirPath, config.TeamFile))
+	fmt.Fprintf(cmd.OutOrStdout(), "  Worktree dir: %s\n", wtDir)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Source:       %s\n", defaultBranch)
+	if added {
+		fmt.Fprintf(cmd.OutOrStdout(), "  Gitignore:    %s added to .gitignore\n", gitignoreEntry)
+	} else {
+		fmt.Fprintf(cmd.OutOrStdout(), "  Gitignore:    %s (already in .gitignore)\n", gitignoreEntry)
+	}
+	return nil
+}
+
+func runInitMigrate(cmd *cobra.Command, repoRoot, dirPath, legacyPath, gitignoreEntry string, personal bool) error {
+	if err := os.MkdirAll(dirPath, 0750); err != nil {
+		return errhint.WithFix(
+			fmt.Errorf("failed to create config directory: %w", err),
+			"check directory permissions for .rimba/ in the repo root",
+		)
+	}
+
+	if err := os.Rename(legacyPath, filepath.Join(dirPath, config.TeamFile)); err != nil {
+		return fmt.Errorf("failed to move legacy config: %w", err)
+	}
+
+	if !personal {
+		if err := os.WriteFile(filepath.Join(dirPath, config.LocalFile), nil, 0600); err != nil {
+			return fmt.Errorf("failed to create local config: %w", err)
+		}
+	}
+
+	_, _ = fileutil.RemoveGitignoreEntry(repoRoot, config.FileName)
+
+	if _, err := fileutil.EnsureGitignore(repoRoot, gitignoreEntry); err != nil {
+		return fmt.Errorf("failed to update .gitignore: %w", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Migrated rimba config in %s\n", repoRoot)
+	fmt.Fprintf(cmd.OutOrStdout(), "  Moved:     %s → %s\n", config.FileName, filepath.Join(config.DirName, config.TeamFile))
+	if !personal {
+		fmt.Fprintf(cmd.OutOrStdout(), "  Created:   %s\n", filepath.Join(config.DirName, config.LocalFile))
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "  Gitignore: updated (%s → %s)\n", config.FileName, gitignoreEntry)
+	return nil
+}
+
+func runInitAgents(cmd *cobra.Command, repoRoot string, local, uninstall bool) error {
+	if uninstall {
+		if local {
+			return runInstall(cmd, repoRoot, "project-local", "Removed", agentfile.UninstallLocal, nil)
+		}
+		return runInstall(cmd, repoRoot, "project", "Removed", agentfile.UninstallProject, agentfile.UnregisterMCPProject)
+	}
+	if local {
+		return runInstall(cmd, repoRoot, "project-local", "Installed", agentfile.InstallLocal, nil)
+	}
+	return runInstall(cmd, repoRoot, "project", "Installed", agentfile.InstallProject, agentfile.RegisterMCPProject)
+}
+
+func runInitGlobal(cmd *cobra.Command, uninstall bool) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home directory: %w", err)
+	}
+	if uninstall {
+		return runInstall(cmd, home, "user", "Removed", agentfile.UninstallGlobal, agentfile.UnregisterMCPGlobal)
+	}
+	return runInstall(cmd, home, "user", "Installed", agentfile.InstallGlobal, agentfile.RegisterMCPGlobal)
 }
 
 // runInstall runs installFn(dir) and optionally mcpFn(dir), then prints results.

--- a/cmd/init_mode.go
+++ b/cmd/init_mode.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/lugassawan/rimba/internal/errhint"
+	"github.com/spf13/cobra"
+)
+
+type initMode struct {
+	global    bool
+	agents    bool
+	local     bool
+	uninstall bool
+}
+
+func initModeFromFlags(cmd *cobra.Command) initMode {
+	g, _ := cmd.Flags().GetBool(flagGlobal)
+	a, _ := cmd.Flags().GetBool(flagAgents)
+	l, _ := cmd.Flags().GetBool(flagLocal)
+	u, _ := cmd.Flags().GetBool(flagUninstall)
+	return initMode{global: g, agents: a, local: l, uninstall: u}
+}
+
+func (m initMode) validate() error {
+	if m.local && !m.agents {
+		return errhint.WithFix(
+			errors.New("--local requires --agents"),
+			"run: rimba init --agents --local",
+		)
+	}
+	if m.uninstall && !m.global && !m.agents {
+		return errhint.WithFix(
+			errors.New("--uninstall requires -g or --agents"),
+			"run: rimba init -g --uninstall  OR  rimba init --agents --uninstall",
+		)
+	}
+	return nil
+}

--- a/cmd/init_mode_test.go
+++ b/cmd/init_mode_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInitModeValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    initMode
+		wantErr string // empty = expect nil
+	}{
+		{name: "empty mode", mode: initMode{}},
+		{name: "global only", mode: initMode{global: true}},
+		{name: "global + uninstall", mode: initMode{global: true, uninstall: true}},
+		{name: "agents only", mode: initMode{agents: true}},
+		{name: "agents + local", mode: initMode{agents: true, local: true}},
+		{name: "agents + uninstall", mode: initMode{agents: true, uninstall: true}},
+		{name: "agents + local + uninstall", mode: initMode{agents: true, local: true, uninstall: true}},
+		{
+			name:    "global + local without agents (validate fires before global branch)",
+			mode:    initMode{global: true, local: true},
+			wantErr: "--local requires --agents",
+		},
+		{
+			name:    "local without agents",
+			mode:    initMode{local: true},
+			wantErr: "--local requires --agents",
+		},
+		{
+			name:    "uninstall without target",
+			mode:    initMode{uninstall: true},
+			wantErr: "--uninstall requires",
+		},
+		{
+			name:    "local + uninstall without agents (local check fires first)",
+			mode:    initMode{local: true, uninstall: true},
+			wantErr: "--local requires --agents",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.mode.validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validate() = nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("validate() = %q, want to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -338,6 +338,331 @@ func TestInitWithoutFlagSkipsAgentFiles(t *testing.T) {
 	}
 }
 
+func TestInitAgentsErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		blockPath   string // relative path to pre-create as a directory to trigger the error
+		wantErrFrag string // substring expected in the error
+	}{
+		{
+			name:        "install error (AGENTS.md is a directory)",
+			blockPath:   "AGENTS.md",
+			wantErrFrag: "agent files",
+		},
+		{
+			// Pre-create .mcp.json as a directory so os.ReadFile returns EISDIR (not ErrNotExist),
+			// causing RegisterMCPProject to fail after InstallProject succeeds.
+			name:        "MCP register error (.mcp.json is a directory)",
+			blockPath:   ".mcp.json",
+			wantErrFrag: "mcp servers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repoDir := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(repoDir, tt.blockPath), 0750); err != nil {
+				t.Fatal(err)
+			}
+
+			repoName := filepath.Base(repoDir)
+			wtPath := filepath.Join(filepath.Dir(repoDir), repoName+"-worktrees")
+			t.Cleanup(func() { os.RemoveAll(wtPath) })
+
+			r := &mockRunner{
+				run: func(args ...string) (string, error) {
+					if len(args) >= 2 && args[1] == cmdShowToplevel {
+						return repoDir, nil
+					}
+					if len(args) >= 1 && args[0] == cmdSymbolicRef {
+						return refsRemotesOriginMain, nil
+					}
+					return "", nil
+				},
+				runInDir: noopRunInDir,
+			}
+			restore := overrideNewRunner(r)
+			defer restore()
+
+			cmd, _ := newTestCmd()
+			cmd.Flags().Bool(flagAgents, true, "")
+			err := initCmd.RunE(cmd, nil)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErrFrag)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrFrag) {
+				t.Errorf("error = %q, want %q", err.Error(), tt.wantErrFrag)
+			}
+		})
+	}
+}
+
+func TestInitMigrateGitignoreWriteError(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// Pre-create legacy .rimba.toml so migration case triggers.
+	if err := os.WriteFile(filepath.Join(repoDir, config.FileName), []byte("[rimba]\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Read-only .gitignore: RemoveGitignoreEntry fails silently; EnsureGitignore fails loudly.
+	gitignorePath := filepath.Join(repoDir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte("# existing\n"), 0444); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	err := initCmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when .gitignore is read-only during migration, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to update .gitignore") {
+		t.Errorf("error = %q, want 'failed to update .gitignore'", err.Error())
+	}
+}
+
+func TestInitFreshWorktreeDirConflict(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// Pre-create a FILE at the worktree path so os.MkdirAll(wtDir) fails.
+	// wtDir = filepath.Join(repoDir, "../repoName-worktrees")
+	repoName := filepath.Base(repoDir)
+	wtPath := filepath.Join(filepath.Dir(repoDir), repoName+"-worktrees")
+	if err := os.WriteFile(wtPath, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Remove(wtPath) })
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	err := initCmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when worktree dir is a file, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to create worktree directory") {
+		t.Errorf("error = %q, want 'failed to create worktree directory'", err.Error())
+	}
+}
+
+func TestInitFreshGitignoreWriteError(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// Remove the worktree dir created outside repoDir (../repoName-worktrees).
+	repoName := filepath.Base(repoDir)
+	wtDir := filepath.Join(repoDir, "..", repoName+"-worktrees")
+	t.Cleanup(func() { os.RemoveAll(wtDir) })
+
+	// Pre-create .gitignore as read-only without the rimba entry.
+	gitignorePath := filepath.Join(repoDir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte("# existing\n"), 0444); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	err := initCmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when .gitignore is read-only, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to update .gitignore") {
+		t.Errorf("error = %q, want 'failed to update .gitignore'", err.Error())
+	}
+}
+
+func TestInitFreshConflictingFile(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// Pre-create a file at dirPath so os.MkdirAll fails in runInitFresh.
+	dirPath := filepath.Join(repoDir, config.DirName)
+	if err := os.WriteFile(dirPath, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	err := initCmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when dirPath is a file, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to create config directory") {
+		t.Errorf("error = %q, want 'failed to create config directory'", err.Error())
+	}
+}
+
+func TestInitFreshRepoNameError(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// First --show-toplevel call succeeds (RepoRoot in RunE); second fails (RepoName in runInitFresh).
+	callCount := 0
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				callCount++
+				if callCount == 1 {
+					return repoDir, nil
+				}
+				return "", errors.New("repo name lookup failed")
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	if err := initCmd.RunE(cmd, nil); err == nil {
+		t.Fatal("expected error when RepoName fails, got nil")
+	}
+}
+
+func TestInitFreshDefaultBranchError(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// Return repo root for --show-toplevel; fail everything else so DefaultBranch errors.
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			return "", errors.New("command not found")
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	err := initCmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when DefaultBranch fails, got nil")
+	}
+}
+
+func TestInitMigrateConflictingDir(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// Pre-create legacy .rimba.toml so migration case triggers.
+	legacyPath := filepath.Join(repoDir, config.FileName)
+	if err := os.WriteFile(legacyPath, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-create a FILE at dirPath so os.MkdirAll fails.
+	dirPath := filepath.Join(repoDir, config.DirName)
+	if err := os.WriteFile(dirPath, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	err := initCmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error when dirPath is a file, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to create config directory") {
+		t.Errorf("error = %q, want to contain 'failed to create config directory'", err.Error())
+	}
+}
+
+func TestInitFreshGitignoreAlreadyPresent(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// Pre-seed .gitignore with the entry that rimba would add
+	gitignoreEntry := filepath.Join(config.DirName, config.LocalFile)
+	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte(gitignoreEntry+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	if err := initCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("initCmd.RunE: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "already in .gitignore") {
+		t.Errorf("output should say 'already in .gitignore', got:\n%s", out)
+	}
+}
+
 // --- Tests for new 3-tier flag surface ---
 
 func TestInitGlobalInstall(t *testing.T) {
@@ -467,6 +792,96 @@ func TestInitAgentsLocalAddsGitignore(t *testing.T) {
 	// AGENTS.md should be in .gitignore (local tier)
 	if !strings.Contains(gitignore, "AGENTS.md") {
 		t.Errorf(".gitignore should contain AGENTS.md, got:\n%s", gitignore)
+	}
+}
+
+func TestInitAgentsUninstall(t *testing.T) {
+	repoDir := t.TempDir()
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	// Install
+	cmd1, _ := newTestCmd()
+	cmd1.Flags().Bool(flagAgents, true, "")
+	if err := initCmd.RunE(cmd1, nil); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	agentsPath := filepath.Join(repoDir, "AGENTS.md")
+	if _, err := os.Stat(agentsPath); os.IsNotExist(err) {
+		t.Fatal("AGENTS.md should exist after install")
+	}
+
+	// Uninstall
+	cmd2, buf := newTestCmd()
+	cmd2.Flags().Bool(flagAgents, true, "")
+	cmd2.Flags().Bool(flagUninstall, true, "")
+	if err := initCmd.RunE(cmd2, nil); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Removed") {
+		t.Errorf("output should say 'Removed', got:\n%s", buf.String())
+	}
+	if _, err := os.Stat(agentsPath); err == nil {
+		t.Error("AGENTS.md should be removed after uninstall")
+	}
+}
+
+func TestInitAgentsLocalUninstall(t *testing.T) {
+	repoDir := t.TempDir()
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	// Install local
+	cmd1, _ := newTestCmd()
+	cmd1.Flags().Bool(flagAgents, true, "")
+	cmd1.Flags().Bool(flagLocal, true, "")
+	if err := initCmd.RunE(cmd1, nil); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	agentsPath := filepath.Join(repoDir, "AGENTS.md")
+	if _, err := os.Stat(agentsPath); os.IsNotExist(err) {
+		t.Fatal("AGENTS.md should exist after local install")
+	}
+
+	// Uninstall local
+	cmd2, buf := newTestCmd()
+	cmd2.Flags().Bool(flagAgents, true, "")
+	cmd2.Flags().Bool(flagLocal, true, "")
+	cmd2.Flags().Bool(flagUninstall, true, "")
+	if err := initCmd.RunE(cmd2, nil); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Removed") {
+		t.Errorf("output should say 'Removed', got:\n%s", buf.String())
+	}
+	if _, err := os.Stat(agentsPath); err == nil {
+		t.Error("AGENTS.md should be removed after local uninstall")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extract four-bool flag matrix (`global`, `agents`, `local`, `uninstall`) into `initMode` struct with a single `validate()` method in new `cmd/init_mode.go`
- Split the 160-line `RunE` into four focused package-level dispatcher functions: `runInitGlobal`, `runInitAgents`, `runInitMigrate`, `runInitFresh`
- Add `cmd/init_mode_test.go` with 12 table-driven pure-unit tests for `validate()` — no Cobra, no git, no filesystem

## Test Plan
- [x] Unit tests pass (`go test ./cmd/... -run TestInit -count=1` — 35 pass)
- [x] E2e subprocess tests pass (`go test ./tests/e2e/... -run TestInit -count=1` — 18 pass)
- [x] Full suite passes (`go test ./... -count=1` — 1599 pass)
- [x] Linter passes (`go vet ./...` — clean)
- [x] Build passes (`go build ./...` — clean)
- [x] Format clean (`gofmt -l` — no output)

Closes #142