### PR TITLE
docs: clarify INSTALL_DIR and RIMBA_QUIET scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@
 curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/install.sh | bash
 ```
 
+The install script honors the shell variable `INSTALL_DIR` (default: `$HOME/.local/bin`). This is read by `scripts/install.sh`, not by the `rimba` binary:
+
+```sh
+INSTALL_DIR="$HOME/bin" curl -sSfL https://raw.githubusercontent.com/lugassawan/rimba/main/scripts/install.sh | bash
+```
+
 ### Go install
 
 ```sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,7 +99,7 @@ When `auto_detect` is enabled (default), rimba recognizes these lockfiles automa
 | Variable | Description |
 |----------|-------------|
 | `RIMBA_DEBUG` | Log git command timing to stderr (set to any value, e.g. `RIMBA_DEBUG=1`). The `--debug` flag on any command has the same effect. |
-| `RIMBA_QUIET` | Suppress pre-execution hints (set to any value, e.g. `RIMBA_QUIET=1`) |
+| `RIMBA_QUIET` | Suppress optional rimba hints (pre-execution flag hints and post-update tips). Set to any value (e.g. `RIMBA_QUIET=1`). Does **not** suppress errors, normal command output, or output from programs launched via `rimba exec` / `rimba open`. |
 | `NO_COLOR` | Disable colored output globally (per [no-color.org](https://no-color.org)) |
 
 ## MCP server registration


### PR DESCRIPTION
Documents INSTALL_DIR as an install.sh shell variable and narrows RIMBA_QUIET to optional hints only.

Fixes #175