### PR TITLE
[chore] Surface issue-link line in PR template as a named section

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Installation help
-    url: https://github.com/lugassawan/rimba#install
+    url: https://github.com/lugassawan/rimba#installation
     about: Check the README's Install section before opening an issue.
   - name: Configuration reference
     url: https://github.com/lugassawan/rimba/blob/main/docs/configuration.md

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,8 @@
 - [ ] Linter passes (`make lint`)
 - [ ] E2E tests pass (`make test-e2e`)
 
-<!-- Link to the GitHub issue this PR addresses.
-     Use: Closes #<number>, Fixes #<number>, or Resolves #<number>
-     For ad-hoc changes without an issue, replace with: Issue: N/A -->
+## Issue
+
+<!-- Closes #NNN   /   Fixes #NNN   /   Resolves #NNN -->
+<!-- No issue? Replace the line below with: Issue: N/A  -->
 Closes #


### PR DESCRIPTION
## Summary

- Wraps the `Closes #` line in an `## Issue` heading so it is harder to skip when using `gh pr create --body` (which does not inject the template automatically)
- Moves the opt-out instruction (`Issue: N/A`) into a visible comment above the field rather than buried in prose

Issue: N/A

## Test plan

- [ ] Open a new PR via web UI — `## Issue` section appears with `Closes #` pre-filled