### PR TITLE
[chore] Ignore vendor/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ coverage.*
 profile.cov
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 
 # Go workspace file
 go.work


### PR DESCRIPTION
## Summary
- Uncomments `vendor/` in `.gitignore` so a committed vendor tree is not accidentally tracked

## Test Plan
- [ ] Confirm `vendor/` no longer appears as untracked in `git status`

N/A