### PR TITLE
[refactor] Extract validateTypeFilter/typeFilterCompletion + move listArchivedBranches (#147)

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -108,12 +108,8 @@ func execValidateFlags(opts execOpts) error {
 	if !opts.all && opts.typeFilter == "" {
 		return errors.New("provide --all or --type to select worktrees")
 	}
-	if opts.typeFilter != "" && !resolver.ValidPrefixType(opts.typeFilter) {
-		valid := make([]string, 0, len(resolver.AllPrefixes()))
-		for _, p := range resolver.AllPrefixes() {
-			valid = append(valid, strings.TrimSuffix(p, "/"))
-		}
-		return fmt.Errorf("invalid type %q; valid types: %s", opts.typeFilter, strings.Join(valid, ", "))
+	if err := validateTypeFilter(opts.typeFilter); err != nil {
+		return err
 	}
 	return nil
 }
@@ -211,16 +207,7 @@ func init() {
 	execCmd.Flags().Bool(flagFailFast, false, "stop after the first failure")
 	execCmd.Flags().Int(flagConcurrency, 0, "max parallel executions (0 = unlimited)")
 
-	_ = execCmd.RegisterFlagCompletionFunc(flagType, func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		var types []string
-		for _, p := range resolver.AllPrefixes() {
-			t := strings.TrimSuffix(p, "/")
-			if strings.HasPrefix(t, toComplete) {
-				types = append(types, t)
-			}
-		}
-		return types, cobra.ShellCompDirectiveNoFileComp
-	})
+	_ = execCmd.RegisterFlagCompletionFunc(flagType, typeFilterCompletion())
 
 	rootCmd.AddCommand(execCmd)
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/spf13/cobra"
+)
+
+// validateTypeFilter returns nil for empty input or a recognized prefix; otherwise an error
+// listing the valid types. Shared by exec and list.
+func validateTypeFilter(typeFilter string) error {
+	if typeFilter == "" || resolver.ValidPrefixType(typeFilter) {
+		return nil
+	}
+	valid := make([]string, 0, len(resolver.AllPrefixes()))
+	for _, p := range resolver.AllPrefixes() {
+		valid = append(valid, strings.TrimSuffix(p, "/"))
+	}
+	return fmt.Errorf("invalid type %q; valid types: %s", typeFilter, strings.Join(valid, ", "))
+}
+
+// typeFilterCompletion returns a cobra.CompletionFunc that completes against resolver.AllPrefixes().
+func typeFilterCompletion() cobra.CompletionFunc {
+	return func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		var types []string
+		for _, p := range resolver.AllPrefixes() {
+			t := strings.TrimSuffix(p, "/")
+			if strings.HasPrefix(t, toComplete) {
+				types = append(types, t)
+			}
+		}
+		return types, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,20 +1,15 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/hint"
 	"github.com/lugassawan/rimba/internal/operations"
-	"github.com/lugassawan/rimba/internal/output"
-	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/spinner"
-	"github.com/lugassawan/rimba/internal/termcolor"
 	"github.com/spf13/cobra"
 )
 
@@ -129,14 +124,7 @@ func listReadFlags(cmd *cobra.Command) listOpts {
 }
 
 func listValidateType(typeFilter string) error {
-	if typeFilter == "" || resolver.ValidPrefixType(typeFilter) {
-		return nil
-	}
-	valid := make([]string, 0, len(resolver.AllPrefixes()))
-	for _, p := range resolver.AllPrefixes() {
-		valid = append(valid, strings.TrimSuffix(p, "/"))
-	}
-	return fmt.Errorf("invalid type %q; valid types: %s", typeFilter, strings.Join(valid, ", "))
+	return validateTypeFilter(typeFilter)
 }
 
 func listShowHints(cmd *cobra.Command) {
@@ -167,63 +155,5 @@ func init() {
 	listCmd.MarkFlagsMutuallyExclusive(flagArchived, flagBehind)
 	listCmd.MarkFlagsMutuallyExclusive(flagArchived, flagFull)
 
-	_ = listCmd.RegisterFlagCompletionFunc(flagType, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		var types []string
-		for _, p := range resolver.AllPrefixes() {
-			t := strings.TrimSuffix(p, "/")
-			if strings.HasPrefix(t, toComplete) {
-				types = append(types, t)
-			}
-		}
-		return types, cobra.ShellCompDirectiveNoFileComp
-	})
-}
-
-func listArchivedBranches(cmd *cobra.Command, r git.Runner, mainBranch string) error {
-	archived, err := operations.ListArchivedBranches(r, mainBranch)
-	if err != nil {
-		return err
-	}
-
-	prefixes := resolver.AllPrefixes()
-
-	if isJSON(cmd) {
-		items := make([]output.ListArchivedItem, 0, len(archived))
-		for _, b := range archived {
-			task, typeName := resolver.TaskAndType(b, prefixes)
-			items = append(items, output.ListArchivedItem{Task: task, Type: typeName, Branch: b})
-		}
-		return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
-	}
-
-	if len(archived) == 0 {
-		fmt.Fprintln(cmd.OutOrStdout(), "No archived branches found.")
-		return nil
-	}
-
-	noColor, _ := cmd.Flags().GetBool(flagNoColor)
-	p := termcolor.NewPainter(noColor)
-
-	tbl := termcolor.NewTable(2)
-	tbl.AddRow(
-		p.Paint("TASK", termcolor.Bold),
-		p.Paint("TYPE", termcolor.Bold),
-		p.Paint("BRANCH", termcolor.Bold),
-	)
-
-	for _, b := range archived {
-		task, typeName := resolver.TaskAndType(b, prefixes)
-
-		typeCell := typeName
-		if c := typeColor(typeName); c != "" {
-			typeCell = p.Paint(typeCell, c)
-		}
-
-		tbl.AddRow("  "+task, typeCell, b)
-	}
-
-	fmt.Fprintln(cmd.OutOrStdout(), "Archived branches:")
-	tbl.Render(cmd.OutOrStdout())
-	fmt.Fprintf(cmd.OutOrStdout(), "\nTo restore: rimba restore <task>\n")
-	return nil
+	_ = listCmd.RegisterFlagCompletionFunc(flagType, typeFilterCompletion())
 }

--- a/cmd/list_render.go
+++ b/cmd/list_render.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lugassawan/rimba/internal/gh"
+	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -128,4 +129,53 @@ func formatCICell(status gh.CIStatus, p *termcolor.Painter) string {
 	default:
 		return p.Paint("–", termcolor.Gray)
 	}
+}
+
+func listArchivedBranches(cmd *cobra.Command, r git.Runner, mainBranch string) error {
+	archived, err := operations.ListArchivedBranches(r, mainBranch)
+	if err != nil {
+		return err
+	}
+
+	prefixes := resolver.AllPrefixes()
+
+	if isJSON(cmd) {
+		items := make([]output.ListArchivedItem, 0, len(archived))
+		for _, b := range archived {
+			task, typeName := resolver.TaskAndType(b, prefixes)
+			items = append(items, output.ListArchivedItem{Task: task, Type: typeName, Branch: b})
+		}
+		return output.WriteJSON(cmd.OutOrStdout(), version, "list", items)
+	}
+
+	if len(archived) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No archived branches found.")
+		return nil
+	}
+
+	noColor, _ := cmd.Flags().GetBool(flagNoColor)
+	p := termcolor.NewPainter(noColor)
+
+	tbl := termcolor.NewTable(2)
+	tbl.AddRow(
+		p.Paint("TASK", termcolor.Bold),
+		p.Paint("TYPE", termcolor.Bold),
+		p.Paint("BRANCH", termcolor.Bold),
+	)
+
+	for _, b := range archived {
+		task, typeName := resolver.TaskAndType(b, prefixes)
+
+		typeCell := typeName
+		if c := typeColor(typeName); c != "" {
+			typeCell = p.Paint(typeCell, c)
+		}
+
+		tbl.AddRow("  "+task, typeCell, b)
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), "Archived branches:")
+	tbl.Render(cmd.OutOrStdout())
+	fmt.Fprintf(cmd.OutOrStdout(), "\nTo restore: rimba restore <task>\n")
+	return nil
 }


### PR DESCRIPTION
## Summary

- Extract `validateTypeFilter` into new `cmd/flags.go`, eliminating the duplicate `ValidPrefixType` check + error-format string that existed separately in `cmd/exec.go` and `cmd/list.go` (Fowler: Extract Function)
- Extract `typeFilterCompletion` into `cmd/flags.go`, replacing two identical `cobra.CompletionFunc` closures with a single shared helper (Fowler: Extract Function)
- Move `listArchivedBranches` from `cmd/list.go` into `cmd/list_render.go` where all other list rendering functions live, restoring the dispatch-vs-rendering separation introduced in #131 (Fowler: Move Function)

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Manual smoke: `rimba list --type bogus` and `rimba exec --type bogus 'pwd'` produce identical error strings to main

Closes #147