### PR TITLE
[refactor] Move status dashboard orchestration into operations.StatusDashboard (#143)

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,34 +1,19 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
-	"sort"
 	"strconv"
-	"sync"
 	"time"
 
-	"github.com/lugassawan/rimba/internal/fsutil"
-	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
-	"github.com/lugassawan/rimba/internal/parallel"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/lugassawan/rimba/internal/termcolor"
 	"github.com/spf13/cobra"
 )
-
-const recentWindow = 7 * 24 * time.Hour
-
-type statusEntry struct {
-	entry      git.WorktreeEntry
-	status     resolver.WorktreeStatus
-	commitTime time.Time
-	hasTime    bool
-	sizeBytes  *int64
-	recent7D   *int
-}
 
 var statusCmd = &cobra.Command{
 	Use:         "status",
@@ -37,24 +22,18 @@ var statusCmd = &cobra.Command{
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
-
-		mainBranch, err := resolveMainBranch(r)
-		if err != nil {
-			return err
-		}
-
-		entries, err := git.ListWorktrees(r)
-		if err != nil {
-			return err
-		}
-
-		mainEntry := git.FindEntry(entries, mainBranch)
-		candidates := git.FilterEntries(entries, mainBranch)
-
 		staleDays, _ := cmd.Flags().GetInt(flagStaleDays)
 		detail, _ := cmd.Flags().GetBool(flagDetail)
 
-		if len(candidates) == 0 {
+		s := spinner.New(spinnerOpts(cmd))
+		s.Start("Collecting worktree status...")
+		res, err := operations.StatusDashboard(context.Background(), r, operations.StatusDashboardRequest{Detail: detail})
+		s.Stop()
+		if err != nil {
+			return err
+		}
+
+		if len(res.Entries) == 0 {
 			if isJSON(cmd) {
 				return output.WriteJSON(cmd.OutOrStdout(), version, "status", output.StatusData{
 					Summary:   output.StatusSummary{},
@@ -66,44 +45,18 @@ var statusCmd = &cobra.Command{
 			return nil
 		}
 
-		s := spinner.New(spinnerOpts(cmd))
-		defer s.Stop()
-		s.Start("Collecting worktree status...")
-
-		var mainSize int64
-		var mainErr error
-		var mainWG sync.WaitGroup
-		if detail && mainEntry != nil {
-			mainWG.Add(1)
-			go func(path string) {
-				defer mainWG.Done()
-				mainSize, mainErr = fsutil.DirSize(path)
-			}(mainEntry.Path)
-		}
-
-		results := collectStatuses(r, candidates, s, detail)
-		mainWG.Wait()
-		s.Stop()
-
-		var footprint *operations.DiskFootprint
-		if detail {
-			sizes := make([]*int64, len(results))
-			for i, r := range results {
-				sizes[i] = r.sizeBytes
-			}
-			fp := operations.BuildDiskFootprint(sizes, mainSize, mainErr)
-			footprint = &fp
-			sortBySizeDesc(results)
-		}
-
 		if isJSON(cmd) {
-			return writeStatusJSON(cmd, results, staleDays, footprint)
+			return writeStatusJSON(cmd, res.Entries, staleDays, res.Footprint)
 		}
 
 		noColor, _ := cmd.Flags().GetBool(flagNoColor)
 		p := termcolor.NewPainter(noColor)
-
-		renderStatusDashboard(cmd.OutOrStdout(), p, results, staleDays, detail, footprint)
+		renderStatusDashboard(cmd.OutOrStdout(), p, statusRender{
+			results:   res.Entries,
+			staleDays: staleDays,
+			detail:    detail,
+			footprint: res.Footprint,
+		})
 		return nil
 	},
 }
@@ -114,64 +67,27 @@ func init() {
 	rootCmd.AddCommand(statusCmd)
 }
 
-// collectStatuses gathers dirty/ahead/behind state and last commit time
-// per candidate. Under detail it also computes size and 7-day velocity;
-// per-item errors leave the pointer nil (non-fatal).
-func collectStatuses(r git.Runner, candidates []git.WorktreeEntry, s *spinner.Spinner, detail bool) []statusEntry {
-	s.Update("Collecting status...")
-	return parallel.Collect(len(candidates), 8, func(i int) statusEntry {
-		e := candidates[i]
-		st := operations.CollectWorktreeStatus(r, e.Path)
-		var ct time.Time
-		var hasTime bool
-		if t, err := git.LastCommitTime(r, e.Branch); err == nil {
-			ct = t
-			hasTime = true
-		}
-		se := statusEntry{entry: e, status: st, commitTime: ct, hasTime: hasTime}
-		if detail {
-			if n, err := fsutil.DirSize(e.Path); err == nil {
-				se.sizeBytes = &n
-			}
-			if c, err := git.CommitCountSince(r, e.Branch, recentWindow); err == nil {
-				se.recent7D = &c
-			}
-		}
-		return se
-	})
-}
-
-// sortBySizeDesc sorts largest first, stable, nils last.
-func sortBySizeDesc(results []statusEntry) {
-	sort.SliceStable(results, func(i, j int) bool {
-		a, b := results[i].sizeBytes, results[j].sizeBytes
-		switch {
-		case a == nil && b == nil:
-			return false
-		case a == nil:
-			return false
-		case b == nil:
-			return true
-		default:
-			return *a > *b
-		}
-	})
+type statusRender struct {
+	results   []operations.StatusEntry
+	staleDays int
+	detail    bool
+	footprint *operations.DiskFootprint
 }
 
 // renderStatusDashboard prints the summary header and per-worktree table.
-func renderStatusDashboard(out io.Writer, p *termcolor.Painter, results []statusEntry, staleDays int, detail bool, footprint *operations.DiskFootprint) {
-	staleThreshold := time.Now().Add(-time.Duration(staleDays) * 24 * time.Hour)
-	summary := buildCLIStatusSummary(results, staleThreshold)
+func renderStatusDashboard(out io.Writer, p *termcolor.Painter, r statusRender) {
+	staleThreshold := time.Now().Add(-time.Duration(r.staleDays) * 24 * time.Hour)
+	summary := operations.SummarizeStatus(r.results, staleThreshold)
 	prefixes := resolver.AllPrefixes()
 
 	fmt.Fprintf(out, "Worktrees: %s  Dirty: %s  Stale: %s  Behind: %s\n",
-		p.Paint(strconv.Itoa(summary.total), termcolor.Bold),
-		colorCount(p, summary.dirty, termcolor.Yellow),
-		colorCount(p, summary.stale, termcolor.Red),
-		colorCount(p, summary.behind, termcolor.Red),
+		p.Paint(strconv.Itoa(summary.Total), termcolor.Bold),
+		colorCount(p, summary.Dirty, termcolor.Yellow),
+		colorCount(p, summary.Stale, termcolor.Red),
+		colorCount(p, summary.Behind, termcolor.Red),
 	)
-	if detail && footprint != nil {
-		fmt.Fprintln(out, formatDiskLine(p, footprint))
+	if r.detail && r.footprint != nil {
+		fmt.Fprintln(out, formatDiskLine(p, r.footprint))
 	}
 	fmt.Fprintln(out)
 
@@ -183,7 +99,7 @@ func renderStatusDashboard(out io.Writer, p *termcolor.Painter, results []status
 		p.Paint("STATUS", termcolor.Bold),
 		p.Paint("AGE", termcolor.Bold),
 	}
-	if detail {
+	if r.detail {
 		header = append(header,
 			p.Paint("SIZE", termcolor.Bold),
 			p.Paint("7D", termcolor.Bold),
@@ -191,8 +107,8 @@ func renderStatusDashboard(out io.Writer, p *termcolor.Painter, results []status
 	}
 	tbl.AddRow(header...)
 
-	for _, r := range results {
-		tbl.AddRow(buildStatusRow(r, prefixes, staleThreshold, p, detail)...)
+	for _, e := range r.results {
+		tbl.AddRow(buildStatusRow(e, prefixes, staleThreshold, p, r.detail)...)
 	}
 
 	tbl.Render(out)
@@ -214,59 +130,38 @@ func formatDiskLine(p *termcolor.Painter, fp *operations.DiskFootprint) string {
 // renderActionHints prints one-line next-step suggestions derived from the
 // summary counts. Emits nothing when all counts are zero. The hints are
 // CLI-only and never appear in the JSON output.
-func renderActionHints(out io.Writer, p *termcolor.Painter, summary cliStatusSummary) {
-	if summary.behind == 0 && summary.stale == 0 && summary.dirty == 0 {
+func renderActionHints(out io.Writer, p *termcolor.Painter, summary operations.StatusSummary) {
+	if summary.Behind == 0 && summary.Stale == 0 && summary.Dirty == 0 {
 		return
 	}
 
 	fmt.Fprintln(out)
 
-	if summary.behind > 0 {
+	if summary.Behind > 0 {
 		fmt.Fprintf(out, "%s %d behind main. Run: %s\n",
 			p.Paint("→", termcolor.Yellow),
-			summary.behind,
+			summary.Behind,
 			p.Paint("rimba sync --all", termcolor.Bold),
 		)
 	}
-	if summary.stale > 0 {
+	if summary.Stale > 0 {
 		fmt.Fprintf(out, "%s %d stale. Run: %s\n",
 			p.Paint("→", termcolor.Yellow),
-			summary.stale,
+			summary.Stale,
 			p.Paint("rimba clean --stale", termcolor.Bold),
 		)
 	}
-	if summary.dirty > 0 {
+	if summary.Dirty > 0 {
 		fmt.Fprintf(out, "%s %d dirty. Review uncommitted changes before merging.\n",
 			p.Paint("→", termcolor.Yellow),
-			summary.dirty,
+			summary.Dirty,
 		)
 	}
 }
 
-type cliStatusSummary struct {
-	total, dirty, stale, behind int
-}
-
-// buildCLIStatusSummary counts summary stats from results.
-func buildCLIStatusSummary(results []statusEntry, staleThreshold time.Time) cliStatusSummary {
-	s := cliStatusSummary{total: len(results)}
-	for _, r := range results {
-		if r.status.Dirty {
-			s.dirty++
-		}
-		if r.status.Behind > 0 {
-			s.behind++
-		}
-		if r.hasTime && r.commitTime.Before(staleThreshold) {
-			s.stale++
-		}
-	}
-	return s
-}
-
 // buildStatusRow formats a single worktree row for the status table.
-func buildStatusRow(r statusEntry, prefixes []string, staleThreshold time.Time, p *termcolor.Painter, detail bool) []string {
-	task, typeName := resolver.TaskAndType(r.entry.Branch, prefixes)
+func buildStatusRow(r operations.StatusEntry, prefixes []string, staleThreshold time.Time, p *termcolor.Painter, detail bool) []string {
+	task, typeName := resolver.TaskAndType(r.Entry.Branch, prefixes)
 
 	taskCell := "  " + task
 	typeCell := typeName
@@ -274,7 +169,7 @@ func buildStatusRow(r statusEntry, prefixes []string, staleThreshold time.Time, 
 		typeCell = p.Paint(typeCell, c)
 	}
 
-	row := []string{taskCell, typeCell, r.entry.Branch, colorStatus(p, r.status), formatAgeCell(r, staleThreshold, p)}
+	row := []string{taskCell, typeCell, r.Entry.Branch, colorStatus(p, r.Status), formatAgeCell(r, staleThreshold, p)}
 	if detail {
 		row = append(row, formatSizeCell(r, p), formatRecentCell(r, p))
 	}
@@ -282,68 +177,63 @@ func buildStatusRow(r statusEntry, prefixes []string, staleThreshold time.Time, 
 }
 
 // formatSizeCell renders the SIZE column. Nil (errored) renders as "?".
-func formatSizeCell(r statusEntry, p *termcolor.Painter) string {
-	if r.sizeBytes == nil {
+func formatSizeCell(r operations.StatusEntry, p *termcolor.Painter) string {
+	if r.SizeBytes == nil {
 		return p.Paint("?", termcolor.Gray)
 	}
-	return resolver.FormatBytes(*r.sizeBytes)
+	return resolver.FormatBytes(*r.SizeBytes)
 }
 
 // formatRecentCell renders the 7D column. Nil (errored) renders as "?".
-func formatRecentCell(r statusEntry, p *termcolor.Painter) string {
-	if r.recent7D == nil {
+func formatRecentCell(r operations.StatusEntry, p *termcolor.Painter) string {
+	if r.Recent7D == nil {
 		return p.Paint("?", termcolor.Gray)
 	}
-	return strconv.Itoa(*r.recent7D)
+	return strconv.Itoa(*r.Recent7D)
 }
 
 // formatAgeCell formats the age cell with color and stale indicator.
-func formatAgeCell(r statusEntry, staleThreshold time.Time, p *termcolor.Painter) string {
-	if !r.hasTime {
+func formatAgeCell(r operations.StatusEntry, staleThreshold time.Time, p *termcolor.Painter) string {
+	if !r.HasTime {
 		return p.Paint("unknown", termcolor.Gray)
 	}
-	ageStr := resolver.FormatAge(r.commitTime)
-	if r.commitTime.Before(staleThreshold) {
+	ageStr := resolver.FormatAge(r.CommitTime)
+	if r.CommitTime.Before(staleThreshold) {
 		return p.Paint(ageStr, termcolor.Red) + " " + p.Paint("⚠ stale", termcolor.Red)
 	}
-	return p.Paint(ageStr, resolver.AgeColor(r.commitTime))
+	return p.Paint(ageStr, resolver.AgeColor(r.CommitTime))
 }
 
 // writeStatusJSON builds the JSON output for the status command.
-func writeStatusJSON(cmd *cobra.Command, results []statusEntry, staleDays int, footprint *operations.DiskFootprint) error {
+func writeStatusJSON(cmd *cobra.Command, results []operations.StatusEntry, staleDays int, footprint *operations.DiskFootprint) error {
 	staleThreshold := time.Now().Add(-time.Duration(staleDays) * 24 * time.Hour)
 	prefixes := resolver.AllPrefixes()
 
-	var summary output.StatusSummary
-	summary.Total = len(results)
+	opsSummary := operations.SummarizeStatus(results, staleThreshold)
+	summary := output.StatusSummary{
+		Total:  opsSummary.Total,
+		Dirty:  opsSummary.Dirty,
+		Stale:  opsSummary.Stale,
+		Behind: opsSummary.Behind,
+	}
 
 	items := make([]output.StatusItem, 0, len(results))
 	for _, r := range results {
-		if r.status.Dirty {
-			summary.Dirty++
-		}
-		if r.status.Behind > 0 {
-			summary.Behind++
-		}
-
-		task, typeName := resolver.TaskAndType(r.entry.Branch, prefixes)
+		task, typeName := resolver.TaskAndType(r.Entry.Branch, prefixes)
 
 		item := output.StatusItem{
 			Task:      task,
 			Type:      typeName,
-			Branch:    r.entry.Branch,
-			Status:    r.status,
-			SizeBytes: r.sizeBytes,
-			Recent7D:  r.recent7D,
+			Branch:    r.Entry.Branch,
+			Status:    r.Status,
+			SizeBytes: r.SizeBytes,
+			Recent7D:  r.Recent7D,
 		}
 
-		if r.hasTime {
-			stale := r.commitTime.Before(staleThreshold)
-			if stale {
-				summary.Stale++
-			}
+		if r.HasTime {
+			stale := r.CommitTime.Before(staleThreshold)
 			item.Age = &output.StatusAge{
-				LastCommit: r.commitTime.UTC().Format(time.RFC3339),
+				LastCommit: r.CommitTime.UTC().Format(time.RFC3339),
 				Stale:      stale,
 			}
 		}

--- a/cmd/status_detail_test.go
+++ b/cmd/status_detail_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
 	"github.com/lugassawan/rimba/internal/termcolor"
@@ -18,36 +17,6 @@ import (
 )
 
 func ptr[T any](v T) *T { return &v }
-
-func TestSortBySizeDesc(t *testing.T) {
-	results := []statusEntry{
-		{entry: git.WorktreeEntry{Branch: "small"}, sizeBytes: ptr(int64(100))},
-		{entry: git.WorktreeEntry{Branch: "errored"}, sizeBytes: nil},
-		{entry: git.WorktreeEntry{Branch: "big"}, sizeBytes: ptr(int64(5000))},
-		{entry: git.WorktreeEntry{Branch: "medium"}, sizeBytes: ptr(int64(1000))},
-		{entry: git.WorktreeEntry{Branch: "errored2"}, sizeBytes: nil},
-	}
-	sortBySizeDesc(results)
-	wantOrder := []string{"big", "medium", "small", "errored", "errored2"}
-	for i, w := range wantOrder {
-		if results[i].entry.Branch != w {
-			t.Errorf("index %d: got %q, want %q (full: %+v)", i, results[i].entry.Branch, w, results)
-		}
-	}
-}
-
-func TestSortBySizeDescAllNil(t *testing.T) {
-	// Two nil-sized entries: order is preserved (stable).
-	results := []statusEntry{
-		{entry: git.WorktreeEntry{Branch: "a"}},
-		{entry: git.WorktreeEntry{Branch: "b"}},
-	}
-	sortBySizeDesc(results)
-	if results[0].entry.Branch != "a" || results[1].entry.Branch != "b" {
-		t.Errorf("expected stable order [a, b], got [%s, %s]",
-			results[0].entry.Branch, results[1].entry.Branch)
-	}
-}
 
 func TestFormatDiskLine(t *testing.T) {
 	p := termcolor.NewPainter(true) // no color
@@ -72,10 +41,10 @@ func TestFormatDiskLine(t *testing.T) {
 func TestFormatSizeCell(t *testing.T) {
 	p := termcolor.NewPainter(true)
 
-	if got := formatSizeCell(statusEntry{sizeBytes: nil}, p); got != "?" {
+	if got := formatSizeCell(operations.StatusEntry{SizeBytes: nil}, p); got != "?" {
 		t.Errorf("nil sizeBytes cell = %q, want '?'", got)
 	}
-	if got := formatSizeCell(statusEntry{sizeBytes: ptr(int64(2048))}, p); got != "2.0KB" {
+	if got := formatSizeCell(operations.StatusEntry{SizeBytes: ptr(int64(2048))}, p); got != "2.0KB" {
 		t.Errorf("2048-byte cell = %q, want '2.0KB'", got)
 	}
 }
@@ -83,10 +52,10 @@ func TestFormatSizeCell(t *testing.T) {
 func TestFormatRecentCell(t *testing.T) {
 	p := termcolor.NewPainter(true)
 
-	if got := formatRecentCell(statusEntry{recent7D: nil}, p); got != "?" {
+	if got := formatRecentCell(operations.StatusEntry{Recent7D: nil}, p); got != "?" {
 		t.Errorf("nil recent7D cell = %q, want '?'", got)
 	}
-	if got := formatRecentCell(statusEntry{recent7D: ptr(42)}, p); got != "42" {
+	if got := formatRecentCell(operations.StatusEntry{Recent7D: ptr(42)}, p); got != "42" {
 		t.Errorf("recent7D=42 cell = %q, want '42'", got)
 	}
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -254,37 +255,37 @@ func TestRenderActionHints(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		summary    cliStatusSummary
+		summary    operations.StatusSummary
 		wantEmpty  bool
 		wantSubstr []string
 		notSubstr  []string
 	}{
 		{
 			name:      "all zero emits nothing",
-			summary:   cliStatusSummary{total: 3},
+			summary:   operations.StatusSummary{Total: 3},
 			wantEmpty: true,
 		},
 		{
 			name:       "behind only emits sync hint",
-			summary:    cliStatusSummary{total: 3, behind: 2},
+			summary:    operations.StatusSummary{Total: 3, Behind: 2},
 			wantSubstr: []string{"2 behind main", "rimba sync --all"},
 			notSubstr:  []string{"stale", "dirty", "Review"},
 		},
 		{
 			name:       "stale only emits clean hint",
-			summary:    cliStatusSummary{total: 3, stale: 1},
+			summary:    operations.StatusSummary{Total: 3, Stale: 1},
 			wantSubstr: []string{"1 stale", "rimba clean --stale"},
 			notSubstr:  []string{"behind main", "dirty", "Review"},
 		},
 		{
 			name:       "dirty only emits review hint",
-			summary:    cliStatusSummary{total: 3, dirty: 4},
+			summary:    operations.StatusSummary{Total: 3, Dirty: 4},
 			wantSubstr: []string{"4 dirty", "Review uncommitted changes"},
 			notSubstr:  []string{"behind main", "stale", "rimba sync", "rimba clean"},
 		},
 		{
 			name:    "multiple non-zero emits all applicable hints",
-			summary: cliStatusSummary{total: 5, behind: 2, stale: 1, dirty: 3},
+			summary: operations.StatusSummary{Total: 5, Behind: 2, Stale: 1, Dirty: 3},
 			wantSubstr: []string{
 				"2 behind main", "rimba sync --all",
 				"1 stale", "rimba clean --stale",

--- a/internal/operations/mock_runner_test.go
+++ b/internal/operations/mock_runner_test.go
@@ -3,13 +3,14 @@ package operations
 import "errors"
 
 const (
-	branchMain         = "main"
-	branchFeature      = "feature/login"
-	branchBugfixTypo   = "bugfix/typo"
-	pathWtFeatureLogin = "/wt/feature-login"
-	errNotARepo        = "not a git repo"
-	gitCmdRevList      = "rev-list"
-	pathMainRepo       = "/repo"
+	branchMain            = "main"
+	branchFeature         = "feature/login"
+	branchBugfixTypo      = "bugfix/typo"
+	pathWtFeatureLogin    = "/wt/feature-login"
+	errNotARepo           = "not a git repo"
+	gitCmdRevList         = "rev-list"
+	pathMainRepo          = "/repo"
+	refsRemotesOriginMain = "refs/remotes/origin/main"
 )
 
 var errGitFailed = errors.New("git failed")

--- a/internal/operations/mock_runner_test.go
+++ b/internal/operations/mock_runner_test.go
@@ -8,6 +8,8 @@ const (
 	branchBugfixTypo   = "bugfix/typo"
 	pathWtFeatureLogin = "/wt/feature-login"
 	errNotARepo        = "not a git repo"
+	gitCmdRevList      = "rev-list"
+	pathMainRepo       = "/repo"
 )
 
 var errGitFailed = errors.New("git failed")

--- a/internal/operations/status_dashboard.go
+++ b/internal/operations/status_dashboard.go
@@ -1,0 +1,154 @@
+package operations
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/lugassawan/rimba/internal/fsutil"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/parallel"
+	"github.com/lugassawan/rimba/internal/resolver"
+)
+
+const recentWindow = 7 * 24 * time.Hour
+
+// StatusEntry holds per-worktree data collected during a status dashboard run.
+type StatusEntry struct {
+	Entry      git.WorktreeEntry
+	Status     resolver.WorktreeStatus
+	CommitTime time.Time
+	HasTime    bool
+	SizeBytes  *int64
+	Recent7D   *int
+}
+
+// StatusSummary is the aggregate counts across all dashboard entries.
+type StatusSummary struct {
+	Total, Dirty, Stale, Behind int
+}
+
+// StatusDashboardRequest configures a StatusDashboard call.
+type StatusDashboardRequest struct {
+	Detail bool // when true, fan-out DirSize + 7D-velocity, build Footprint, sort by size desc
+}
+
+// StatusDashboardResult carries entries and optional disk footprint.
+type StatusDashboardResult struct {
+	Entries   []StatusEntry  // empty when no worktree candidates
+	Footprint *DiskFootprint // nil unless req.Detail
+}
+
+// StatusDashboard is the shared pipeline for the `rimba status` dashboard:
+// resolve main → list → filter → parallel collect → optional disk-size
+// fan-out → BuildDiskFootprint → sort by size desc.
+//
+// Spinner is a UI concern excluded from this layer; callers wrap the call
+// with spinner.Start/Stop as needed.
+func StatusDashboard(_ context.Context, gitR git.Runner, req StatusDashboardRequest) (StatusDashboardResult, error) {
+	mainBranch, err := ResolveMainBranch(gitR, "")
+	if err != nil {
+		return StatusDashboardResult{}, err
+	}
+
+	allEntries, err := git.ListWorktrees(gitR)
+	if err != nil {
+		return StatusDashboardResult{}, err
+	}
+
+	mainEntry := git.FindEntry(allEntries, mainBranch)
+	candidates := git.FilterEntries(allEntries, mainBranch)
+
+	if len(candidates) == 0 {
+		return StatusDashboardResult{}, nil
+	}
+
+	var mainSize int64
+	var mainErr error
+	var mainWG sync.WaitGroup
+	if req.Detail && mainEntry != nil {
+		mainWG.Add(1)
+		go func(path string) {
+			defer mainWG.Done()
+			mainSize, mainErr = fsutil.DirSize(path)
+		}(mainEntry.Path)
+	}
+
+	entries := collectStatusEntries(gitR, candidates, req.Detail)
+	mainWG.Wait()
+
+	var footprint *DiskFootprint
+	if req.Detail {
+		sizes := make([]*int64, len(entries))
+		for i, e := range entries {
+			sizes[i] = e.SizeBytes
+		}
+		fp := BuildDiskFootprint(sizes, mainSize, mainErr)
+		footprint = &fp
+		sortEntriesBySizeDesc(entries)
+	}
+
+	return StatusDashboardResult{Entries: entries, Footprint: footprint}, nil
+}
+
+// SummarizeStatus counts dirty, stale, and behind entries.
+// An entry is stale only when HasTime is true and CommitTime is before staleThreshold.
+func SummarizeStatus(entries []StatusEntry, staleThreshold time.Time) StatusSummary {
+	s := StatusSummary{Total: len(entries)}
+	for _, e := range entries {
+		if e.Status.Dirty {
+			s.Dirty++
+		}
+		if e.Status.Behind > 0 {
+			s.Behind++
+		}
+		if e.HasTime && e.CommitTime.Before(staleThreshold) {
+			s.Stale++
+		}
+	}
+	return s
+}
+
+// collectStatusEntries gathers dirty/ahead/behind state and last commit time
+// per candidate in parallel. Under detail it also computes size and 7-day
+// velocity; per-item errors leave the pointer nil (non-fatal).
+func collectStatusEntries(gitR git.Runner, candidates []git.WorktreeEntry, detail bool) []StatusEntry {
+	return parallel.Collect(len(candidates), 8, func(i int) StatusEntry {
+		e := candidates[i]
+		st := CollectWorktreeStatus(gitR, e.Path)
+		var ct time.Time
+		var hasTime bool
+		if t, err := git.LastCommitTime(gitR, e.Branch); err == nil {
+			ct = t
+			hasTime = true
+		}
+		se := StatusEntry{Entry: e, Status: st, CommitTime: ct, HasTime: hasTime}
+		if detail {
+			if n, err := fsutil.DirSize(e.Path); err == nil {
+				se.SizeBytes = &n
+			}
+			if c, err := git.CommitCountSince(gitR, e.Branch, recentWindow); err == nil {
+				se.Recent7D = &c
+			}
+		}
+		return se
+	})
+}
+
+// sortEntriesBySizeDesc sorts largest first, stable, nils last.
+func sortEntriesBySizeDesc(entries []StatusEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		a, b := entries[i].SizeBytes, entries[j].SizeBytes
+		switch {
+		case a == nil && b == nil:
+			return false
+		case a == nil:
+			return false
+		case b == nil:
+			return true
+		default:
+			return *a > *b
+		}
+	})
+}

--- a/internal/operations/status_dashboard_test.go
+++ b/internal/operations/status_dashboard_test.go
@@ -54,7 +54,7 @@ func (r *statusDashboardRunner) run(args ...string) (string, error) {
 	case len(args) >= 2 && args[0] == gitCmdRevList && args[1] == "--count":
 		return r.handleRevListCount(args)
 	case len(args) >= 1 && args[0] == "symbolic-ref":
-		return "refs/remotes/origin/main", nil
+		return refsRemotesOriginMain, nil
 	}
 	return "", nil
 }
@@ -266,6 +266,76 @@ func TestStatusDashboardLastCommitTimeErrorIsNonFatal(t *testing.T) {
 		if e.Entry.Branch == branchBugfixLogin && e.HasTime {
 			t.Errorf("bugfix/login: expected HasTime=false on commit-time error")
 		}
+	}
+}
+
+func TestStatusDashboardGitListError(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == "symbolic-ref" {
+				return refsRemotesOriginMain, nil
+			}
+			return "", errGitFailed
+		},
+		runInDir: noopRunInDir,
+	}
+	_, err := StatusDashboard(context.Background(), r, StatusDashboardRequest{})
+	if err == nil {
+		t.Fatal("expected error when git.ListWorktrees fails")
+	}
+}
+
+func TestStatusDashboardDetailNilMainEntry(t *testing.T) {
+	// Candidates exist but no main-branch worktree → mainEntry == nil,
+	// so the main-size goroutine must not be launched.
+	branchFeat := "feature/y"
+	porcelain := porcelainEntries(
+		struct{ path, branch string }{pathWtFeatureAuth, branchFeat},
+	)
+	r := (&statusDashboardRunner{
+		porcelain:   porcelain,
+		commitTimes: map[string]string{branchFeat: "1700000000"},
+	}).build()
+
+	res, err := StatusDashboard(context.Background(), r, StatusDashboardRequest{Detail: true})
+	if err != nil {
+		t.Fatalf("StatusDashboard: %v", err)
+	}
+	if len(res.Entries) != 1 {
+		t.Fatalf("Entries = %d, want 1", len(res.Entries))
+	}
+	if res.Footprint == nil {
+		t.Fatal("Footprint should be non-nil with Detail=true")
+	}
+}
+
+func TestSortEntriesBySizeDesc(t *testing.T) {
+	ptr := func(v int64) *int64 { return &v }
+
+	entries := []StatusEntry{
+		{Entry: git.WorktreeEntry{Branch: "small"}, SizeBytes: ptr(100)},
+		{Entry: git.WorktreeEntry{Branch: "errored"}, SizeBytes: nil},
+		{Entry: git.WorktreeEntry{Branch: "big"}, SizeBytes: ptr(5000)},
+		{Entry: git.WorktreeEntry{Branch: "medium"}, SizeBytes: ptr(1000)},
+		{Entry: git.WorktreeEntry{Branch: "errored2"}, SizeBytes: nil},
+	}
+	sortEntriesBySizeDesc(entries)
+	wantOrder := []string{"big", "medium", "small", "errored", "errored2"}
+	for i, w := range wantOrder {
+		if entries[i].Entry.Branch != w {
+			t.Errorf("index %d: got %q, want %q", i, entries[i].Entry.Branch, w)
+		}
+	}
+}
+
+func TestSortEntriesBySizeDescAllNil(t *testing.T) {
+	entries := []StatusEntry{
+		{Entry: git.WorktreeEntry{Branch: "a"}},
+		{Entry: git.WorktreeEntry{Branch: "b"}},
+	}
+	sortEntriesBySizeDesc(entries)
+	if entries[0].Entry.Branch != "a" || entries[1].Entry.Branch != "b" {
+		t.Errorf("expected stable order [a, b], got [%s, %s]", entries[0].Entry.Branch, entries[1].Entry.Branch)
 	}
 }
 

--- a/internal/operations/status_dashboard_test.go
+++ b/internal/operations/status_dashboard_test.go
@@ -1,0 +1,342 @@
+package operations
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/resolver"
+)
+
+// statusDashboardRunner builds a mockRunner backed by configurable worktree data.
+type statusDashboardRunner struct {
+	porcelain    string
+	dirtyDirs    map[string]bool
+	behindByDir  map[string]int    // dir → behind count
+	commitTimes  map[string]string // branch → unix timestamp string; "" means error
+	commitCounts map[string]string // branch → count string; "" means error
+}
+
+func (r *statusDashboardRunner) build() *mockRunner {
+	return &mockRunner{run: r.run, runInDir: r.runInDir}
+}
+
+func (r *statusDashboardRunner) handleLog(args []string) (string, error) {
+	branch := args[len(args)-1]
+	ts, ok := r.commitTimes[branch]
+	if !ok || ts == "" {
+		return "", errGitFailed
+	}
+	return ts + "\t-", nil
+}
+
+func (r *statusDashboardRunner) handleRevListCount(args []string) (string, error) {
+	branch := args[len(args)-1]
+	c, ok := r.commitCounts[branch]
+	if !ok {
+		return "0", nil
+	}
+	if c == "" {
+		return "", errGitFailed
+	}
+	return c, nil
+}
+
+func (r *statusDashboardRunner) run(args ...string) (string, error) {
+	switch {
+	case len(args) >= 2 && args[0] == cmdWorktreeTest && args[1] == cmdList:
+		return r.porcelain, nil
+	case len(args) >= 1 && args[0] == "log":
+		return r.handleLog(args)
+	case len(args) >= 2 && args[0] == gitCmdRevList && args[1] == "--count":
+		return r.handleRevListCount(args)
+	case len(args) >= 1 && args[0] == "symbolic-ref":
+		return "refs/remotes/origin/main", nil
+	}
+	return "", nil
+}
+
+func (r *statusDashboardRunner) runInDir(dir string, args ...string) (string, error) {
+	if len(args) >= 1 && args[0] == gitCmdStatus {
+		if r.dirtyDirs[dir] {
+			return "M file.go", nil
+		}
+		return "", nil
+	}
+	if len(args) >= 1 && args[0] == gitCmdRevList {
+		if behind, ok := r.behindByDir[dir]; ok && behind > 0 {
+			return string(rune('0'+behind)) + "\t0", nil
+		}
+		return "0\t0", nil
+	}
+	return "", nil
+}
+
+func TestStatusDashboardEmpty(t *testing.T) {
+	porcelain := porcelainEntries(struct{ path, branch string }{pathMainRepo, "main"})
+	r := (&statusDashboardRunner{
+		porcelain:   porcelain,
+		commitTimes: map[string]string{},
+	}).build()
+
+	res, err := StatusDashboard(context.Background(), r, StatusDashboardRequest{})
+	if err != nil {
+		t.Fatalf("StatusDashboard: %v", err)
+	}
+	if len(res.Entries) != 0 {
+		t.Errorf("Entries = %d, want 0", len(res.Entries))
+	}
+	if res.Footprint != nil {
+		t.Error("Footprint should be nil when no candidates")
+	}
+}
+
+func TestStatusDashboardCollectsStatuses(t *testing.T) {
+	porcelain := porcelainEntries(
+		struct{ path, branch string }{pathMainRepo, "main"},
+		struct{ path, branch string }{pathWtFeatureAuth, branchFeatureAuth},
+		struct{ path, branch string }{pathWtBugfixLogin, branchBugfixLogin},
+		struct{ path, branch string }{pathWtChoreLogout, branchChoreLogout},
+	)
+	fixedTS := "1700000000"
+	r := (&statusDashboardRunner{
+		porcelain:   porcelain,
+		dirtyDirs:   map[string]bool{pathWtFeatureAuth: true},
+		behindByDir: map[string]int{pathWtFeatureAuth: 2},
+		commitTimes: map[string]string{
+			branchFeatureAuth: fixedTS,
+			branchBugfixLogin: fixedTS,
+			branchChoreLogout: fixedTS,
+		},
+	}).build()
+
+	res, err := StatusDashboard(context.Background(), r, StatusDashboardRequest{})
+	if err != nil {
+		t.Fatalf("StatusDashboard: %v", err)
+	}
+	if len(res.Entries) != 3 {
+		t.Fatalf("Entries = %d, want 3", len(res.Entries))
+	}
+	if res.Footprint != nil {
+		t.Error("Footprint should be nil when Detail=false")
+	}
+
+	var featureEntry *StatusEntry
+	for i := range res.Entries {
+		if res.Entries[i].Entry.Branch == branchFeatureAuth {
+			featureEntry = &res.Entries[i]
+			break
+		}
+	}
+	if featureEntry == nil {
+		t.Fatal("feature/auth entry not found in results")
+	}
+	if !featureEntry.Status.Dirty {
+		t.Error("feature/auth: expected Dirty=true")
+	}
+	if featureEntry.Status.Behind != 2 {
+		t.Errorf("feature/auth: Behind = %d, want 2", featureEntry.Status.Behind)
+	}
+	if !featureEntry.HasTime {
+		t.Error("feature/auth: expected HasTime=true")
+	}
+}
+
+func TestStatusDashboardDetailPopulatesSizesAndVelocity(t *testing.T) {
+	mainDir := t.TempDir()
+	bigDir := t.TempDir()
+	smallDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(bigDir, "blob"), make([]byte, 8*1024), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(smallDir, "tiny"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	branchBig := "feature/big"
+	branchSmall := "feature/small"
+	porcelain := porcelainEntries(
+		struct{ path, branch string }{mainDir, "main"},
+		struct{ path, branch string }{bigDir, branchBig},
+		struct{ path, branch string }{smallDir, branchSmall},
+	)
+	r := (&statusDashboardRunner{
+		porcelain: porcelain,
+		commitTimes: map[string]string{
+			branchBig:   "1700000000",
+			branchSmall: "1700000000",
+		},
+		commitCounts: map[string]string{
+			branchBig:   "9",
+			branchSmall: "3",
+		},
+	}).build()
+
+	res, err := StatusDashboard(context.Background(), r, StatusDashboardRequest{Detail: true})
+	if err != nil {
+		t.Fatalf("StatusDashboard detail: %v", err)
+	}
+	if len(res.Entries) != 2 {
+		t.Fatalf("Entries = %d, want 2", len(res.Entries))
+	}
+	if res.Footprint == nil {
+		t.Fatal("Footprint should be non-nil when Detail=true")
+	}
+	if res.Entries[0].Entry.Branch != branchBig {
+		t.Errorf("Entries[0].Branch = %q, want %q (sort by size desc)", res.Entries[0].Entry.Branch, branchBig)
+	}
+	for _, e := range res.Entries {
+		if e.SizeBytes == nil {
+			t.Errorf("branch %q: SizeBytes is nil, expected populated", e.Entry.Branch)
+		}
+		if e.Recent7D == nil {
+			t.Errorf("branch %q: Recent7D is nil, expected populated", e.Entry.Branch)
+		}
+	}
+	if res.Footprint.MainErr != nil {
+		t.Errorf("Footprint.MainErr = %v, want nil", res.Footprint.MainErr)
+	}
+	if res.Footprint.TotalBytes == 0 {
+		t.Error("Footprint.TotalBytes should be non-zero")
+	}
+}
+
+func TestStatusDashboardDetailMainSizeErrorPropagates(t *testing.T) {
+	nonexistent := "/nonexistent/path/that/does/not/exist/xyz123"
+	bigDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bigDir, "blob"), make([]byte, 512), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	branchFeat := "feature/x"
+	porcelain := porcelainEntries(
+		struct{ path, branch string }{nonexistent, "main"},
+		struct{ path, branch string }{bigDir, branchFeat},
+	)
+	r := (&statusDashboardRunner{
+		porcelain:   porcelain,
+		commitTimes: map[string]string{branchFeat: "1700000000"},
+	}).build()
+
+	res, err := StatusDashboard(context.Background(), r, StatusDashboardRequest{Detail: true})
+	if err != nil {
+		t.Fatalf("StatusDashboard: %v", err)
+	}
+	if res.Footprint == nil {
+		t.Fatal("Footprint should be non-nil with Detail=true")
+	}
+	if res.Footprint.MainErr == nil {
+		t.Error("Footprint.MainErr should be non-nil when main path is invalid")
+	}
+	if res.Footprint.TotalBytes == 0 {
+		t.Error("Footprint.TotalBytes should include worktree bytes even when main errors")
+	}
+}
+
+func TestStatusDashboardLastCommitTimeErrorIsNonFatal(t *testing.T) {
+	porcelain := porcelainEntries(
+		struct{ path, branch string }{pathMainRepo, "main"},
+		struct{ path, branch string }{pathWtFeatureAuth, branchFeatureAuth},
+		struct{ path, branch string }{pathWtBugfixLogin, branchBugfixLogin},
+	)
+	r := (&statusDashboardRunner{
+		porcelain: porcelain,
+		commitTimes: map[string]string{
+			branchFeatureAuth: "1700000000",
+			branchBugfixLogin: "",
+		},
+	}).build()
+
+	res, err := StatusDashboard(context.Background(), r, StatusDashboardRequest{})
+	if err != nil {
+		t.Fatalf("StatusDashboard: %v", err)
+	}
+	if len(res.Entries) != 2 {
+		t.Fatalf("Entries = %d, want 2", len(res.Entries))
+	}
+
+	for _, e := range res.Entries {
+		if e.Entry.Branch == branchFeatureAuth && !e.HasTime {
+			t.Errorf("feature/auth: expected HasTime=true")
+		}
+		if e.Entry.Branch == branchBugfixLogin && e.HasTime {
+			t.Errorf("bugfix/login: expected HasTime=false on commit-time error")
+		}
+	}
+}
+
+// resolverStatus is a small helper to build a WorktreeStatus for test entries.
+func resolverStatus(dirty bool, behind int) resolver.WorktreeStatus {
+	return resolver.WorktreeStatus{Dirty: dirty, Behind: behind}
+}
+
+func TestSummarizeStatus(t *testing.T) {
+	now := time.Now()
+	staleThreshold := now.Add(-14 * 24 * time.Hour)
+	oldCommit := now.Add(-30 * 24 * time.Hour)
+	recentCommit := now.Add(-1 * time.Hour)
+
+	entry := func(dirty bool, behind int, ct time.Time, hasTime bool) StatusEntry {
+		return StatusEntry{
+			Entry:      git.WorktreeEntry{Branch: "feature/x"},
+			Status:     resolverStatus(dirty, behind),
+			CommitTime: ct,
+			HasTime:    hasTime,
+		}
+	}
+
+	cases := []struct {
+		name    string
+		entries []StatusEntry
+		want    StatusSummary
+	}{
+		{name: "empty", entries: nil, want: StatusSummary{}},
+		{
+			name:    "all zero",
+			entries: []StatusEntry{entry(false, 0, recentCommit, true), entry(false, 0, recentCommit, true)},
+			want:    StatusSummary{Total: 2},
+		},
+		{
+			name:    "dirty only",
+			entries: []StatusEntry{entry(true, 0, recentCommit, true), entry(false, 0, recentCommit, true)},
+			want:    StatusSummary{Total: 2, Dirty: 1},
+		},
+		{
+			name:    "behind only",
+			entries: []StatusEntry{entry(false, 3, recentCommit, true), entry(false, 0, recentCommit, true)},
+			want:    StatusSummary{Total: 2, Behind: 1},
+		},
+		{
+			name:    "stale only",
+			entries: []StatusEntry{entry(false, 0, oldCommit, true), entry(false, 0, recentCommit, true)},
+			want:    StatusSummary{Total: 2, Stale: 1},
+		},
+		{
+			name:    "hasTime=false must not count as stale",
+			entries: []StatusEntry{entry(false, 0, oldCommit, false)},
+			want:    StatusSummary{Total: 1},
+		},
+		{
+			name: "mix of all",
+			entries: []StatusEntry{
+				entry(true, 2, oldCommit, true),
+				entry(false, 0, recentCommit, true),
+				entry(true, 0, oldCommit, false),
+			},
+			want: StatusSummary{Total: 3, Dirty: 2, Behind: 1, Stale: 1},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SummarizeStatus(tc.entries, staleThreshold)
+			if got != tc.want {
+				t.Errorf("SummarizeStatus = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Extract `StatusEntry`, `StatusSummary`, `SummarizeStatus` into `internal/operations/status_dashboard.go` — domain types belong with the operation that produces them, not in `cmd/`
- Add `StatusDashboard` operation that owns the full pipeline: resolve main → list → filter → parallel collect → optional disk-size fan-out → `BuildDiskFootprint` → sort by size desc
- Introduce `statusRender` parameter object in `cmd/status.go`, collapsing a 6-arg `renderStatusDashboard` signature into a named struct
- `cmd/status.go` `RunE` shrinks from ~70 lines to ~25; `collectStatuses`, `sortBySizeDesc`, `cliStatusSummary`, `buildCLIStatusSummary` all deleted from `cmd/`
- Add characterization tests: `TestStatusDashboard*`, `TestSummarizeStatus` in `internal/operations/`

Closes #143. Follows the template established by #133 (`list_worktrees.go`).

## Test Plan

- [x] `go test ./...` — 1624 passed, 0 failures
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `./custom-gcl run ./...` — clean (pre-commit hook)
- [ ] Manual: `rimba status` and `rimba status --detail` output unchanged
- [ ] Manual: `rimba status --json` and `rimba status --detail --json` byte-identical to pre-refactor