### PR TITLE
[docs] update user-facing documentation for v1.8.1→HEAD features (#150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,15 @@ rimba remove my-feature
 
 | Command | Description |
 |---------|-------------|
-| `rimba init` | Initialize rimba in the current repository |
-| `rimba add <task>` | Create a new worktree with auto-prefixed branch (`service/task` for monorepos) |
+| `rimba init` | Initialize rimba in the current repo; with `--agents` / `-g` also installs agent files and registers MCP server |
+| `rimba add <task>` | Create a new worktree with auto-prefixed branch (`service/task` for monorepos), or `pr:<num>` to create one from a GitHub PR |
 | `rimba remove <task>` | Remove a worktree and delete its branch |
 | `rimba rename <old> <new>` | Rename a worktree's task, branch, and directory |
 | `rimba duplicate <task>` | Create a copy of an existing worktree |
 | `rimba archive <task>` | Archive a worktree (remove directory, keep branch) |
 | `rimba restore <task>` | Restore an archived worktree from its preserved branch |
 | `rimba list` | List worktrees (compact by default; `--full` for all columns) |
-| `rimba status` | Show worktree dashboard with summary stats and age info |
+| `rimba status` | Show worktree dashboard; `--detail` adds disk size, 7-day commit velocity, and disk-footprint summary |
 | `rimba log` | Show last commit from each worktree, sorted by recency |
 | `rimba open <task>` | Open a worktree or run a command inside it |
 | `rimba merge <task>` | Merge a worktree branch into main or another worktree |
@@ -138,6 +138,16 @@ agent = 'claude'
 ```
 
 > See [docs/configuration.md](docs/configuration.md) for the full field reference, dependency management, and environment variables.
+
+Running `rimba init --agents` or `rimba init -g` additionally creates or patches MCP server config files in client tools (`.mcp.json`, `.cursor/mcp.json`, `~/.claude/settings.json`, and others). See [docs/configuration.md#mcp-server-registration](docs/configuration.md#mcp-server-registration) for the full list of patched files and entry format.
+
+## Global flags
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output in JSON (where supported: `list`, `status`, `deps status`, `conflict-check`, `exec`) |
+| `--no-color` | Disable colored output (also respects `NO_COLOR`) |
+| `--debug` | Log git commands and timings to stderr (also respects `RIMBA_DEBUG=1`) |
 
 ## Troubleshooting
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -32,8 +32,20 @@ var newGHRunner = gh.Default
 var addCmd = &cobra.Command{
 	Use:   "add <task|pr:<num>> or add <service>/<task>",
 	Short: "Create a new worktree for a task or GitHub PR",
-	Long:  "Create a worktree, copy files, install dependencies, and run hooks.\nUse <service>/<task> to scope to a specific service in a monorepo.\nUse pr:<num> to create a worktree from a GitHub PR's head branch.",
-	Args:  cobra.ExactArgs(1),
+	Long: `Create a worktree, copy files, install dependencies, and run hooks.
+Use <service>/<task> to scope to a specific service in a monorepo.
+Use pr:<num> to create a worktree from a GitHub PR's head branch.
+
+  rimba add my-feature
+  rimba add my-feature --bugfix          # Use bugfix/ prefix
+  rimba add auth-api/my-feature          # Monorepo service scope
+  rimba add pr:123                       # Create worktree from PR #123
+  rimba add pr:123 --task review/auth    # Override auto-derived task name
+
+pr:<num> requires gh installed and authenticated. For cross-fork PRs, rimba adds a
+gh-fork-<owner> remote automatically. Without --task, the task name is derived as
+review/<num>-<slug>. The --task flag is only valid in pr:<num> mode.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.FromContext(cmd.Context())
 

--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -10,6 +11,61 @@ import (
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/spf13/cobra"
 )
+
+var completionCmd = &cobra.Command{
+	Use:         "completion <bash|zsh|fish|powershell>",
+	Short:       "Generate shell completion scripts",
+	ValidArgs:   []string{"bash", "zsh", "fish", "powershell"},
+	Args:        cobra.ExactArgs(1),
+	Annotations: map[string]string{"skipConfig": "true"},
+	Long: `Generate shell completion scripts for rimba.
+
+Bash:
+  # Load for the current session:
+  source <(rimba completion bash)
+
+  # Install permanently (Linux):
+  rimba completion bash > /etc/bash_completion.d/rimba
+
+  # Install permanently (macOS with Homebrew bash-completion@2):
+  rimba completion bash > "$(brew --prefix)/etc/bash_completion.d/rimba"
+
+Zsh:
+  # Load for the current session:
+  source <(rimba completion zsh)
+
+  # Install permanently:
+  rimba completion zsh > "${fpath[1]}/_rimba"
+
+Fish:
+  rimba completion fish > ~/.config/fish/completions/rimba.fish
+
+PowerShell:
+  rimba completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session:
+  rimba completion powershell > rimba.ps1
+  # then source rimba.ps1 from your PowerShell profile`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+		switch args[0] {
+		case "bash":
+			return cmd.Root().GenBashCompletionV2(out, true)
+		case "zsh":
+			return cmd.Root().GenZshCompletion(out)
+		case "fish":
+			return cmd.Root().GenFishCompletion(out, true)
+		case "powershell":
+			return cmd.Root().GenPowerShellCompletionWithDesc(out)
+		default:
+			return fmt.Errorf("unsupported shell %q: choose bash, zsh, fish, or powershell", args[0])
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}
 
 // completeWorktreeTasks returns task names for shell completion.
 func completeWorktreeTasks(_ *cobra.Command, toComplete string) []string {

--- a/cmd/completions_test.go
+++ b/cmd/completions_test.go
@@ -367,6 +367,32 @@ func TestCompleteArchivedTasks(t *testing.T) {
 	})
 }
 
+func TestCompletionCmd(t *testing.T) {
+	shells := []string{"bash", "zsh", "fish", "powershell"}
+	for _, shell := range shells {
+		t.Run(shell, func(t *testing.T) {
+			cmd, out := newTestCmd()
+			cmd.AddCommand(completionCmd)
+			cmd.SetArgs([]string{"completion", shell})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("completion %s: unexpected error: %v", shell, err)
+			}
+			if out.Len() == 0 {
+				t.Errorf("completion %s: expected non-empty output", shell)
+			}
+		})
+	}
+
+	t.Run("invalid shell", func(t *testing.T) {
+		cmd, _ := newTestCmd()
+		cmd.AddCommand(completionCmd)
+		cmd.SetArgs([]string{"completion", "fish2"})
+		if err := cmd.Execute(); err == nil {
+			t.Fatal("expected error for unsupported shell, got nil")
+		}
+	})
+}
+
 func TestCompleteArchivedTasksError(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -43,7 +43,13 @@ Use -g --uninstall to remove user-level files, --agents --uninstall for project-
 or --agents --local --uninstall for project-local files.
 Use --personal to gitignore the entire .rimba/ directory instead of just the local
 config file. In personal mode, settings.local.toml is not created since the whole
-directory is already personal.`,
+directory is already personal.
+
+When --agents or -g is used, rimba also registers itself as an MCP server (server name:
+rimba, command: rimba mcp) in client config files (.mcp.json, .cursor/mcp.json,
+~/.claude/settings.json, ~/.codex/config.toml, ~/.gemini/settings.json,
+~/.codeium/windsurf/mcp_config.json, ~/.roo/mcp.json). --agents --local does not
+register MCP — it only updates agent files. Registration is idempotent.`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		m := initModeFromFlags(cmd)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -31,7 +31,20 @@ const (
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all worktrees",
-	Long:  "Lists all git worktrees with task, type, and status. Use --full to show branch, path, and (when gh is installed and authenticated) PR number and CI rollup.",
+	Long: `Lists all git worktrees with task, type, and status.
+
+Use --full to show branch, path, and (when gh is installed and authenticated) PR number
+and CI rollup. CI symbols: ✓ success · ● pending · ✗ failure · – unknown.
+
+  rimba list                     # Compact view
+  rimba list --full              # All columns including PR/CI
+  rimba list --type bugfix       # Filter by prefix type
+  rimba list --service auth-api  # Filter by service (monorepo)
+  rimba list --dirty             # Only worktrees with uncommitted changes
+  rimba list --behind            # Only worktrees behind upstream
+  rimba list --archived          # Archived branches (no active worktree)
+
+--archived is mutually exclusive with --type, --dirty, --behind, and --full.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := listReadFlags(cmd)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,8 +31,15 @@ const (
 var commandName string
 
 var rootCmd = &cobra.Command{
-	Use:           "rimba",
-	Short:         "Manage git worktrees — create, sync, merge, and organize branches",
+	Use:   "rimba",
+	Short: "Manage git worktrees — create, sync, merge, and organize branches",
+	Long: `rimba is a git worktree manager. It creates, syncs, merges, and organizes
+branches as isolated worktrees so you can work on multiple tasks in parallel.
+
+Persistent flags (available on every command):
+  --json      Output in JSON format (where supported)
+  --no-color  Disable colored output (also respects NO_COLOR)
+  --debug     Log git commands and timings to stderr (also respects RIMBA_DEBUG=1)`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
@@ -86,6 +93,8 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
 	rootCmd.PersistentFlags().Bool(flagJSON, false, "output in JSON format")
 	rootCmd.PersistentFlags().Bool(flagNoColor, false, "disable colored output")
 	rootCmd.PersistentFlags().Bool(flagDebug, false, "Log git commands and timings to stderr")

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -16,9 +16,18 @@ import (
 )
 
 var statusCmd = &cobra.Command{
-	Use:         "status",
-	Short:       "Show worktree dashboard with summary stats and age info",
-	Long:        "Displays a summary of all worktrees including total count, dirty, stale, and behind counts, plus per-worktree age information.",
+	Use:   "status",
+	Short: "Show worktree dashboard with summary stats and age info",
+	Long: `Displays a summary of all worktrees including total count, dirty, stale, and behind counts,
+plus per-worktree age information.
+
+Use --detail to add SIZE and 7D columns and a disk-footprint summary line. SIZE is the
+on-disk footprint of the worktree directory; 7D is the number of commits on the branch
+in the last 7 days. With --detail, rows are sorted largest-first.
+
+  rimba status
+  rimba status --detail          # Add SIZE/7D columns and disk summary
+  rimba status --stale-days 7    # Consider worktrees stale after 7 days`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -13,9 +13,16 @@ import (
 )
 
 var updateCmd = &cobra.Command{
-	Use:         "update",
-	Short:       "Update rimba to the latest version",
-	Long:        "Check for the latest release on GitHub and update the binary in place.",
+	Use:   "update",
+	Short: "Update rimba to the latest version",
+	Long: `Check for the latest release on GitHub and update the binary in place.
+
+If the current binary cannot be replaced due to file permissions, rimba installs the
+new version to ~/.local/bin instead and prints the path.
+
+After a successful update, rimba prints a one-line tip if agent files are installed at
+user level (run rimba init -g to refresh) or in this repo (run rimba init --agents to
+refresh). Set RIMBA_QUIET=1 to suppress the tip.`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		force, _ := cmd.Flags().GetBool("force")

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,6 +12,7 @@ These flags are available on every command via the root `rimba` command:
 |------|-------------|
 | `--json` | Output in JSON format (supported by `list`, `status`, `deps status`, `conflict-check`, `exec`) |
 | `--no-color` | Disable colored output (also respects `NO_COLOR` env var) |
+| `--debug` | Log git commands and timings to stderr (also respects `RIMBA_DEBUG=1`) |
 
 ---
 
@@ -19,19 +20,40 @@ These flags are available on every command via the root `rimba` command:
 
 ### rimba init
 
-Initialize rimba in the current repository. Detects the repo root, creates the `.rimba/` config directory with `settings.toml` (team-shared) and `settings.local.toml` (personal overrides), and sets up the worktree directory. Use `--agent-files` to also install AI agent instruction files (`AGENTS.md`, `.github/copilot-instructions.md`, `.cursor/rules/rimba.mdc`, `.claude/skills/rimba/SKILL.md`).
+Initialize rimba in the current repository. Detects the repo root, creates the `.rimba/` config directory with `settings.toml` (team-shared) and `settings.local.toml` (personal overrides), and sets up the worktree directory.
 
-If `.rimba/` already exists, config creation is skipped but agent files are still installed or updated when `--agent-files` is passed. If a legacy `.rimba.toml` exists, it is migrated into the new directory layout.
+Agent files (`AGENTS.md`, `.github/copilot-instructions.md`, `.cursor/rules/rimba.mdc`, `.claude/skills/rimba/SKILL.md`) are installed at three tiers:
+
+- `--agents` — project-team level (committed to git)
+- `--agents --local` — project-personal level (gitignored)
+- `-g` / `--global` — user level (`~/`) — works outside a git repository
+
+When agent files are installed (`--agents` or `-g`), rimba also registers itself as an MCP server (server name: `rimba`, command: `rimba mcp`) in the corresponding client config files (`.mcp.json`, `.cursor/mcp.json`, `~/.claude/settings.json`, `~/.codex/config.toml`, `~/.gemini/settings.json`, `~/.codeium/windsurf/mcp_config.json`, `~/.roo/mcp.json`). Use `--uninstall` with the same flags to remove.
+
+If `.rimba/` already exists, config creation is skipped but agent files are still installed or updated. If a legacy `.rimba.toml` exists, it is migrated into the new directory layout.
 
 ```sh
-rimba init                  # Initialize config and worktree directory
-rimba init --agent-files    # Also install AI agent instruction files
+rimba init                        # Initialize config and worktree directory
+rimba init --agents               # Also install agent files at project level (committed)
+rimba init --agents --local       # Install agent files gitignored (personal)
+rimba init -g                     # Install agent files at user level (~/)
+rimba init -g --uninstall         # Remove user-level agent files and MCP registration
+rimba init --agents --uninstall   # Remove project-team agent files and MCP registration
 ```
+
+> **Notes:**
+> - `--local` is not allowed with `-g`.
+> - `--local` without `--agents` errors with: `--local requires --agents`.
+> - `--uninstall` requires `-g` or `--agents`.
+> - `-g` / `--global` and `--agents` are mutually exclusive.
 
 | Flag | Description |
 |------|-------------|
-| `--agent-files` | Install AI agent instruction files (AGENTS.md, copilot, cursor, claude) |
-| `--personal` | Gitignore the entire `.rimba/` directory instead of just the local config file (for solo developers) |
+| `--agents` | Install AI agent instruction files at project level |
+| `-g`, `--global` | Install agent files at user level (`~/`) — works outside a git repo |
+| `--local` | Install agent files gitignored (personal overrides; requires `--agents`) |
+| `--uninstall` | Remove agent files and MCP registration (requires `-g` or `--agents`) |
+| `--personal` | Gitignore the entire `.rimba/` directory instead of just the local config file |
 
 ---
 
@@ -39,7 +61,7 @@ rimba init --agent-files    # Also install AI agent instruction files
 
 ### rimba add
 
-Create a new worktree with a branch named `<prefix><task>` and copy dotfiles from the repo root. In monorepos, prefix the task with a service directory name to create service-scoped branches.
+Create a new worktree with a branch named `<prefix><task>` and copy dotfiles from the repo root. In monorepos, prefix the task with a service directory name to create service-scoped branches. Use `pr:<num>` to create a worktree from a GitHub PR's head branch.
 
 ```sh
 rimba add my-feature
@@ -47,9 +69,13 @@ rimba add my-feature --bugfix        # Use bugfix/ prefix instead of feature/
 rimba add my-feature -s develop      # Branch from a different source
 rimba add auth-api/my-feature        # Monorepo: branch auth-api/feature/my-feature
 rimba add auth-api/my-feature --bugfix  # Monorepo: branch auth-api/bugfix/my-feature
+rimba add pr:123                     # Create worktree from PR #123's head branch
+rimba add pr:123 --task review/auth-tweak  # Override auto-derived task name
 ```
 
 > **Monorepo:** If the first segment before `/` matches a directory in the repo root, rimba treats it as a service scope. The branch uses a 3-segment pattern: `<service>/<prefix>/<task>`. No configuration needed — detection is automatic.
+
+> **PR mode:** `pr:<num>` requires `gh` to be installed and authenticated. For cross-fork PRs, rimba adds a `gh-fork-<owner>` remote automatically. Without `--task`, the task name is derived as `review/<num>-<slug>`.
 
 | Flag | Description |
 |------|-------------|
@@ -59,6 +85,7 @@ rimba add auth-api/my-feature --bugfix  # Monorepo: branch auth-api/bugfix/my-fe
 | `--test` | Use `test/` branch prefix |
 | `--chore` | Use `chore/` branch prefix |
 | `-s`, `--source` | Source branch to create worktree from (default from config) |
+| `--task` | Override auto-derived task name (`pr:<num>` mode only) |
 | `--skip-deps` | Skip dependency detection and installation |
 | `--skip-hooks` | Skip post-create hooks |
 
@@ -141,11 +168,11 @@ rimba restore my-feature
 
 ### rimba list
 
-List all worktrees with task, type, and status. Use `--full` to show all columns including branch and path. The current worktree is marked with `*`.
+List all worktrees with task, type, and status. Use `--full` to show all columns including branch, path, and (when `gh` is installed and authenticated) PR number and CI rollup. The current worktree is marked with `*`.
 
 ```sh
 rimba list
-rimba list --full               # Show all columns (branch, path)
+rimba list --full               # Show all columns (branch, path, PR, CI)
 rimba list --type bugfix        # Show only bugfix worktrees
 rimba list --dirty              # Show only dirty worktrees
 rimba list --behind             # Show only worktrees behind upstream
@@ -166,15 +193,19 @@ TASK            TYPE     STATUS
 Example output with `--full`:
 
 ```
-TASK            TYPE     BRANCH              PATH              STATUS
-* auth-flow     feature  feature/auth-flow   feature-auth-flow [dirty]
-  fix-login     bugfix   bugfix/fix-login    bugfix-fix-login  ↑2 ↓1
-  ui-cleanup    chore    chore/ui-cleanup    chore-ui-cleanup  ✓
+TASK            TYPE     BRANCH              PATH               STATUS    PR     CI
+* auth-flow     feature  feature/auth-flow   feature-auth-flow  [dirty]   #142   ✓
+  fix-login     bugfix   bugfix/fix-login    bugfix-fix-login   ↑2 ↓1     #138   ●
+  ui-cleanup    chore    chore/ui-cleanup    chore-ui-cleanup   ✓         –      –
 ```
+
+> **PR/CI columns:** Require `gh` installed and authenticated; otherwise a yellow warning is printed and those cells render as `–`. CI symbols: ✓ success · ● pending · ✗ failure · – unknown.
+
+> **Note:** `--archived` is mutually exclusive with `--type`, `--dirty`, `--behind`, and `--full`.
 
 | Flag | Description |
 |------|-------------|
-| `--full` | Show all columns including branch and path |
+| `--full` | Show all columns including branch, path, and PR/CI (when `gh` is available) |
 | `--type` | Filter by prefix type (e.g. `feature`, `bugfix`, `hotfix`, `docs`, `test`, `chore`) |
 | `--dirty` | Show only worktrees with uncommitted changes |
 | `--behind` | Show only worktrees behind their upstream branch |
@@ -183,10 +214,11 @@ TASK            TYPE     BRANCH              PATH              STATUS
 
 ### rimba status
 
-Show a worktree dashboard with summary stats (total, dirty, stale, behind) and per-worktree age information.
+Show a worktree dashboard with summary stats (total, dirty, stale, behind) and per-worktree age information. Use `--detail` to also show disk size, 7-day commit velocity, and a disk-footprint summary line.
 
 ```sh
 rimba status
+rimba status --detail           # Add SIZE and 7D columns; sort by disk size (largest first)
 rimba status --stale-days 7     # Consider worktrees stale after 7 days
 rimba status --json             # Output as JSON
 ```
@@ -203,8 +235,24 @@ TASK          TYPE     BRANCH              STATUS    AGE
   payments    feature  feature/payments    ✓         3d
 ```
 
+Example output with `--detail`:
+
+```
+Worktrees: 4  Dirty: 1  Stale: 1  Behind: 0
+Disk: total 1.2 GB  (main: 480 MB, worktrees: 720 MB)
+
+TASK          TYPE     BRANCH              STATUS    AGE   SIZE    7D
+  auth-flow   feature  feature/auth-flow   [dirty]   2d    310 MB  4
+  payments    feature  feature/payments    ✓         3d    220 MB  1
+  fix-login   bugfix   bugfix/fix-login    ✓         5h    140 MB  6
+  ui-cleanup  chore    chore/ui-cleanup    ✓         21d   50 MB   0  ⚠ stale
+```
+
+> **Columns:** `SIZE` is the on-disk footprint of the worktree directory. `7D` is the number of commits on the worktree's branch in the last 7 days. `--detail` sorts rows largest-first.
+
 | Flag | Description |
 |------|-------------|
+| `--detail` | Add SIZE and 7D columns; print disk-footprint summary; sort by disk size |
 | `--stale-days` | Number of days after which a worktree is considered stale (default: 14) |
 
 ### rimba log
@@ -532,6 +580,8 @@ rimba update --force     # Also works on dev builds
 | `--force` | Update even if running a development build |
 
 > **Note:** If the binary cannot be replaced due to file permissions, rimba installs to `~/.local/bin` instead.
+
+> **Post-update tips:** After a successful update, rimba prints a one-line tip if agent files are installed at user level (`rimba init -g` to refresh) or in this repo (`rimba init --agents` to refresh). Set `RIMBA_QUIET=1` to suppress.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,3 +101,43 @@ When `auto_detect` is enabled (default), rimba recognizes these lockfiles automa
 | `RIMBA_DEBUG` | Log git command timing to stderr (set to any value, e.g. `RIMBA_DEBUG=1`). The `--debug` flag on any command has the same effect. |
 | `RIMBA_QUIET` | Suppress pre-execution hints (set to any value, e.g. `RIMBA_QUIET=1`) |
 | `NO_COLOR` | Disable colored output globally (per [no-color.org](https://no-color.org)) |
+
+## MCP server registration
+
+When `rimba init --agents` or `rimba init -g` is run, rimba registers itself as an MCP server (server name: `rimba`, command: `rimba mcp`) in client config files alongside the agent instruction files. The registration is idempotent — running the command again updates the entry without duplicating it. `--agents --local` updates agent files only and does **not** register MCP.
+
+### User-level (`rimba init -g`)
+
+Patches the following files in your home directory:
+
+| File | Format |
+|------|--------|
+| `~/.claude/settings.json` | JSON (`mcpServers` object) |
+| `~/.codex/config.toml` | TOML (`[[mcp_servers]]` array) |
+| `~/.gemini/settings.json` | JSON (`mcpServers` object) |
+| `~/.codeium/windsurf/mcp_config.json` | JSON (`mcpServers` object) |
+| `~/.roo/mcp.json` | JSON (`mcpServers` object) |
+
+### Project-level (`rimba init --agents`)
+
+Patches the following files in the repo root:
+
+| File | Format |
+|------|--------|
+| `.mcp.json` | JSON (`mcpServers` object) |
+| `.cursor/mcp.json` | JSON (`mcpServers` object) |
+
+Use `rimba init -g --uninstall` or `rimba init --agents --uninstall` to remove the registration from the corresponding files.
+
+## Validation
+
+Configuration is validated on every command invocation; errors are surfaced together with a `To fix:` hint.
+
+| Field | Error | Fix hint |
+|-------|-------|----------|
+| `worktree_dir` | `worktree_dir must be relative, got "<dir>"` | Set a path relative to the repo root in `.rimba/settings.toml` |
+| `deps.modules[].dir` | `deps.modules[<i>]: dir is empty` | Set `dir = "<path>"` for the module |
+| `deps.modules[].dir` (duplicate) | `deps.modules[<i>]: duplicate dir "<dir>"` | Remove the duplicate `[[deps.modules]]` entry |
+| `deps.modules[].install` | `deps.modules["<dir>"]: install command is empty` | Set `install = "<command>"` for the module |
+| `open.<name>` (empty key) | `open: shortcut name is empty` | Remove the empty-keyed entry under `[open]` |
+| `open.<name>` (path separator) | `open["<name>"]: shortcut name must not contain path separators` | Rename the shortcut to a name without `/` |


### PR DESCRIPTION
## Summary

- Updated `docs/commands.md`: added `--debug` global flag, rewrote `rimba init` section with 3-tier agent model and MCP-registration note, added `pr:<num>` form and `--task` flag to `rimba add`, updated `rimba list` with PR/CI columns and `--archived` mutex note, updated `rimba status` with `--detail`/SIZE/7D columns, updated `rimba update` with post-update tip
- Updated `docs/configuration.md`: added MCP server registration section (user-level and project-level file lists) and validation errors table
- Updated `README.md`: refreshed command-table rows for `init`, `add`, `status`; added MCP paragraph to Configuration section; added new Global flags section before Troubleshooting; updated Cobra `Long` strings for `root`, `init`, `add`, `list`, `status`, `update`
- Added custom `completionCmd` in `cmd/completions.go` with per-shell install instructions (bash/zsh/fish/powershell); disabled Cobra's auto-generated default completion command; added `TestCompletionCmd` in `cmd/completions_test.go`

## Test Plan

- [x] Unit tests pass (`go test ./...` — 1659 passed)
- [x] Linter passes (no issues)
- [x] `go build ./...` succeeds
- [x] All `--help` outputs verified: `rimba`, `rimba init`, `rimba add`, `rimba list`, `rimba status`, `rimba update`, `rimba completion`
- [x] `rimba completion bash` produces a valid bash completion script

Closes #150