### PR TITLE
[refactor] Apply errhint.WithFix consistently to all user-facing errors (#148)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/hint"
@@ -56,7 +57,10 @@ var addCmd = &cobra.Command{
 		}
 
 		if cmd.Flags().Changed(flagTask) {
-			return errors.New("--task requires a pr:<num> argument")
+			return errhint.WithFix(
+				errors.New("--task requires a pr:<num> argument"),
+				"pass a PR argument: rimba add pr:<num> --task <name>",
+			)
 		}
 
 		return runAddTask(cmd, r, args[0], cfg, repoRoot, postOpts, s)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/executor"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/hint"
@@ -106,7 +107,10 @@ func execReadFlags(cmd *cobra.Command) execOpts {
 
 func execValidateFlags(opts execOpts) error {
 	if !opts.all && opts.typeFilter == "" {
-		return errors.New("provide --all or --type to select worktrees")
+		return errhint.WithFix(
+			errors.New("provide --all or --type to select worktrees"),
+			"run: rimba exec --all <cmd>  OR  rimba exec --type <prefix> <cmd>",
+		)
 	}
 	if err := validateTypeFilter(opts.typeFilter); err != nil {
 		return err

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +19,10 @@ func validateTypeFilter(typeFilter string) error {
 	for _, p := range resolver.AllPrefixes() {
 		valid = append(valid, strings.TrimSuffix(p, "/"))
 	}
-	return fmt.Errorf("invalid type %q; valid types: %s", typeFilter, strings.Join(valid, ", "))
+	return errhint.WithFix(
+		fmt.Errorf("invalid type %q; valid types: %s", typeFilter, strings.Join(valid, ", ")),
+		"use a prefix defined in .rimba/settings.toml [prefixes] section",
+	)
 }
 
 // typeFilterCompletion returns a cobra.CompletionFunc that completes against resolver.AllPrefixes().

--- a/internal/errhint/errhint_test.go
+++ b/internal/errhint/errhint_test.go
@@ -44,6 +44,33 @@ func TestWithFix(t *testing.T) {
 				"To fix: retry",
 			},
 		},
+		{
+			name: "exec provide --all hint",
+			err:  errors.New("provide --all or --type to select worktrees"),
+			fix:  "run: rimba exec --all <cmd>  OR  rimba exec --type <prefix> <cmd>",
+			wantSubstr: []string{
+				"provide --all or --type",
+				"To fix: run: rimba exec --all",
+			},
+		},
+		{
+			name: "worktree not found hint",
+			err:  errors.New(`worktree not found for task "mytask"`),
+			fix:  "run: rimba list  to see available worktrees",
+			wantSubstr: []string{
+				"worktree not found",
+				"To fix: run: rimba list",
+			},
+		},
+		{
+			name: "not a git repository hint",
+			err:  errors.New("not a git repository"),
+			fix:  "run from inside a git repository, or run: git init",
+			wantSubstr: []string{
+				"not a git repository",
+				"To fix: run from inside a git repository",
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/gh/pr_meta.go
+++ b/internal/gh/pr_meta.go
@@ -6,10 +6,15 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
+
+	"github.com/lugassawan/rimba/internal/errhint"
 )
 
 // safeNameRe matches strings safe to embed in git remote names and URLs.
 var safeNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+const ghShapeHint = "gh CLI returned an unexpected response shape — update gh: gh --version"
 
 // PRMeta holds the metadata needed to check out a PR's head branch.
 type PRMeta struct {
@@ -40,28 +45,29 @@ func FetchPRMeta(ctx context.Context, r Runner, num int) (PRMeta, error) {
 		"--json", "number,title,headRefName,headRepository,headRepositoryOwner,isCrossRepository",
 	)
 	if err != nil {
-		return PRMeta{}, fmt.Errorf("fetch PR #%d: %w", num, err)
+		fetchErr := fmt.Errorf("fetch PR #%d: %w", num, err)
+		return PRMeta{}, errhint.WithFix(fetchErr, classifyFetchPRErr(err))
 	}
 	var resp prViewResponse
 	if err := json.Unmarshal(out, &resp); err != nil {
-		return PRMeta{}, fmt.Errorf("parse PR #%d metadata: %w", num, err)
+		return PRMeta{}, errhint.WithFix(fmt.Errorf("parse PR #%d metadata: %w", num, err), ghShapeHint)
 	}
 	if resp.HeadRefName == "" {
-		return PRMeta{}, fmt.Errorf("PR #%d: missing headRefName in response", num)
+		return PRMeta{}, errhint.WithFix(fmt.Errorf("PR #%d: missing headRefName in response", num), ghShapeHint)
 	}
 	owner := resp.HeadRepositoryOwner.Login
 	repoName := resp.HeadRepository.Name
 	if owner == "" {
-		return PRMeta{}, fmt.Errorf("PR #%d: missing headRepositoryOwner in response", num)
+		return PRMeta{}, errhint.WithFix(fmt.Errorf("PR #%d: missing headRepositoryOwner in response", num), ghShapeHint)
 	}
 	if repoName == "" {
-		return PRMeta{}, fmt.Errorf("PR #%d: missing headRepository in response", num)
+		return PRMeta{}, errhint.WithFix(fmt.Errorf("PR #%d: missing headRepository in response", num), ghShapeHint)
 	}
 	if !safeNameRe.MatchString(owner) {
-		return PRMeta{}, fmt.Errorf("PR #%d: unsafe headRepositoryOwner %q", num, owner)
+		return PRMeta{}, errhint.WithFix(fmt.Errorf("PR #%d: unsafe headRepositoryOwner %q", num, owner), ghShapeHint)
 	}
 	if !safeNameRe.MatchString(repoName) {
-		return PRMeta{}, fmt.Errorf("PR #%d: unsafe headRepository.name %q", num, repoName)
+		return PRMeta{}, errhint.WithFix(fmt.Errorf("PR #%d: unsafe headRepository.name %q", num, repoName), ghShapeHint)
 	}
 	return PRMeta{
 		Number:            resp.Number,
@@ -71,4 +77,16 @@ func FetchPRMeta(ctx context.Context, r Runner, num int) (PRMeta, error) {
 		HeadRepoName:      repoName,
 		IsCrossRepository: resp.IsCrossRepository,
 	}, nil
+}
+
+func classifyFetchPRErr(err error) string {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "404") || strings.Contains(msg, "Could not resolve"):
+		return "verify PR number and repo access: gh pr view <num>"
+	case strings.Contains(msg, "rate limit"):
+		return "GitHub API rate limit hit — wait or set GITHUB_TOKEN"
+	default:
+		return "check network access and gh auth: gh auth status"
+	}
 }

--- a/internal/gh/pr_meta_test.go
+++ b/internal/gh/pr_meta_test.go
@@ -83,6 +83,78 @@ func TestFetchPRMetaRunnerError(t *testing.T) {
 		t.Fatal("expected error when runner fails")
 	}
 	assertContains(t, err, "fetch PR #999")
+	assertContains(t, err, "To fix:")
+}
+
+func TestFetchPRMetaRunnerErrorClassifier(t *testing.T) {
+	tests := []struct {
+		name       string
+		runErr     string
+		wantSubstr string
+	}{
+		{
+			name:       "404 error routes to PR number hint",
+			runErr:     "HTTP 404: Not Found",
+			wantSubstr: "verify PR number and repo access",
+		},
+		{
+			name:       "could not resolve routes to PR number hint",
+			runErr:     "Could not resolve to a Repository",
+			wantSubstr: "verify PR number and repo access",
+		},
+		{
+			name:       "rate limit routes to token hint",
+			runErr:     "API rate limit exceeded",
+			wantSubstr: "GitHub API rate limit hit",
+		},
+		{
+			name:       "generic error routes to auth hint",
+			runErr:     "connection refused",
+			wantSubstr: "gh auth status",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &mockRunner{
+				run: func(_ context.Context, _ ...string) ([]byte, error) {
+					return nil, errors.New(tt.runErr)
+				},
+			}
+			_, err := FetchPRMeta(context.Background(), r, 1)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			assertContains(t, err, tt.wantSubstr)
+		})
+	}
+}
+
+func TestFetchPRMetaShapeErrorsHaveGhHint(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+	}{
+		{"empty response", `{}`},
+		{"missing owner", `{"headRefName":"main","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":""}}`},
+		{"missing repo", `{"headRefName":"main","headRepository":{"name":""},"headRepositoryOwner":{"login":"alice"}}`},
+		{"unsafe owner", `{"headRefName":"main","headRepository":{"name":"repo"},"headRepositoryOwner":{"login":"alice;rm -rf /"}}`},
+		{"unsafe repo", `{"headRefName":"main","headRepository":{"name":"repo$(whoami)"},"headRepositoryOwner":{"login":"alice"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &mockRunner{
+				run: func(_ context.Context, _ ...string) ([]byte, error) {
+					return []byte(tt.json), nil
+				},
+			}
+			_, err := FetchPRMeta(context.Background(), r, 1)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			assertContains(t, err, "To fix:")
+			assertContains(t, err, "update gh")
+		})
+	}
 }
 
 func TestFetchPRMetaInvalidJSON(t *testing.T) {

--- a/internal/gh/pr_status.go
+++ b/internal/gh/pr_status.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
+	"github.com/lugassawan/rimba/internal/errhint"
 )
 
 // CIStatus is the aggregated CI rollup state for a PR.
@@ -59,7 +61,10 @@ func QueryPRStatus(ctx context.Context, r Runner, branch string) (PRStatus, erro
 	}
 	var entries []prListEntry
 	if err := json.Unmarshal(out, &entries); err != nil {
-		return PRStatus{}, fmt.Errorf("parse gh pr list: %w", err)
+		return PRStatus{}, errhint.WithFix(
+			fmt.Errorf("parse gh pr list: %w", err),
+			"check gh CLI version: gh --version, and update if older than 2.40",
+		)
 	}
 	if len(entries) == 0 {
 		return PRStatus{}, nil

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -5,7 +5,11 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/lugassawan/rimba/internal/errhint"
 )
+
+const internalGitInvariantHint = "report this — git output unexpectedly malformed"
 
 // BranchExists checks whether a local branch exists.
 func BranchExists(r Runner, branch string) bool {
@@ -118,21 +122,33 @@ func LastCommitTime(r Runner, branch string) (time.Time, error) {
 func LastCommitInfo(r Runner, branch string) (time.Time, string, error) {
 	out, err := r.Run("log", "-1", "--format=%ct\t%s", branch)
 	if err != nil {
-		return time.Time{}, "", fmt.Errorf("last commit info for %s: %w", branch, err)
+		return time.Time{}, "", errhint.WithFix(
+			fmt.Errorf("last commit info for %s: %w", branch, err),
+			"verify the branch exists: git branch --list <branch>",
+		)
 	}
 	out = strings.TrimSpace(out)
 	if out == "" {
-		return time.Time{}, "", fmt.Errorf("no commits on branch %s", branch)
+		return time.Time{}, "", errhint.WithFix(
+			fmt.Errorf("no commits on branch %s", branch),
+			"add a commit on the branch before running this",
+		)
 	}
 
 	tsStr, subject, found := strings.Cut(out, "\t")
 	if !found {
-		return time.Time{}, "", fmt.Errorf("malformed commit info %q", out)
+		return time.Time{}, "", errhint.WithFix(
+			fmt.Errorf("malformed commit info %q", out),
+			internalGitInvariantHint,
+		)
 	}
 
 	ts, err := strconv.ParseInt(tsStr, 10, 64)
 	if err != nil {
-		return time.Time{}, "", fmt.Errorf("parse commit timestamp %q: %w", tsStr, err)
+		return time.Time{}, "", errhint.WithFix(
+			fmt.Errorf("parse commit timestamp %q: %w", tsStr, err),
+			internalGitInvariantHint,
+		)
 	}
 	return time.Unix(ts, 0), subject, nil
 }

--- a/internal/git/commit_count.go
+++ b/internal/git/commit_count.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/lugassawan/rimba/internal/errhint"
 )
 
 // CommitCountSince counts commits on branch within the last `since`
@@ -21,12 +23,18 @@ func CommitCountSince(r Runner, branch string, since time.Duration) (int, error)
 		branch,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("commit count since for %s: %w", branch, err)
+		return 0, errhint.WithFix(
+			fmt.Errorf("commit count since for %s: %w", branch, err),
+			"verify the branch exists: git branch --list <branch>",
+		)
 	}
 
 	n, err := strconv.Atoi(strings.TrimSpace(out))
 	if err != nil {
-		return 0, fmt.Errorf("parse commit count %q: %w", out, err)
+		return 0, errhint.WithFix(
+			fmt.Errorf("parse commit count %q: %w", out, err),
+			internalGitInvariantHint,
+		)
 	}
 	return n, nil
 }

--- a/internal/git/mock_runner_test.go
+++ b/internal/git/mock_runner_test.go
@@ -406,6 +406,8 @@ func TestDefaultBranchNotFound(t *testing.T) {
 		t.Fatal("expected error when no default branch found")
 	}
 	assertContains(t, err, "could not detect default branch")
+	assertContains(t, err, "To fix:")
+	assertContains(t, err, "git branch -M main")
 }
 
 func TestHooksDirError(t *testing.T) {
@@ -486,6 +488,8 @@ func TestRepoRootError(t *testing.T) {
 		t.Fatal("expected error from RepoRoot")
 	}
 	assertContains(t, err, errNotAGitRepo)
+	assertContains(t, err, "To fix:")
+	assertContains(t, err, "git init")
 }
 
 func TestHooksDirRelativePathRepoRootError(t *testing.T) {
@@ -882,6 +886,7 @@ func TestLastCommitInfoRunError(t *testing.T) {
 		t.Fatal("expected error from runner failure")
 	}
 	assertContains(t, err, "last commit info")
+	assertContains(t, err, "To fix:")
 }
 
 func TestLocalBranchesError(t *testing.T) {

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -5,7 +5,11 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/lugassawan/rimba/internal/errhint"
 )
+
+const notInRepoHint = "run from inside a git repository, or run: git init"
 
 const (
 	refsHeadsPrefix = "refs/heads/"
@@ -22,7 +26,7 @@ const (
 func RepoRoot(r Runner) (string, error) {
 	out, err := r.Run(cmdRevParse, "--show-toplevel")
 	if err != nil {
-		return "", fmt.Errorf("not a git repository: %w", err)
+		return "", errhint.WithFix(fmt.Errorf("not a git repository: %w", err), notInRepoHint)
 	}
 	return out, nil
 }
@@ -93,7 +97,10 @@ func DefaultBranch(r Runner) (string, error) {
 		return "master", nil
 	}
 
-	return "", errors.New("could not detect default branch (no main or master found)")
+	return "", errhint.WithFix(
+		errors.New("could not detect default branch (no main or master found)"),
+		"set the default branch: git branch -M main",
+	)
 }
 
 // resolveCommonDir returns the absolute path to the git common directory.
@@ -101,7 +108,7 @@ func DefaultBranch(r Runner) (string, error) {
 func resolveCommonDir(r Runner) (string, error) {
 	commonDir, err := r.Run(cmdRevParse, "--git-common-dir")
 	if err != nil {
-		return "", fmt.Errorf("not a git repository: %w", err)
+		return "", errhint.WithFix(fmt.Errorf("not a git repository: %w", err), notInRepoHint)
 	}
 
 	if !filepath.IsAbs(commonDir) {

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -3,6 +3,8 @@ package git
 import (
 	"fmt"
 	"strings"
+
+	"github.com/lugassawan/rimba/internal/errhint"
 )
 
 const (
@@ -124,7 +126,10 @@ func Prune(r Runner, dryRun bool) (string, error) {
 	}
 	out, err := r.Run(args...)
 	if err != nil {
-		return "", fmt.Errorf("prune: %w", err)
+		return "", errhint.WithFix(
+			fmt.Errorf("prune: %w", err),
+			"check repo permissions, then run: git worktree list",
+		)
 	}
 	return out, nil
 }

--- a/internal/operations/add_pr_worktree.go
+++ b/internal/operations/add_pr_worktree.go
@@ -36,7 +36,7 @@ func AddPRWorktree(
 	progress.Notify(onProgress, fmt.Sprintf("Fetching PR #%d metadata...", params.PRNumber))
 	meta, err := gh.FetchPRMeta(ctx, ghR, params.PRNumber)
 	if err != nil {
-		return AddResult{}, errhint.WithFix(err, "verify PR number and repo access")
+		return AddResult{}, err
 	}
 
 	task := params.TaskOverride

--- a/internal/operations/add_pr_worktree_test.go
+++ b/internal/operations/add_pr_worktree_test.go
@@ -196,7 +196,7 @@ func TestAddPRWorktreeFetchPRMetaFailure(t *testing.T) {
 			if len(args) > 0 && args[0] == ghArgAuth {
 				return []byte("Logged in"), nil
 			}
-			return nil, errors.New("PR not found")
+			return nil, errors.New("HTTP 404: Not Found")
 		},
 	}
 	gitR := &mockRunner{

--- a/internal/operations/clean.go
+++ b/internal/operations/clean.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/progress"
 )
@@ -46,7 +47,10 @@ type StaleResult struct {
 func FindMergedCandidates(r git.Runner, mergeRef, mainBranch string) (MergedResult, error) {
 	mergedList, err := git.MergedBranches(r, mergeRef)
 	if err != nil {
-		return MergedResult{}, fmt.Errorf("failed to list merged branches: %w", err)
+		return MergedResult{}, errhint.WithFix(
+			fmt.Errorf("failed to list merged branches: %w", err),
+			"check that the main branch exists: git branch --list main",
+		)
 	}
 
 	mergedSet := make(map[string]bool, len(mergedList))

--- a/internal/operations/operations.go
+++ b/internal/operations/operations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/resolver"
 )
@@ -57,7 +58,10 @@ func FindWorktree(r git.Runner, service, task string) (resolver.WorktreeInfo, er
 				return resolver.WorktreeInfo{}, ambiguityError(task, matches)
 			}
 		}
-		return resolver.WorktreeInfo{}, fmt.Errorf(ErrWorktreeNotFoundFmt, task)
+		return resolver.WorktreeInfo{}, errhint.WithFix(
+			fmt.Errorf(ErrWorktreeNotFoundFmt, task),
+			"run: rimba list  to see available worktrees",
+		)
 	}
 	return wt, nil
 }

--- a/internal/operations/operations_test.go
+++ b/internal/operations/operations_test.go
@@ -77,8 +77,15 @@ func TestFindWorktree(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		if _, err := FindWorktree(r, "", "nonexistent"); err == nil {
+		_, err := FindWorktree(r, "", "nonexistent")
+		if err == nil {
 			t.Fatal("expected error for missing worktree")
+		}
+		if !strings.Contains(err.Error(), "To fix:") {
+			t.Errorf("worktree-not-found error missing hint, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "rimba list") {
+			t.Errorf("worktree-not-found error missing 'rimba list' hint, got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Apply `errhint.WithFix` to all user-facing errors in `cmd/*`, `internal/gh/*`, `internal/operations/*`, and `internal/git/*` that were missing actionable hints
- Add `classifyFetchPRErr` helper in `pr_meta.go` to distinguish 404 / rate-limit / network errors with context-specific hints; remove now-redundant outer wrap in `add_pr_worktree.go`
- Introduce shared `notInRepoHint` constant in `git/repo.go` and `internalGitInvariantHint` constant in `git/branch.go` to keep error voice consistent across leaf sites

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] Hint-presence assertions added for highest-traffic paths: `cmd/exec.go` no-selector, `internal/gh/pr_meta.go` classifier branches, `internal/operations/operations.go` worktree-not-found, `internal/git/repo.go` not-a-git-repository

Closes #148