### PR TITLE
[refactor] De-duplicate mcpreg register/unregister and JSON/TOML paths (#144)

### DIFF
--- a/internal/agentfile/mcpreg.go
+++ b/internal/agentfile/mcpreg.go
@@ -68,7 +68,7 @@ func UnregisterMCPProject(repoRoot string) ([]Result, error) {
 	return unregisterMCPSpecs(repoRoot, ProjectMCPSpecs())
 }
 
-func registerMCPSpecs(baseDir string, specs []MCPSpec) ([]Result, error) {
+func applyMCPSpecs(baseDir string, specs []MCPSpec, remove bool) ([]Result, error) {
 	results := make([]Result, 0, len(specs))
 	for _, spec := range specs {
 		path := filepath.Join(baseDir, spec.RelPath)
@@ -76,9 +76,9 @@ func registerMCPSpecs(baseDir string, specs []MCPSpec) ([]Result, error) {
 		var err error
 		switch spec.Format {
 		case mcpJSON:
-			action, err = patchJSON(path, spec.ContainerKey, false)
+			action, err = patchJSON(path, spec.ContainerKey, remove)
 		case mcpTOML:
-			action, err = patchTOML(path, spec.ContainerKey, false)
+			action, err = patchTOML(path, spec.ContainerKey, remove)
 		}
 		if err != nil {
 			return results, err
@@ -88,24 +88,12 @@ func registerMCPSpecs(baseDir string, specs []MCPSpec) ([]Result, error) {
 	return results, nil
 }
 
+func registerMCPSpecs(baseDir string, specs []MCPSpec) ([]Result, error) {
+	return applyMCPSpecs(baseDir, specs, false)
+}
+
 func unregisterMCPSpecs(baseDir string, specs []MCPSpec) ([]Result, error) {
-	results := make([]Result, 0, len(specs))
-	for _, spec := range specs {
-		path := filepath.Join(baseDir, spec.RelPath)
-		var action string
-		var err error
-		switch spec.Format {
-		case mcpJSON:
-			action, err = patchJSON(path, spec.ContainerKey, true)
-		case mcpTOML:
-			action, err = patchTOML(path, spec.ContainerKey, true)
-		}
-		if err != nil {
-			return results, err
-		}
-		results = append(results, Result{RelPath: spec.RelPath, Action: action})
-	}
-	return results, nil
+	return applyMCPSpecs(baseDir, specs, true)
 }
 
 func desiredEntry() map[string]any {

--- a/internal/agentfile/mcpreg.go
+++ b/internal/agentfile/mcpreg.go
@@ -50,22 +50,22 @@ func ProjectMCPSpecs() []MCPSpec {
 
 // RegisterMCPGlobal patches all user-level MCP config files to add the rimba server entry.
 func RegisterMCPGlobal(homeDir string) ([]Result, error) {
-	return registerMCPSpecs(homeDir, GlobalMCPSpecs())
+	return applyMCPSpecs(homeDir, GlobalMCPSpecs(), false)
 }
 
 // UnregisterMCPGlobal removes the rimba server entry from all user-level MCP config files.
 func UnregisterMCPGlobal(homeDir string) ([]Result, error) {
-	return unregisterMCPSpecs(homeDir, GlobalMCPSpecs())
+	return applyMCPSpecs(homeDir, GlobalMCPSpecs(), true)
 }
 
 // RegisterMCPProject patches project-level MCP config files to add the rimba server entry.
 func RegisterMCPProject(repoRoot string) ([]Result, error) {
-	return registerMCPSpecs(repoRoot, ProjectMCPSpecs())
+	return applyMCPSpecs(repoRoot, ProjectMCPSpecs(), false)
 }
 
 // UnregisterMCPProject removes the rimba server entry from project-level MCP config files.
 func UnregisterMCPProject(repoRoot string) ([]Result, error) {
-	return unregisterMCPSpecs(repoRoot, ProjectMCPSpecs())
+	return applyMCPSpecs(repoRoot, ProjectMCPSpecs(), true)
 }
 
 func applyMCPSpecs(baseDir string, specs []MCPSpec, remove bool) ([]Result, error) {
@@ -86,14 +86,6 @@ func applyMCPSpecs(baseDir string, specs []MCPSpec, remove bool) ([]Result, erro
 		results = append(results, Result{RelPath: spec.RelPath, Action: action})
 	}
 	return results, nil
-}
-
-func registerMCPSpecs(baseDir string, specs []MCPSpec) ([]Result, error) {
-	return applyMCPSpecs(baseDir, specs, false)
-}
-
-func unregisterMCPSpecs(baseDir string, specs []MCPSpec) ([]Result, error) {
-	return applyMCPSpecs(baseDir, specs, true)
 }
 
 func desiredEntry() map[string]any {

--- a/internal/agentfile/mcpreg.go
+++ b/internal/agentfile/mcpreg.go
@@ -20,6 +20,17 @@ const (
 	mcpTOML
 )
 
+// mcpCodec parameterizes the unmarshal + write pair across JSON and TOML formats.
+type mcpCodec struct {
+	unmarshal func([]byte, any) error
+	write     func(path string, cfg map[string]any) error
+}
+
+var (
+	jsonCodec = mcpCodec{unmarshal: json.Unmarshal, write: writeJSON}
+	tomlCodec = mcpCodec{unmarshal: toml.Unmarshal, write: writeTOML}
+)
+
 // MCPSpec describes a single agent MCP config file to patch.
 type MCPSpec struct {
 	RelPath      string    // relative to baseDir (homeDir or repoRoot)
@@ -68,18 +79,18 @@ func UnregisterMCPProject(repoRoot string) ([]Result, error) {
 	return applyMCPSpecs(repoRoot, ProjectMCPSpecs(), true)
 }
 
+func codecFor(f mcpFormat) mcpCodec {
+	if f == mcpTOML {
+		return tomlCodec
+	}
+	return jsonCodec
+}
+
 func applyMCPSpecs(baseDir string, specs []MCPSpec, remove bool) ([]Result, error) {
 	results := make([]Result, 0, len(specs))
 	for _, spec := range specs {
 		path := filepath.Join(baseDir, spec.RelPath)
-		var action string
-		var err error
-		switch spec.Format {
-		case mcpJSON:
-			action, err = patchJSON(path, spec.ContainerKey, remove)
-		case mcpTOML:
-			action, err = patchTOML(path, spec.ContainerKey, remove)
-		}
+		action, err := patchMCP(path, spec.ContainerKey, remove, codecFor(spec.Format))
 		if err != nil {
 			return results, err
 		}
@@ -88,102 +99,62 @@ func applyMCPSpecs(baseDir string, specs []MCPSpec, remove bool) ([]Result, erro
 	return results, nil
 }
 
+func patchMCP(path, containerKey string, remove bool, codec mcpCodec) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return actionSkippedNoConfig, nil
+		}
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	var cfg map[string]any
+	if err := codec.unmarshal(data, &cfg); err != nil {
+		return "", fmt.Errorf("parse %s: %w", path, err)
+	}
+	var action string
+	if remove {
+		action = removeFromContainer(cfg, containerKey)
+	} else {
+		action = addToContainer(cfg, containerKey)
+	}
+	if action == actionUnchanged {
+		return action, nil
+	}
+	return action, codec.write(path, cfg)
+}
+
+func addToContainer(cfg map[string]any, containerKey string) string {
+	servers, _ := cfg[containerKey].(map[string]any)
+	if servers == nil {
+		servers = map[string]any{}
+	}
+	desired := desiredEntry()
+	if reflect.DeepEqual(servers[mcpServerName], desired) {
+		return actionUnchanged
+	}
+	servers[mcpServerName] = desired
+	cfg[containerKey] = servers
+	return actionRegistered
+}
+
+func removeFromContainer(cfg map[string]any, containerKey string) string {
+	servers, _ := cfg[containerKey].(map[string]any)
+	if servers == nil {
+		return actionUnchanged
+	}
+	if _, present := servers[mcpServerName]; !present {
+		return actionUnchanged
+	}
+	delete(servers, mcpServerName)
+	cfg[containerKey] = servers
+	return actionUnregistered
+}
+
 func desiredEntry() map[string]any {
 	return map[string]any{
 		"command": mcpServerName,
 		"args":    []any{"mcp"},
 	}
-}
-
-func patchJSON(path, containerKey string, remove bool) (string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return actionSkippedNoConfig, nil
-		}
-		return "", fmt.Errorf("read %s: %w", path, err)
-	}
-	var cfg map[string]any
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return "", fmt.Errorf("parse %s: %w", path, err)
-	}
-	if remove {
-		return removeFromJSON(path, containerKey, cfg)
-	}
-	return addToJSON(path, containerKey, cfg)
-}
-
-func addToJSON(path, containerKey string, cfg map[string]any) (string, error) {
-	servers, _ := cfg[containerKey].(map[string]any)
-	if servers == nil {
-		servers = map[string]any{}
-	}
-	desired := desiredEntry()
-	if reflect.DeepEqual(servers[mcpServerName], desired) {
-		return actionUnchanged, nil
-	}
-	servers[mcpServerName] = desired
-	cfg[containerKey] = servers
-	return actionRegistered, writeJSON(path, cfg)
-}
-
-func removeFromJSON(path, containerKey string, cfg map[string]any) (string, error) {
-	servers, _ := cfg[containerKey].(map[string]any)
-	if servers == nil {
-		return actionUnchanged, nil
-	}
-	if _, present := servers[mcpServerName]; !present {
-		return actionUnchanged, nil
-	}
-	delete(servers, mcpServerName)
-	cfg[containerKey] = servers
-	return actionUnregistered, writeJSON(path, cfg)
-}
-
-func patchTOML(path, containerKey string, remove bool) (string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return actionSkippedNoConfig, nil
-		}
-		return "", fmt.Errorf("read %s: %w", path, err)
-	}
-	var cfg map[string]any
-	if err := toml.Unmarshal(data, &cfg); err != nil {
-		return "", fmt.Errorf("parse %s: %w", path, err)
-	}
-	if remove {
-		return removeFromTOML(path, containerKey, cfg)
-	}
-	return addToTOML(path, containerKey, cfg)
-}
-
-func addToTOML(path, containerKey string, cfg map[string]any) (string, error) {
-	servers, _ := cfg[containerKey].(map[string]any)
-	if servers == nil {
-		servers = map[string]any{}
-	}
-	// TOML library decodes args as []any, matching desiredEntry() shape.
-	desired := desiredEntry()
-	if reflect.DeepEqual(servers[mcpServerName], desired) {
-		return actionUnchanged, nil
-	}
-	servers[mcpServerName] = desired
-	cfg[containerKey] = servers
-	return actionRegistered, writeTOML(path, cfg)
-}
-
-func removeFromTOML(path, containerKey string, cfg map[string]any) (string, error) {
-	servers, _ := cfg[containerKey].(map[string]any)
-	if servers == nil {
-		return actionUnchanged, nil
-	}
-	if _, present := servers[mcpServerName]; !present {
-		return actionUnchanged, nil
-	}
-	delete(servers, mcpServerName)
-	cfg[containerKey] = servers
-	return actionUnregistered, writeTOML(path, cfg)
 }
 
 func writeJSON(path string, cfg map[string]any) error {

--- a/internal/agentfile/mcpreg.go
+++ b/internal/agentfile/mcpreg.go
@@ -128,6 +128,8 @@ func addToContainer(cfg map[string]any, containerKey string) string {
 	if servers == nil {
 		servers = map[string]any{}
 	}
+	// desiredEntry uses []any; go-toml/v2 also decodes TOML arrays as []any,
+	// so reflect.DeepEqual works correctly for TOML idempotency.
 	desired := desiredEntry()
 	if reflect.DeepEqual(servers[mcpServerName], desired) {
 		return actionUnchanged

--- a/internal/agentfile/mcpreg_test.go
+++ b/internal/agentfile/mcpreg_test.go
@@ -479,6 +479,31 @@ func TestUnregisterMCPGlobalTOMLSkipsWhenKeyMissing(t *testing.T) {
 	}
 }
 
+func TestPatchReadErrorReturnsError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; chmod 000 has no effect")
+	}
+	home := t.TempDir()
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(claudeDir, "settings.json")
+	seedJSON(t, path, map[string]any{})
+	if err := os.Chmod(path, 0000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0600) })
+
+	_, err := RegisterMCPGlobal(home)
+	if err == nil {
+		t.Error("expected error for unreadable file, got nil")
+	}
+	if !strings.Contains(err.Error(), "settings.json") {
+		t.Errorf("error should mention file path, got: %v", err)
+	}
+}
+
 func TestUnregisterMCPGlobalMalformedTOMLReturnsError(t *testing.T) {
 	home := t.TempDir()
 	codexDir := filepath.Join(home, ".codex")


### PR DESCRIPTION
## Summary
- Collapsed `registerMCPSpecs`/`unregisterMCPSpecs` (differed only by a `remove bool`) into a single `applyMCPSpecs(baseDir, specs, remove bool)` driver; public wrappers call it directly
- Introduced `mcpCodec{unmarshal, write}` strategy struct with `jsonCodec`/`tomlCodec` package values and `codecFor(mcpFormat)` selector; replaced `patchJSON`+`patchTOML` with a single `patchMCP` that uses the codec for both parsing and serialisation
- Extracted format-agnostic `addToContainer`/`removeFromContainer` helpers; deleted `addToJSON`, `addToTOML`, `removeFromJSON`, `removeFromTOML` — ~225 lines → ~120 lines, no behavior change

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] e2e MCP tests pass (`go test ./tests/e2e/ -run 'TestInitGlobalWithMCPConfigs|TestInitGlobalUninstallWithMCP'`)

Closes #144