### PR TITLE
[fix] Route diagnostic warnings to stderr; surface IsDirty errors

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -235,7 +235,7 @@ func cleanFetchMergeRef(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, ma
 	s.Start("Fetching from origin...")
 	if err := git.Fetch(r, "origin"); err != nil {
 		s.Stop()
-		fmt.Fprintf(cmd.OutOrStdout(), "Warning: fetch failed (no remote?): continuing with local state\n")
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: fetch failed (no remote?): continuing with local state\n")
 		return mainBranch
 	}
 	return "origin/" + mainBranch
@@ -288,7 +288,7 @@ func confirmRemoval(cmd *cobra.Command, count int, label string) bool {
 
 func printWarnings(cmd *cobra.Command, warnings []string) {
 	for _, w := range warnings {
-		fmt.Fprintf(cmd.OutOrStdout(), "Warning: %s\n", w)
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s\n", w)
 	}
 }
 

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -11,12 +11,15 @@ import (
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/operations"
+	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/spf13/cobra"
 )
 
 func TestCleanMergedFetchFails(t *testing.T) {
 	worktreeOut := cleanMergedWorktreeOut()
-	cmd, buf := newCleanMergedCmd()
+	cmd, outBuf := newCleanMergedCmd()
+	var errBuf bytes.Buffer
+	cmd.SetErr(&errBuf) // separate stderr so we can verify warning routing
 	_ = cmd.Flags().Set(flagForce, "true")
 
 	var mergedRef string
@@ -47,9 +50,11 @@ func TestCleanMergedFetchFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf(fatalCleanMerged, err)
 	}
-	out := buf.String()
-	if !strings.Contains(out, "Warning: fetch failed") {
-		t.Errorf("expected fetch warning, got %q", out)
+	if strings.Contains(outBuf.String(), "Warning: fetch failed") {
+		t.Errorf("warning leaked to stdout: %q", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Warning: fetch failed") {
+		t.Errorf("expected fetch warning on stderr, got %q", errBuf.String())
 	}
 	if mergedRef != branchMain {
 		t.Errorf("merged ref = %q, want %q (local fallback)", mergedRef, branchMain)
@@ -569,18 +574,54 @@ func TestCleanStaleForce(t *testing.T) {
 
 func TestPrintWarnings(t *testing.T) {
 	cmd := &cobra.Command{}
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
 	printWarnings(cmd, []string{"first", "second"})
-	out := buf.String()
-	if !strings.Contains(out, "Warning: first") || !strings.Contains(out, "Warning: second") {
-		t.Errorf("got %q", out)
+
+	if strings.Contains(outBuf.String(), "Warning") {
+		t.Errorf("warnings leaked to stdout: %q", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Warning: first") || !strings.Contains(errBuf.String(), "Warning: second") {
+		t.Errorf("stderr = %q, want both warnings", errBuf.String())
 	}
 
-	buf.Reset()
+	outBuf.Reset()
+	errBuf.Reset()
 	printWarnings(cmd, nil)
-	if buf.Len() != 0 {
-		t.Errorf("expected no output for empty warnings, got %q", buf.String())
+	if outBuf.Len() != 0 || errBuf.Len() != 0 {
+		t.Errorf("expected no output for empty warnings")
+	}
+}
+
+func TestCleanFetchMergeRefWarningOnStderr(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool(flagNoColor, true, "")
+	cmd.Flags().Bool(flagJSON, false, "")
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == cmdFetch {
+				return "", errors.New("no remote")
+			}
+			return "", nil
+		},
+	}
+	s := spinner.New(spinnerOpts(cmd))
+	defer s.Stop()
+
+	ref := cleanFetchMergeRef(cmd, r, s, branchMain)
+	if ref != branchMain {
+		t.Errorf("ref = %q, want %q (local fallback)", ref, branchMain)
+	}
+	if strings.Contains(outBuf.String(), "Warning") {
+		t.Errorf("warning leaked to stdout: %q", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Warning: fetch failed") {
+		t.Errorf("stderr = %q, want 'Warning: fetch failed'", errBuf.String())
 	}
 }
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -147,7 +147,7 @@ func execSelectWorktrees(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, o
 	}
 
 	if opts.dirty {
-		filtered = filterDirtyWorktrees(r, s, filtered)
+		filtered = filterDirtyWorktrees(cmd, r, s, filtered)
 	}
 	return filtered, nil
 }
@@ -217,8 +217,11 @@ func init() {
 }
 
 // filterDirtyWorktrees filters worktrees to only those with uncommitted changes.
-func filterDirtyWorktrees(r git.Runner, s *spinner.Spinner, worktrees []resolver.WorktreeInfo) []resolver.WorktreeInfo {
+// If IsDirty returns an error for a worktree, it is treated as dirty (included)
+// and a warning is emitted to cmd.ErrOrStderr() so the error is visible.
+func filterDirtyWorktrees(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, worktrees []resolver.WorktreeInfo) []resolver.WorktreeInfo {
 	isDirty := make([]bool, len(worktrees))
+	warnings := make([]string, len(worktrees))
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 8)
 
@@ -231,12 +234,23 @@ func filterDirtyWorktrees(r git.Runner, s *spinner.Spinner, worktrees []resolver
 			defer func() { <-sem }()
 
 			dirty, err := git.IsDirty(r, path)
-			if err == nil && dirty {
+			if err != nil {
+				warnings[idx] = fmt.Sprintf("Warning: cannot check dirty status for %s: %v", path, err)
+				isDirty[idx] = true
+				return
+			}
+			if dirty {
 				isDirty[idx] = true
 			}
 		}(i, wt.Path)
 	}
 	wg.Wait()
+
+	for _, w := range warnings {
+		if w != "" {
+			fmt.Fprintln(cmd.ErrOrStderr(), w)
+		}
+	}
 
 	var out []resolver.WorktreeInfo
 	for i, wt := range worktrees {

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -233,12 +234,47 @@ func TestFilterDirtyWorktrees(t *testing.T) {
 	s := testExecSpinner(cmd)
 	defer s.Stop()
 
-	result := filterDirtyWorktrees(r, s, worktrees)
+	result := filterDirtyWorktrees(cmd, r, s, worktrees)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 dirty worktree, got %d", len(result))
 	}
 	if result[0].Path != "/dirty" {
 		t.Errorf("expected /dirty, got %s", result[0].Path)
+	}
+}
+
+func TestFilterDirtyWorktreesIsDirtyErrorIncludedAndWarned(t *testing.T) {
+	worktrees := []resolver.WorktreeInfo{
+		{Path: "/wt/error", Branch: "feature/a"},
+	}
+	r := &mockRunner{
+		run: func(_ ...string) (string, error) { return "", nil },
+		runInDir: func(_ string, _ ...string) (string, error) {
+			return "", errors.New("permission denied")
+		},
+	}
+
+	cmd, _ := newTestCmd()
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+
+	s := testExecSpinner(cmd)
+	defer s.Stop()
+
+	result := filterDirtyWorktrees(cmd, r, s, worktrees)
+
+	if len(result) != 1 {
+		t.Fatalf("expected erroring worktree to be included (treated as dirty), got %d", len(result))
+	}
+	if result[0].Path != "/wt/error" {
+		t.Errorf("path = %q, want /wt/error", result[0].Path)
+	}
+	if strings.Contains(outBuf.String(), "Warning") {
+		t.Errorf("warning leaked to stdout: %q", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Warning: cannot check dirty status") {
+		t.Errorf("stderr = %q, want warning", errBuf.String())
 	}
 }
 

--- a/cmd/list_render.go
+++ b/cmd/list_render.go
@@ -52,7 +52,7 @@ func listRenderTable(cmd *cobra.Command, rows []resolver.WorktreeDetail, full bo
 	p := termcolor.NewPainter(noColor)
 
 	if ghWarning != "" {
-		fmt.Fprintln(cmd.OutOrStdout(), p.Paint(ghWarning, termcolor.Yellow))
+		fmt.Fprintln(cmd.ErrOrStderr(), p.Paint(ghWarning, termcolor.Yellow))
 	}
 
 	tbl := termcolor.NewTable(2)

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -834,6 +834,25 @@ func TestListRenderTableFullWithPRInfo(t *testing.T) {
 	}
 }
 
+func TestListRenderTableGhWarningOnStderr(t *testing.T) {
+	cmd, _ := newListTestCmd()
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+	rows := []resolver.WorktreeDetail{
+		{Task: "a", Branch: "feature/a", Type: "feature", Path: "/wt/a"},
+	}
+
+	listRenderTable(cmd, rows, false, nil, "gh unavailable; PR/CI columns blank")
+
+	if strings.Contains(outBuf.String(), "gh unavailable") {
+		t.Errorf("warning leaked to stdout: %q", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "gh unavailable") {
+		t.Errorf("stderr = %q, want gh warning", errBuf.String())
+	}
+}
+
 func TestListRenderJSONPopulatesPRInfo(t *testing.T) {
 	cmd, buf := newListTestCmd()
 	rows := []resolver.WorktreeDetail{

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -84,7 +84,7 @@ var syncCmd = &cobra.Command{
 		s.Start("Fetching from origin...")
 		if err := git.Fetch(r, "origin"); err != nil {
 			s.Stop()
-			fmt.Fprintf(cmd.OutOrStdout(), "Warning: fetch failed (no remote?): continuing with local state\n")
+			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: fetch failed (no remote?): continuing with local state\n")
 		}
 
 		repoRoot, err := git.MainRepoRoot(r)
@@ -211,7 +211,7 @@ func syncWorktree(sc *syncContext, mainBranch string, wt resolver.WorktreeInfo, 
 		if sr.SkipReason == "dirty" {
 			fmt.Fprintf(sc.cmd.OutOrStdout(), "Skipping %s (dirty)\n", sr.Branch)
 		} else {
-			fmt.Fprintf(sc.cmd.OutOrStdout(), "Warning: %s: %s\n", sr.Branch, sr.SkipReason)
+			fmt.Fprintf(sc.cmd.ErrOrStderr(), "Warning: %s: %s\n", sr.Branch, sr.SkipReason)
 		}
 	case sr.Failed:
 		sc.res.failed++

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
 	"strings"
 	"testing"
@@ -512,4 +513,31 @@ func TestPrintSyncSummary(t *testing.T) {
 			t.Errorf("output = %q, want '1 pushed'", out)
 		}
 	})
+}
+
+func TestSyncWorktreeSkipWarningOnStderr(t *testing.T) {
+	var outBuf, errBuf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool(flagNoColor, true, "")
+	cmd.Flags().Bool(flagJSON, false, "")
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+
+	r := &mockRunner{
+		run: func(_ ...string) (string, error) { return "", nil },
+		runInDir: func(_ string, _ ...string) (string, error) {
+			return "", errGitFailed
+		},
+	}
+
+	sc := &syncContext{cmd: cmd, r: r, res: &syncResult{}}
+	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
+	syncWorktree(sc, branchMain, wt, false, false)
+
+	if strings.Contains(outBuf.String(), "Warning") {
+		t.Errorf("warning leaked to stdout: %q", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Warning") {
+		t.Errorf("stderr = %q, want warning", errBuf.String())
+	}
 }

--- a/internal/mcp/tool_exec.go
+++ b/internal/mcp/tool_exec.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/lugassawan/rimba/internal/config"
@@ -163,8 +164,11 @@ func buildExecData(command string, results []executor.Result) execData {
 }
 
 // filterDirty filters worktrees to only those with uncommitted changes.
+// If IsDirty returns an error, the worktree is treated as dirty (included)
+// and a warning is written to os.Stderr so the operator can investigate.
 func filterDirty(r git.Runner, worktrees []resolver.WorktreeInfo) []resolver.WorktreeInfo {
 	isDirtyFlags := make([]bool, len(worktrees))
+	warnings := make([]string, len(worktrees))
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 8)
 
@@ -176,12 +180,23 @@ func filterDirty(r git.Runner, worktrees []resolver.WorktreeInfo) []resolver.Wor
 			defer func() { <-sem }()
 
 			d, err := git.IsDirty(r, path)
-			if err == nil && d {
+			if err != nil {
+				warnings[idx] = fmt.Sprintf("Warning: cannot check dirty status for %s: %v", path, err)
+				isDirtyFlags[idx] = true
+				return
+			}
+			if d {
 				isDirtyFlags[idx] = true
 			}
 		}(i, wt.Path)
 	}
 	wg.Wait()
+
+	for _, w := range warnings {
+		if w != "" {
+			fmt.Fprintln(os.Stderr, w)
+		}
+	}
 
 	var out []resolver.WorktreeInfo
 	for i, wt := range worktrees {

--- a/internal/mcp/tool_exec_test.go
+++ b/internal/mcp/tool_exec_test.go
@@ -2,6 +2,8 @@ package mcp
 
 import (
 	"errors"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -218,9 +220,50 @@ func TestFilterDirtyError(t *testing.T) {
 			return "", errors.New("git error")
 		},
 	}
+	origStderr := os.Stderr
+	pr, pw, _ := os.Pipe()
+	os.Stderr = pw
+
 	result := filterDirty(r, worktrees)
-	if len(result) != 0 {
-		t.Fatalf("expected 0 on error, got %d", len(result))
+
+	pw.Close()
+	os.Stderr = origStderr
+	_, _ = io.Copy(io.Discard, pr)
+
+	if len(result) != 1 {
+		t.Fatalf("expected erroring worktree treated as dirty (len 1), got %d", len(result))
+	}
+}
+
+func TestFilterDirtyErrorIncludedAndWarned(t *testing.T) {
+	worktrees := []resolver.WorktreeInfo{
+		{Path: "/wt/a", Branch: "feature/a"},
+	}
+	r := &mockRunner{
+		runInDir: func(dir string, args ...string) (string, error) {
+			return "", errors.New("permission denied")
+		},
+	}
+
+	origStderr := os.Stderr
+	pr, pw, _ := os.Pipe()
+	os.Stderr = pw
+
+	result := filterDirty(r, worktrees)
+
+	pw.Close()
+	os.Stderr = origStderr
+	var stderrBuf strings.Builder
+	_, _ = io.Copy(&stderrBuf, pr)
+
+	if len(result) != 1 {
+		t.Fatalf("expected erroring worktree to be included, got %d", len(result))
+	}
+	if result[0].Path != "/wt/a" {
+		t.Errorf("path = %q, want /wt/a", result[0].Path)
+	}
+	if !strings.Contains(stderrBuf.String(), "Warning: cannot check dirty status") {
+		t.Errorf("stderr = %q, want warning", stderrBuf.String())
 	}
 }
 

--- a/tests/e2e/clean_test.go
+++ b/tests/e2e/clean_test.go
@@ -374,3 +374,17 @@ func TestCleanStaleMutualExclusive(t *testing.T) {
 	r := rimbaFail(t, repo, "clean", flagMergedE2E, flagStaleE2E)
 	assertContains(t, r.Stderr, "if any flags in the group")
 }
+
+func TestCleanFetchWarningOnStderr(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	// setupCleanInitializedRepo has no remote — fetch fails; clean --merged
+	// continues with local state and exits 0 with "No merged worktrees found."
+	repo := setupCleanInitializedRepo(t)
+
+	r := rimbaSuccess(t, repo, "clean", flagMergedE2E)
+	assertContains(t, r.Stderr, "Warning: fetch failed")
+	assertNotContains(t, r.Stdout, "Warning: fetch failed")
+}

--- a/tests/e2e/list_full_test.go
+++ b/tests/e2e/list_full_test.go
@@ -160,7 +160,8 @@ func TestListFullWarnsWhenGhUnauthenticated(t *testing.T) {
 		t.Fatalf("exit = %d\nstdout: %s\nstderr: %s", r.ExitCode, r.Stdout, r.Stderr)
 	}
 
-	assertContains(t, r.Stdout, "gh unavailable")
+	assertContains(t, r.Stderr, "gh unavailable")
+	assertNotContains(t, r.Stdout, "gh unavailable")
 	for _, want := range []string{"PR", "CI", "feat-unauth"} {
 		assertContains(t, r.Stdout, want)
 	}

--- a/tests/e2e/sync_test.go
+++ b/tests/e2e/sync_test.go
@@ -450,3 +450,18 @@ func TestSyncAllPushDefault(t *testing.T) {
 	r := rimbaSuccess(t, repo, "sync", "--all")
 	assertContains(t, r.Stdout, "2 pushed")
 }
+
+func TestSyncFetchWarningOnStderr(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	// setupInitializedRepo has no remote — fetch fails with a warning but sync
+	// continues using local state, so the overall command still exits 0.
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", taskSync)
+
+	r := rimbaSuccess(t, repo, "sync", taskSync)
+	assertContains(t, r.Stderr, "Warning: fetch failed")
+	assertNotContains(t, r.Stdout, "Warning: fetch failed")
+}


### PR DESCRIPTION
## Summary

- **B3 — warnings on stdout:** Route all `Warning: …` lines to `cmd.ErrOrStderr()` (was `cmd.OutOrStdout()`) across five sites: `cleanFetchMergeRef`, `printWarnings`, `syncCmd` fetch path, `syncWorktree` non-dirty skip path, and `listRenderTable` gh-warning. Stdout is now clean for pipeline and JSON consumers.
- **B4 — silent IsDirty swallow:** `filterDirtyWorktrees` (CLI) and `filterDirty` (MCP) now treat an `IsDirty` error as dirty — the worktree is included in the dirty set and a `Warning: cannot check dirty status for <path>: <err>` line is emitted to stderr. Previously the error was swallowed and the worktree silently excluded, causing `rimba exec --dirty` to miss potentially-dirty trees.

## Test Plan

- [x] Unit tests pass (`make test`) — 1429 tests, 0 failures
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2E tests pass (`make test-e2e`) — 25 packages, 0 failures
- [x] New unit tests assert warnings land on **stderr not stdout** with separated `SetOut`/`SetErr` buffers: `TestPrintWarnings`, `TestCleanFetchMergeRefWarningOnStderr`, `TestCleanMergedFetchFails` (updated), `TestSyncWorktreeSkipWarningOnStderr`, `TestListRenderTableGhWarningOnStderr`
- [x] New B4 unit tests assert erroring worktrees are included and warned: `TestFilterDirtyWorktreesIsDirtyErrorIncludedAndWarned`, `TestFilterDirtyError` (updated), `TestFilterDirtyErrorIncludedAndWarned`
- [x] E2E tests `TestCleanFetchWarningOnStderr` and `TestSyncFetchWarningOnStderr` assert `r.Stderr` contains warning, `r.Stdout` does not

## Issue

Closes #170