### PR TITLE
[docs] Update contributor docs and Command Reference for v1.8.1→HEAD

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,8 @@ See AGENTS.md at the repo root for full rimba documentation.
 ### Key Commands
 
 - `rimba add <task>` — create worktree (`rimba add service/task` for monorepos)
-- `rimba list` / `rimba status` — inspect worktrees (`--service <svc>` to filter)
+- `rimba add pr:<num>` — create worktree from a GitHub PR
+- `rimba list` (`--full` adds PR/CI columns) / `rimba status` (`--detail` adds disk/velocity) — inspect worktrees (`--service <svc>` to filter)
 - `rimba merge <task>` — merge into main and auto-clean up
 - `rimba clean --merged` — remove merged worktrees
 - `rimba exec <cmd>` — run command across all worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,8 @@ curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/insta
 
 | Concern | Commands |
 |---------|----------|
-| Create & navigate | `rimba add <task>` (or `rimba add service/task` for monorepos), `rimba open <task>` |
-| Inspect | `rimba list`, `rimba status`, `rimba log` |
+| Create & navigate | `rimba add <task>` (or `rimba add service/task` for monorepos), `rimba add pr:<num>` (from a GitHub PR), `rimba open <task>` |
+| Inspect | `rimba list` (`--full` adds PR/CI columns), `rimba status` (`--detail` adds disk/velocity), `rimba log` |
 | Sync & merge | `rimba sync [task]`, `rimba merge <task>` |
 | Clean up | `rimba clean --merged`, `rimba archive <task>`, `rimba remove <task>` |
 | Cross-cutting | `rimba exec <cmd>`, `rimba conflict-check`, `rimba deps status` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,37 @@ This convention is enforced locally by git hooks and in CI by PR title validatio
 | `make bench` | Run benchmarks |
 | `make hooks` | Activate git hooks from `.githooks/` |
 
+## Testing
+
+rimba uses a two-tier test layout:
+
+**Unit tests** live next to source under `internal/**/*_test.go` and `cmd/*_test.go`. They run in-process and use mock runners injected through the `git.Runner` / `gh.Runner` interfaces (`cmd/mock_runner_test.go`, `internal/operations/mock_runner_test.go`, `internal/gh/mock_runner_test.go`).
+
+**End-to-end tests** live in `tests/e2e/`. `TestMain` in `tests/e2e/e2e_test.go` builds the binary once with coverage instrumentation (`go build -cover -o … .`) and executes it as a subprocess against a real git repo. Use the `rimba` / `rimbaSuccess` / `rimbaFail` helpers defined in `e2e_test.go:146-203`. Repo-setup helpers come from `testutil/githelper.go` (`NewTestRepo`).
+
+| Target | Runs |
+|--------|------|
+| `make test-short` | Unit tests only |
+| `make test-e2e` | End-to-end tier only |
+| `make test-coverage` | Both tiers, aggregated coverage |
+
+## Adding a Subcommand
+
+Use `cmd/add.go` as the canonical recent reference (added in #138 with the `pr:<num>` variant).
+
+1. Create `cmd/<name>.go`. Declare per-file `flag*` / `hint*` consts at the top.
+2. Declare `var <name>Cmd = &cobra.Command{Use, Short, Long, Args, RunE}`. In `RunE`, read config via `config.FromContext(cmd.Context())`, build a `git.Runner` via `newRunner()`, and (if needed) a `gh.Runner` via the package-level overridable `var newGHRunner = gh.Default` so tests can swap it.
+3. Keep business logic out of `cmd/`. Delegate to `internal/operations/<name>.go` so the same pipeline can back an MCP tool (see `internal/operations.ListWorktrees` / `internal/mcp/tool_list.go`).
+4. Wrap user-facing errors with `errhint.WithFix(err, "<actionable fix>")`.
+5. Bind flags and register the command in `init()` via `rootCmd.AddCommand(<name>Cmd)`.
+6. Add a unit test in `cmd/<name>_test.go` using a mock runner and an e2e test in `tests/e2e/<name>_test.go` using the subprocess helpers.
+
+## Project Conventions
+
+- **`internal/gh`** — thin wrapper around the `gh` CLI (`internal/gh/runner.go` defines the `Runner` interface). Use `gh.Default()` in production; inject a fake in tests. Provides `IsAvailable`, `CheckAuth`, `FetchPRMeta`, `QueryPRStatus`.
+- **`internal/operations.ListWorktrees`** (`internal/operations/list_worktrees.go`) — the shared pipeline behind both `cmd/list.go` and the MCP `list` tool (`internal/mcp/tool_list.go`). Mirror this pattern when adding a subcommand that should also be reachable from MCP.
+- **`internal/errhint.WithFix`** (`internal/errhint/errhint.go`) — wrap user-facing errors with an actionable fix line. Preserves sentinel via `%w`. See `cmd/add.go`, `cmd/exec.go`, `cmd/sync.go` for examples.
+
 ## License
 
 All contributions are licensed under the [MIT](LICENSE) license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Use `cmd/add.go` as the canonical recent reference (added in #138 with the `pr:<
 
 ## Project Conventions
 
-- **`internal/gh`** — thin wrapper around the `gh` CLI (`internal/gh/runner.go` defines the `Runner` interface). Use `gh.Default()` in production; inject a fake in tests. Provides `IsAvailable`, `CheckAuth`, `FetchPRMeta`, `QueryPRStatus`.
+- **`internal/gh`** — thin wrapper around the `gh` CLI. `runner.go` defines the `Runner` interface; package-level helpers: `IsAvailable` (`detect.go`), `CheckAuth` (`auth.go`), `FetchPRMeta` (`pr_meta.go`), `QueryPRStatus` (`pr_status.go`). Use `gh.Default()` in production; inject a fake in tests.
 - **`internal/operations.ListWorktrees`** (`internal/operations/list_worktrees.go`) — the shared pipeline behind both `cmd/list.go` and the MCP `list` tool (`internal/mcp/tool_list.go`). Mirror this pattern when adding a subcommand that should also be reachable from MCP.
 - **`internal/errhint.WithFix`** (`internal/errhint/errhint.go`) — wrap user-facing errors with an actionable fix line. Preserves sentinel via `%w`. See `cmd/add.go`, `cmd/exec.go`, `cmd/sync.go` for examples.
 

--- a/internal/agentfile/content.go
+++ b/internal/agentfile/content.go
@@ -318,7 +318,7 @@ rimba manages parallel git worktrees. Check for ` + "`" + `.rimba/settings.toml`
 
 - ` + "`" + `rimba add <task>` + "`" + ` — create worktree + branch
 - ` + "`" + `rimba add pr:<num>` + "`" + ` — create worktree from a GitHub PR
-- ` + "`" + `rimba list` + "`" + ` (` + "`" + `--full` + "`" + ` adds PR/CI columns) / ` + "`" + `rimba status` + "`" + ` (` + "`" + `--detail` + "`" + ` adds disk/velocity) — inspect worktrees
+- ` + "`" + `rimba list` + "`" + ` (` + "`" + `--full` + "`" + ` adds PR/CI columns) / ` + "`" + `rimba status` + "`" + ` (` + "`" + `--detail` + "`" + ` adds disk/velocity) — inspect worktrees (` + "`" + `--service <svc>` + "`" + ` to filter)
 - ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
 - ` + "`" + `rimba clean --merged` + "`" + ` — remove merged worktrees
 - ` + "`" + `rimba mcp` + "`" + ` — start MCP server for AI tool integration

--- a/internal/agentfile/content.go
+++ b/internal/agentfile/content.go
@@ -27,8 +27,8 @@ curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/insta
 
 | Concern | Commands |
 |---------|----------|
-| Create & navigate | ` + "`" + `rimba add <task>` + "`" + ` (or ` + "`" + `rimba add service/task` + "`" + ` for monorepos), ` + "`" + `rimba open <task>` + "`" + ` |
-| Inspect | ` + "`" + `rimba list` + "`" + `, ` + "`" + `rimba status` + "`" + `, ` + "`" + `rimba log` + "`" + ` |
+| Create & navigate | ` + "`" + `rimba add <task>` + "`" + ` (or ` + "`" + `rimba add service/task` + "`" + ` for monorepos), ` + "`" + `rimba add pr:<num>` + "`" + ` (from a GitHub PR), ` + "`" + `rimba open <task>` + "`" + ` |
+| Inspect | ` + "`" + `rimba list` + "`" + ` (` + "`" + `--full` + "`" + ` adds PR/CI columns), ` + "`" + `rimba status` + "`" + ` (` + "`" + `--detail` + "`" + ` adds disk/velocity), ` + "`" + `rimba log` + "`" + ` |
 | Sync & merge | ` + "`" + `rimba sync [task]` + "`" + `, ` + "`" + `rimba merge <task>` + "`" + ` |
 | Clean up | ` + "`" + `rimba clean --merged` + "`" + `, ` + "`" + `rimba archive <task>` + "`" + `, ` + "`" + `rimba remove <task>` + "`" + ` |
 | Cross-cutting | ` + "`" + `rimba exec <cmd>` + "`" + `, ` + "`" + `rimba conflict-check` + "`" + `, ` + "`" + `rimba deps status` + "`" + ` |
@@ -98,7 +98,8 @@ See AGENTS.md at the repo root for full rimba documentation.
 ### Key Commands
 
 - ` + "`" + `rimba add <task>` + "`" + ` — create worktree (` + "`" + `rimba add service/task` + "`" + ` for monorepos)
-- ` + "`" + `rimba list` + "`" + ` / ` + "`" + `rimba status` + "`" + ` — inspect worktrees (` + "`" + `--service <svc>` + "`" + ` to filter)
+- ` + "`" + `rimba add pr:<num>` + "`" + ` — create worktree from a GitHub PR
+- ` + "`" + `rimba list` + "`" + ` (` + "`" + `--full` + "`" + ` adds PR/CI columns) / ` + "`" + `rimba status` + "`" + ` (` + "`" + `--detail` + "`" + ` adds disk/velocity) — inspect worktrees (` + "`" + `--service <svc>` + "`" + ` to filter)
 - ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
 - ` + "`" + `rimba clean --merged` + "`" + ` — remove merged worktrees
 - ` + "`" + `rimba exec <cmd>` + "`" + ` — run command across all worktrees
@@ -187,8 +188,8 @@ If not found, **ask the user** before installing. Never install automatically.
 
 | Concern | Commands |
 |---------|----------|
-| Create & navigate | ` + "`" + `rimba add <task>` + "`" + `, ` + "`" + `rimba open <task>` + "`" + ` |
-| Inspect | ` + "`" + `rimba list` + "`" + `, ` + "`" + `rimba status` + "`" + ` |
+| Create & navigate | ` + "`" + `rimba add <task>` + "`" + `, ` + "`" + `rimba add pr:<num>` + "`" + ` (from a GitHub PR), ` + "`" + `rimba open <task>` + "`" + ` |
+| Inspect | ` + "`" + `rimba list` + "`" + ` (` + "`" + `--full` + "`" + ` adds PR/CI columns), ` + "`" + `rimba status` + "`" + ` (` + "`" + `--detail` + "`" + ` adds disk/velocity) |
 | Sync & merge | ` + "`" + `rimba sync [task]` + "`" + `, ` + "`" + `rimba merge <task>` + "`" + ` |
 | Clean up | ` + "`" + `rimba clean --merged` + "`" + `, ` + "`" + `rimba archive <task>` + "`" + `, ` + "`" + `rimba remove <task>` + "`" + ` |
 | Cross-cutting | ` + "`" + `rimba exec <cmd>` + "`" + `, ` + "`" + `rimba conflict-check` + "`" + ` |
@@ -316,7 +317,8 @@ rimba manages parallel git worktrees. Check for ` + "`" + `.rimba/settings.toml`
 ### Key Commands
 
 - ` + "`" + `rimba add <task>` + "`" + ` — create worktree + branch
-- ` + "`" + `rimba list` + "`" + ` / ` + "`" + `rimba status` + "`" + ` — inspect worktrees
+- ` + "`" + `rimba add pr:<num>` + "`" + ` — create worktree from a GitHub PR
+- ` + "`" + `rimba list` + "`" + ` (` + "`" + `--full` + "`" + ` adds PR/CI columns) / ` + "`" + `rimba status` + "`" + ` (` + "`" + `--detail` + "`" + ` adds disk/velocity) — inspect worktrees
 - ` + "`" + `rimba merge <task>` + "`" + ` — merge into main and auto-clean up
 - ` + "`" + `rimba clean --merged` + "`" + ` — remove merged worktrees
 - ` + "`" + `rimba mcp` + "`" + ` — start MCP server for AI tool integration
@@ -341,8 +343,8 @@ If not found, **ask the user** before installing. Never install automatically.
 
 | Concern | Commands |
 |---------|----------|
-| Create & navigate | ` + "`" + `rimba add <task>` + "`" + `, ` + "`" + `rimba open <task>` + "`" + ` |
-| Inspect | ` + "`" + `rimba list` + "`" + `, ` + "`" + `rimba status` + "`" + ` |
+| Create & navigate | ` + "`" + `rimba add <task>` + "`" + `, ` + "`" + `rimba add pr:<num>` + "`" + ` (from a GitHub PR), ` + "`" + `rimba open <task>` + "`" + ` |
+| Inspect | ` + "`" + `rimba list` + "`" + ` (` + "`" + `--full` + "`" + ` adds PR/CI columns), ` + "`" + `rimba status` + "`" + ` (` + "`" + `--detail` + "`" + ` adds disk/velocity) |
 | Sync & merge | ` + "`" + `rimba sync [task]` + "`" + `, ` + "`" + `rimba merge <task>` + "`" + ` |
 | Clean up | ` + "`" + `rimba clean --merged` + "`" + `, ` + "`" + `rimba archive <task>` + "`" + ` |
 | AI integration | ` + "`" + `rimba mcp` + "`" + ` (MCP server for AI coding agents) |
@@ -367,8 +369,8 @@ If not found, **ask the user** before installing. Never install automatically.
 
 | Concern | Commands |
 |---------|----------|
-| Create & navigate | ` + "`" + `rimba add <task>` + "`" + `, ` + "`" + `rimba open <task>` + "`" + ` |
-| Inspect | ` + "`" + `rimba list` + "`" + `, ` + "`" + `rimba status` + "`" + ` |
+| Create & navigate | ` + "`" + `rimba add <task>` + "`" + `, ` + "`" + `rimba add pr:<num>` + "`" + ` (from a GitHub PR), ` + "`" + `rimba open <task>` + "`" + ` |
+| Inspect | ` + "`" + `rimba list` + "`" + ` (` + "`" + `--full` + "`" + ` adds PR/CI columns), ` + "`" + `rimba status` + "`" + ` (` + "`" + `--detail` + "`" + ` adds disk/velocity) |
 | Sync & merge | ` + "`" + `rimba sync [task]` + "`" + `, ` + "`" + `rimba merge <task>` + "`" + ` |
 | Clean up | ` + "`" + `rimba clean --merged` + "`" + `, ` + "`" + `rimba archive <task>` + "`" + ` |
 | AI integration | ` + "`" + `rimba mcp` + "`" + ` (MCP server for AI coding agents) |


### PR DESCRIPTION
## Summary

- Extend Command Reference tables in all 6 agent template blocks (`agentsBlock`, `geminiBlock`, `globalCodexBlock`, `globalGeminiBlock`, `copilotBlock`, `globalCopilotBlock`) to document `rimba add pr:<num>`, `rimba list --full`, and `rimba status --detail`
- Regenerate the managed blocks in `AGENTS.md` and `.github/copilot-instructions.md` via `rimba init --agents`
- Insert three new `CONTRIBUTING.md` sections (`## Testing`, `## Adding a Subcommand`, `## Project Conventions`) covering the e2e subprocess test pattern, the canonical subcommand shape (`cmd/add.go`), and the `internal/gh`, `errhint`, and `operations.ListWorktrees` conventions

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] `go test ./internal/agentfile/...` passes (85 tests — block marker/frontmatter assertions intact)
- [x] `git diff AGENTS.md .github/copilot-instructions.md` shows only expected Command Reference additions inside managed block

Closes #151