### PR TITLE
[fix] Normalize <service>/<task> in duplicate, rename, restore

### DIFF
--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -49,6 +49,8 @@ var duplicateCmd = &cobra.Command{
 			return err
 		}
 
+		_, task = operations.ResolveTaskInput(task, repoRoot)
+
 		prefixes := resolver.AllPrefixes()
 
 		if wt.Branch == cfg.DefaultSource {
@@ -64,7 +66,7 @@ var duplicateCmd = &cobra.Command{
 		asFlag, _ := cmd.Flags().GetString(flagAs)
 		var newTask string
 		if asFlag != "" {
-			newTask = asFlag
+			_, newTask = operations.ResolveTaskInput(asFlag, repoRoot)
 		} else {
 			// Auto-suffix: try task-1, task-2, etc.
 			for i := 1; i <= maxDuplicateSuffix; i++ {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -39,6 +39,9 @@ var renameCmd = &cobra.Command{
 			return err
 		}
 
+		_, task = operations.ResolveTaskInput(task, repoRoot)
+		_, newTask = operations.ResolveTaskInput(newTask, repoRoot)
+
 		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
 
 		s := spinner.New(spinnerOpts(cmd))

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -25,9 +25,6 @@ var restoreCmd = &cobra.Command{
 		return completeArchivedTasks(cmd, toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		task := args[0]
-		cfg := config.FromContext(cmd.Context())
-
 		r := newRunner()
 
 		repoRoot, err := git.MainRepoRoot(r)
@@ -35,7 +32,10 @@ var restoreCmd = &cobra.Command{
 			return err
 		}
 
-		branch, err := operations.FindArchivedBranch(r, task)
+		service, task := operations.ResolveTaskInput(args[0], repoRoot)
+		cfg := config.FromContext(cmd.Context())
+
+		branch, err := operations.FindArchivedBranch(r, service, task)
 		if err != nil {
 			return err
 		}
@@ -65,13 +65,11 @@ var restoreCmd = &cobra.Command{
 			configModules = cfg.Deps.Modules
 		}
 
-		svc, _, _ := resolver.ServiceFromBranch(branch, resolver.AllPrefixes())
-
 		pcResult, err := operations.PostCreateSetup(r, operations.PostCreateParams{
 			RepoRoot:      repoRoot,
 			WtPath:        wtPath,
 			Task:          task,
-			Service:       svc,
+			Service:       service,
 			CopyFiles:     cfg.CopyFiles,
 			SkipDeps:      skipDeps,
 			AutoDetect:    cfg.IsAutoDetectDeps(),

--- a/internal/operations/archived.go
+++ b/internal/operations/archived.go
@@ -7,10 +7,9 @@ import (
 	"github.com/lugassawan/rimba/internal/resolver"
 )
 
-// FindArchivedBranch finds a branch for the given task that is not associated
-// with any active worktree. It tries prefix+task combinations first, then exact
-// match, then falls back to task extraction.
-func FindArchivedBranch(r git.Runner, task string) (string, error) {
+// FindArchivedBranch finds a branch for the given service+task that is not
+// associated with any active worktree. service may be empty for non-monorepo repos.
+func FindArchivedBranch(r git.Runner, service, task string) (string, error) {
 	branches, err := git.LocalBranches(r)
 	if err != nil {
 		return "", fmt.Errorf("list branches: %w", err)
@@ -23,13 +22,13 @@ func FindArchivedBranch(r git.Runner, task string) (string, error) {
 
 	prefixes := resolver.AllPrefixes()
 
-	if b, ok := searchByPrefixedTask(branches, active, prefixes, task); ok {
+	if b, ok := searchByPrefixedTask(branches, active, prefixes, service, task); ok {
 		return b, nil
 	}
-	if b, ok := searchByExactMatch(branches, active, task); ok {
+	if b, ok := searchByExactMatch(branches, active, service, task); ok {
 		return b, nil
 	}
-	if b, ok := searchByTaskExtraction(branches, active, prefixes, task); ok {
+	if b, ok := searchByTaskExtraction(branches, active, prefixes, service, task); ok {
 		return b, nil
 	}
 
@@ -60,9 +59,10 @@ func ListArchivedBranches(r git.Runner, mainBranch string) ([]string, error) {
 }
 
 // searchByPrefixedTask tries prefix+task combinations against branches.
-func searchByPrefixedTask(branches []string, active map[string]bool, prefixes []string, task string) (string, bool) {
+// For monorepo (service non-empty), candidates include the service segment.
+func searchByPrefixedTask(branches []string, active map[string]bool, prefixes []string, service, task string) (string, bool) {
 	for _, p := range prefixes {
-		candidate := resolver.BranchName(p, task)
+		candidate := resolver.FullBranchName(service, p, task)
 		for _, b := range branches {
 			if b == candidate && !active[b] {
 				return b, true
@@ -73,9 +73,10 @@ func searchByPrefixedTask(branches []string, active map[string]bool, prefixes []
 }
 
 // searchByExactMatch checks if the task name exactly matches an inactive branch.
-func searchByExactMatch(branches []string, active map[string]bool, task string) (string, bool) {
+// For monorepo (service non-empty), also tries service+"/"+task as an exact branch name.
+func searchByExactMatch(branches []string, active map[string]bool, service, task string) (string, bool) {
 	for _, b := range branches {
-		if b == task && !active[b] {
+		if !active[b] && (b == task || (service != "" && b == service+"/"+task)) {
 			return b, true
 		}
 	}
@@ -83,15 +84,23 @@ func searchByExactMatch(branches []string, active map[string]bool, task string) 
 }
 
 // searchByTaskExtraction finds a branch whose extracted task matches the given task.
-func searchByTaskExtraction(branches []string, active map[string]bool, prefixes []string, task string) (string, bool) {
+// For monorepo (service non-empty), also verifies the branch's service segment matches.
+func searchByTaskExtraction(branches []string, active map[string]bool, prefixes []string, service, task string) (string, bool) {
 	for _, b := range branches {
 		if active[b] {
 			continue
 		}
 		t, _ := resolver.PureTaskFromBranch(b, prefixes)
-		if t == task {
-			return b, true
+		if t != task {
+			continue
 		}
+		if service != "" {
+			svc, _, _ := resolver.ServiceFromBranch(b, prefixes)
+			if svc != service {
+				continue
+			}
+		}
+		return b, true
 	}
 	return "", false
 }

--- a/internal/operations/archived_test.go
+++ b/internal/operations/archived_test.go
@@ -10,6 +10,8 @@ const (
 	cmdList         = "list"
 
 	branchListArchived = "main\nfeature/archived-task\nfeature/active-task"
+
+	wtListMainOnly = "worktree /repo\nHEAD abc\nbranch refs/heads/main\n"
 )
 
 func TestFindArchivedBranch(t *testing.T) {
@@ -27,7 +29,7 @@ func TestFindArchivedBranch(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "archived-task")
+	branch, err := FindArchivedBranch(mr, "", "archived-task")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -51,7 +53,7 @@ func TestFindArchivedBranchNotFound(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindArchivedBranch(mr, "nonexistent")
+	_, err := FindArchivedBranch(mr, "", "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for nonexistent archived branch")
 	}
@@ -64,14 +66,14 @@ func TestFindArchivedBranchExactMatch(t *testing.T) {
 			case args[0] == cmdBranch:
 				return "main\nmy-custom-branch", nil
 			case args[0] == cmdWorktreeTest && args[1] == cmdList:
-				return "worktree /repo\nHEAD abc\nbranch refs/heads/main\n", nil
+				return wtListMainOnly, nil
 			}
 			return "", nil
 		},
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "my-custom-branch")
+	branch, err := FindArchivedBranch(mr, "", "my-custom-branch")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -87,14 +89,14 @@ func TestFindArchivedBranchByTaskExtraction(t *testing.T) {
 			case args[0] == cmdBranch:
 				return "main\nbugfix/some-task", nil
 			case args[0] == cmdWorktreeTest && args[1] == cmdList:
-				return "worktree /repo\nHEAD abc\nbranch refs/heads/main\n", nil
+				return wtListMainOnly, nil
 			}
 			return "", nil
 		},
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "some-task")
+	branch, err := FindArchivedBranch(mr, "", "some-task")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -121,7 +123,7 @@ func TestFindArchivedBranchExactMatchSkipsActive(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "my-task")
+	branch, err := FindArchivedBranch(mr, "", "my-task")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -148,7 +150,7 @@ func TestFindArchivedBranchPrefixMatchSkipsActive(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "task-x")
+	branch, err := FindArchivedBranch(mr, "", "task-x")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -175,7 +177,7 @@ func TestFindArchivedBranchSkipsActiveInFallback(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindArchivedBranch(mr, "some-task")
+	_, err := FindArchivedBranch(mr, "", "some-task")
 	if err == nil {
 		t.Fatal("expected error when only matching branch is active")
 	}
@@ -192,7 +194,7 @@ func TestFindArchivedBranchError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindArchivedBranch(mr, "any")
+	_, err := FindArchivedBranch(mr, "", "any")
 	if err == nil {
 		t.Fatal("expected error from LocalBranches failure")
 	}
@@ -212,7 +214,7 @@ func TestFindArchivedBranchWorktreeError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindArchivedBranch(mr, "task")
+	_, err := FindArchivedBranch(mr, "", "task")
 	if err == nil {
 		t.Fatal("expected error from ListWorktrees failure")
 	}
@@ -279,5 +281,95 @@ func TestListArchivedBranchesWorktreeError(t *testing.T) {
 	_, err := ListArchivedBranches(mr, branchMain)
 	if err == nil {
 		t.Fatal("expected error from ListWorktrees failure")
+	}
+}
+
+func TestFindArchivedBranchMonorepoByPrefix(t *testing.T) {
+	mr := &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case args[0] == cmdBranch:
+				return "main\nauth-api/feature/login", nil
+			case args[0] == cmdWorktreeTest && args[1] == cmdList:
+				return wtListMainOnly, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	branch, err := FindArchivedBranch(mr, "auth-api", "login")
+	if err != nil {
+		t.Fatalf("FindArchivedBranch: %v", err)
+	}
+	if branch != "auth-api/feature/login" {
+		t.Errorf("branch = %q, want %q", branch, "auth-api/feature/login")
+	}
+}
+
+func TestFindArchivedBranchMonorepoByTaskExtraction(t *testing.T) {
+	mr := &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case args[0] == cmdBranch:
+				return "main\nauth-api/bugfix/login", nil
+			case args[0] == cmdWorktreeTest && args[1] == cmdList:
+				return wtListMainOnly, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	branch, err := FindArchivedBranch(mr, "auth-api", "login")
+	if err != nil {
+		t.Fatalf("FindArchivedBranch: %v", err)
+	}
+	if branch != "auth-api/bugfix/login" {
+		t.Errorf("branch = %q, want %q", branch, "auth-api/bugfix/login")
+	}
+}
+
+func TestFindArchivedBranchMonorepoWrongServiceNoMatch(t *testing.T) {
+	mr := &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case args[0] == cmdBranch:
+				return "main\nweb-api/feature/login", nil
+			case args[0] == cmdWorktreeTest && args[1] == cmdList:
+				return wtListMainOnly, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	_, err := FindArchivedBranch(mr, "auth-api", "login")
+	if err == nil {
+		t.Fatal("expected error when service does not match")
+	}
+}
+
+func TestFindArchivedBranchNonMonorepoRegression(t *testing.T) {
+	mr := &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case args[0] == cmdBranch:
+				return branchListArchived, nil
+			case args[0] == cmdWorktreeTest && args[1] == cmdList:
+				return "worktree /repo\nHEAD abc\nbranch refs/heads/main\n\n" +
+					"worktree /wt/feature-active-task\nHEAD abc\nbranch refs/heads/feature/active-task\n", nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	branch, err := FindArchivedBranch(mr, "", "archived-task")
+	if err != nil {
+		t.Fatalf("FindArchivedBranch: %v", err)
+	}
+	if branch != "feature/archived-task" {
+		t.Errorf("branch = %q, want %q", branch, "feature/archived-task")
 	}
 }

--- a/tests/e2e/monorepo_test.go
+++ b/tests/e2e/monorepo_test.go
@@ -140,3 +140,80 @@ func TestStandardListNoServiceColumn(t *testing.T) {
 	r := rimbaSuccess(t, repo, "list")
 	assertNotContains(t, r.Stdout, "SERVICE")
 }
+
+func TestMonorepoDuplicateStripsServicePrefix(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupMonorepoRepo(t, "auth-api")
+
+	rimbaSuccess(t, repo, "add", "auth-api/login")
+	r := rimbaSuccess(t, repo, "duplicate", "auth-api/login")
+
+	assertContains(t, r.Stdout, "auth-api/feature/login-1")
+	assertNotContains(t, r.Stdout, "auth-api/feature/auth-api/login-1")
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.FullBranchName("auth-api", defaultPrefix, "login-1")
+	assertFileExists(t, resolver.WorktreePath(wtDir, branch))
+}
+
+func TestMonorepoRenameStripsServicePrefix(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupMonorepoRepo(t, "auth-api")
+
+	rimbaSuccess(t, repo, "add", "auth-api/old")
+	r := rimbaSuccess(t, repo, "rename", "auth-api/old", "auth-api/new")
+
+	assertContains(t, r.Stdout, "Renamed worktree")
+	assertNotContains(t, r.Stdout, "auth-api/feature/auth-api/new")
+	assertNotContains(t, r.Stdout, "auth-api/old")
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.FullBranchName("auth-api", defaultPrefix, "new")
+	assertFileExists(t, resolver.WorktreePath(wtDir, branch))
+}
+
+func TestMonorepoRenameBareNewTask(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupMonorepoRepo(t, "auth-api")
+
+	rimbaSuccess(t, repo, "add", "auth-api/old2")
+	r := rimbaSuccess(t, repo, "rename", "auth-api/old2", "new2")
+
+	assertContains(t, r.Stdout, "Renamed worktree")
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.FullBranchName("auth-api", defaultPrefix, "new2")
+	assertFileExists(t, resolver.WorktreePath(wtDir, branch))
+}
+
+func TestMonorepoRestoreFindsArchivedBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupMonorepoRepo(t, "auth-api")
+
+	rimbaSuccess(t, repo, "add", "auth-api/login")
+	rimbaSuccess(t, repo, "archive", "auth-api/login")
+	r := rimbaSuccess(t, repo, "restore", "auth-api/login", flagSkipDepsE2E, flagSkipHooksE2E)
+
+	assertContains(t, r.Stdout, "Restored worktree for task")
+	assertContains(t, r.Stdout, "auth-api/feature/login")
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.FullBranchName("auth-api", defaultPrefix, "login")
+	assertFileExists(t, resolver.WorktreePath(wtDir, branch))
+}


### PR DESCRIPTION
## Summary
- Extended `FindArchivedBranch` to accept a `service` parameter so monorepo archived branches (`auth-api/feature/login`) are matched correctly on restore
- Normalized `args[0]`/`args[1]` via `ResolveTaskInput` in `duplicate`, `rename`, and `restore` after lookup, so the service prefix is never double-applied to branch construction targets
- Added 4 unit tests for monorepo `FindArchivedBranch` paths and 4 e2e tests covering `duplicate`, `rename` (service/new and bare new), and `restore` against monorepo worktrees

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

## Issue

Closes #166