### PR TITLE
[chore] Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Report a defect in a command, internal package, MCP server, or hook
+title: '[bug] '
+labels: bug
+assignees: ''
+---
+
+## Surface affected
+
+<!-- Check all that apply. -->
+- [ ] Command (`cmd/*`)
+- [ ] Branch / worktree resolver (`internal/resolver/`)
+- [ ] Git operations (`internal/git/`)
+- [ ] Worktree operations / hooks (`internal/operations/`)
+- [ ] MCP server (`internal/mcp/`)
+- [ ] Agent files (`internal/agentfile/`)
+- [ ] Config (`.rimba/settings.toml`)
+- [ ] Documentation
+- [ ] Build / CI / release
+
+**Specific surface** (e.g., `cmd/open.go`, `rimba duplicate`, `internal/resolver`):
+
+## rimba version
+
+<!-- Output of: rimba version -->
+
+## Environment
+
+- OS:
+- Shell:
+- git version:
+
+## Reproduction steps
+
+1.
+2.
+3.
+
+## Expected behavior
+
+## Actual behavior
+
+## Logs / screenshots (optional)
+
+<!-- Re-run with --debug to capture git command logs and timings on stderr. -->

--- a/.github/ISSUE_TEMPLATE/chore_maintenance.md
+++ b/.github/ISSUE_TEMPLATE/chore_maintenance.md
@@ -1,0 +1,30 @@
+---
+name: Chore / maintenance
+about: Documentation update, CI tweak, dependency bump, config change — no new behaviour
+title: '[chore] '
+labels: documentation
+assignees: ''
+---
+
+## Type
+
+<!-- Check all that apply. -->
+- [ ] Documentation (README, docs/, command help text)
+- [ ] CI / workflow (`.github/workflows/`, actions)
+- [ ] Dependency / tooling bump (gomod, lint, goreleaser)
+- [ ] Repository config (templates, Dependabot, labels)
+- [ ] Tests (coverage gaps, e2e, fixtures)
+- [ ] Release / packaging (`.goreleaser.yaml`, `scripts/`)
+
+## Files to change
+
+<!-- List paths or globs. -->
+
+## Description
+
+<!-- What needs to change and why. Include the current state and desired state. -->
+
+## Acceptance
+
+<!-- How will we know this is done? -->
+- [ ]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Installation help
+    url: https://github.com/lugassawan/rimba#install
+    about: Check the README's Install section before opening an issue.
+  - name: Configuration reference
+    url: https://github.com/lugassawan/rimba/blob/main/docs/configuration.md
+    about: docs/configuration.md covers settings.toml, env vars, and prefixes.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature request
+about: Propose a new command, flag, hook, or enhancement
+title: '[feat] '
+labels: enhancement
+assignees: ''
+---
+
+## Goal
+
+<!-- One sentence: what should be possible after this lands? -->
+
+## Motivation
+
+<!-- The problem or workflow gap this solves. -->
+
+## Surface
+
+<!-- Check all surfaces this proposal touches. -->
+- [ ] Command (`cmd/*`)
+- [ ] Branch / worktree resolver (`internal/resolver/`)
+- [ ] Git operations (`internal/git/`)
+- [ ] Worktree operations / hooks (`internal/operations/`)
+- [ ] MCP server (`internal/mcp/`)
+- [ ] Agent files (`internal/agentfile/`)
+- [ ] Config (`.rimba/settings.toml`)
+- [ ] Documentation
+- [ ] Build / CI / release
+
+## Sketch (optional)
+
+<!-- Rough usage example, command invocation, or config snippet. -->
+
+## Acceptance (optional)
+
+<!-- Bulleted checklist: how will we know this is done? -->
+- [ ]


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/` with three structured templates (bug report, feature request, chore/maintenance) adapted for rimba's subsystems
- Adds `config.yml` to disable blank issues and surface docs links
- Templates include rimba-specific surface checklists (`cmd/*`, `internal/resolver/`, `internal/git/`, `internal/operations/`, `internal/mcp/`, `internal/agentfile/`)

N/A

## Test plan

- [ ] Visit `github.com/lugassawan/rimba/issues/new/choose` — three template buttons visible, no blank-issue option
- [ ] `gh api repos/lugassawan/rimba/contents/.github/ISSUE_TEMPLATE` returns 4 files