### PR TITLE
[ci] Skip PR title/issue-ref validation for Dependabot PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR title
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -33,6 +34,7 @@ jobs:
           fi
 
       - name: Validate issue reference
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |


### PR DESCRIPTION
## Summary

- Gates `Validate PR title` and `Validate issue reference` steps on `github.event.pull_request.user.login != 'dependabot[bot]'`
- Leaves `Validate PR description` unconditional — Dependabot always writes a non-empty body
- Uses PR author (`user.login`) rather than `github.actor` to stay stable on `synchronize` events triggered by humans rebasing a Dependabot branch

## Why

Dependabot hard-codes `: ` between prefix and message, so its titles (`chore(deps): bump …`) can never match the required `[type] …` regex. The fix must be in the workflow, not in `dependabot.yml`.

## Test plan

- [ ] Human PR with non-conforming title → `Validate PR title` and `Validate issue reference` still fail
- [ ] Next Dependabot PR → both steps show **Skipped**, `Validate PR description` shows **Success**

Closes #190