### PR TITLE
[chore] Add Dependabot for gomod and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with `gomod` and `github-actions` ecosystems
- Both configured on weekly schedule with `open-pull-requests-limit: 5`
- Ensures Go module and Actions version bumps receive automated PRs going forward

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] E2E tests pass (`make test-e2e`)

## Issue

Closes #179