### PR TITLE
[chore] Apply errhint.WithFix to remaining bare fmt.Errorf sites

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -222,7 +222,7 @@ func runInitGlobal(cmd *cobra.Command, uninstall bool) error {
 	if err != nil {
 		return errhint.WithFix(
 			fmt.Errorf("resolve home directory: %w", err),
-			"set HOME to your user home directory: export HOME=/Users/<you>",
+			"set HOME to your user home directory (e.g. /home/<username> on Linux, /Users/<username> on macOS)",
 		)
 	}
 	if uninstall {
@@ -245,7 +245,7 @@ func runInstall(
 	if err != nil {
 		return errhint.WithFix(
 			fmt.Errorf("agent files: %w", err),
-			"check write permissions for the install dir, or retry: rimba init --agents",
+			"check write permissions for the install dir",
 		)
 	}
 	var mcps []agentfile.Result
@@ -254,7 +254,7 @@ func runInstall(
 		if err != nil {
 			return errhint.WithFix(
 				fmt.Errorf("mcp servers: %w", err),
-				"check write permissions for MCP client configs (.mcp.json, .cursor/mcp.json, ~/.claude/settings.json), or retry: rimba init --agents",
+				"check write permissions for MCP client configs (.mcp.json, .cursor/mcp.json, ~/.claude/settings.json)",
 			)
 		}
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -29,6 +29,11 @@ const (
 	tierProjectLocal installTier = "project-local"
 )
 
+const (
+	localConfigHint = "check directory permissions for .rimba/ in the repo root"
+	gitignoreHint   = "check write permissions for .gitignore in the repo root"
+)
+
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize rimba in the current repository",
@@ -134,18 +139,21 @@ func runInitFresh(cmd *cobra.Command, r git.Runner, repoRoot, dirPath, gitignore
 
 	if !personal {
 		if err := os.WriteFile(filepath.Join(dirPath, config.LocalFile), nil, 0600); err != nil {
-			return fmt.Errorf("failed to create local config: %w", err)
+			return errhint.WithFix(fmt.Errorf("failed to create local config: %w", err), localConfigHint)
 		}
 	}
 
 	wtDir := filepath.Join(repoRoot, config.DefaultWorktreeDir(repoName))
 	if err := os.MkdirAll(wtDir, 0750); err != nil {
-		return fmt.Errorf("failed to create worktree directory: %w", err)
+		return errhint.WithFix(
+			fmt.Errorf("failed to create worktree directory: %w", err),
+			"check directory permissions for the worktree dir, or set worktree.dir in .rimba/settings.toml",
+		)
 	}
 
 	added, err := fileutil.EnsureGitignore(repoRoot, gitignoreEntry)
 	if err != nil {
-		return fmt.Errorf("failed to update .gitignore: %w", err)
+		return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Initialized rimba in %s\n", repoRoot)
@@ -169,19 +177,22 @@ func runInitMigrate(cmd *cobra.Command, repoRoot, dirPath, legacyPath, gitignore
 	}
 
 	if err := os.Rename(legacyPath, filepath.Join(dirPath, config.TeamFile)); err != nil {
-		return fmt.Errorf("failed to move legacy config: %w", err)
+		return errhint.WithFix(
+			fmt.Errorf("failed to move legacy config: %w", err),
+			"check write permissions for the repo root and move .rimba.toml to .rimba/settings.toml manually",
+		)
 	}
 
 	if !personal {
 		if err := os.WriteFile(filepath.Join(dirPath, config.LocalFile), nil, 0600); err != nil {
-			return fmt.Errorf("failed to create local config: %w", err)
+			return errhint.WithFix(fmt.Errorf("failed to create local config: %w", err), localConfigHint)
 		}
 	}
 
 	_, _ = fileutil.RemoveGitignoreEntry(repoRoot, config.FileName)
 
 	if _, err := fileutil.EnsureGitignore(repoRoot, gitignoreEntry); err != nil {
-		return fmt.Errorf("failed to update .gitignore: %w", err)
+		return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Migrated rimba config in %s\n", repoRoot)
@@ -209,7 +220,10 @@ func runInitAgents(cmd *cobra.Command, repoRoot string, local, uninstall bool) e
 func runInitGlobal(cmd *cobra.Command, uninstall bool) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return fmt.Errorf("resolve home directory: %w", err)
+		return errhint.WithFix(
+			fmt.Errorf("resolve home directory: %w", err),
+			"set HOME to your user home directory: export HOME=/Users/<you>",
+		)
 	}
 	if uninstall {
 		return runInstall(cmd, home, tierUser, "Removed", agentfile.UninstallGlobal, agentfile.UnregisterMCPGlobal)
@@ -229,13 +243,19 @@ func runInstall(
 ) error {
 	files, err := installFn(dir)
 	if err != nil {
-		return fmt.Errorf("agent files: %w", err)
+		return errhint.WithFix(
+			fmt.Errorf("agent files: %w", err),
+			"check write permissions for the install dir, or retry: rimba init --agents",
+		)
 	}
 	var mcps []agentfile.Result
 	if mcpFn != nil {
 		mcps, err = mcpFn(dir)
 		if err != nil {
-			return fmt.Errorf("mcp servers: %w", err)
+			return errhint.WithFix(
+				fmt.Errorf("mcp servers: %w", err),
+				"check write permissions for MCP client configs (.mcp.json, .cursor/mcp.json, ~/.claude/settings.json), or retry: rimba init --agents",
+			)
 		}
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "%s rimba (%s):\n", verb, tier)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -129,7 +129,7 @@ func runInitFresh(cmd *cobra.Command, r git.Runner, repoRoot, dirPath, gitignore
 	if err := os.MkdirAll(dirPath, 0750); err != nil {
 		return errhint.WithFix(
 			fmt.Errorf("failed to create config directory: %w", err),
-			"check directory permissions for .rimba/ in the repo root",
+			localConfigHint,
 		)
 	}
 
@@ -172,7 +172,7 @@ func runInitMigrate(cmd *cobra.Command, repoRoot, dirPath, legacyPath, gitignore
 	if err := os.MkdirAll(dirPath, 0750); err != nil {
 		return errhint.WithFix(
 			fmt.Errorf("failed to create config directory: %w", err),
-			"check directory permissions for .rimba/ in the repo root",
+			localConfigHint,
 		)
 	}
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -134,7 +134,7 @@ func runInitFresh(cmd *cobra.Command, r git.Runner, repoRoot, dirPath, gitignore
 	}
 
 	if err := config.Save(filepath.Join(dirPath, config.TeamFile), cfg); err != nil {
-		return err
+		return errhint.WithFix(fmt.Errorf("failed to save team config: %w", err), localConfigHint)
 	}
 
 	if !personal {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -7,10 +7,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/lugassawan/rimba/internal/updater"
 	"github.com/spf13/cobra"
 )
+
+const retryUpdateHint = "retry: rimba update"
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
@@ -41,7 +44,10 @@ refresh). Set RIMBA_QUIET=1 to suppress the tip.`,
 		s.Start("Checking for updates...")
 		result, err := u.Check()
 		if err != nil {
-			return fmt.Errorf("checking for updates: %w", err)
+			return errhint.WithFix(
+				fmt.Errorf("checking for updates: %w", err),
+				"check network connectivity, or set GITHUB_TOKEN if rate limited",
+			)
 		}
 
 		if result.UpToDate {
@@ -56,41 +62,56 @@ refresh). Set RIMBA_QUIET=1 to suppress the tip.`,
 		s.Start("Downloading...")
 		newBinary, err := u.Download(result.DownloadURL)
 		if err != nil {
-			return fmt.Errorf("downloading update: %w", err)
+			return errhint.WithFix(
+				fmt.Errorf("downloading update: %w", err),
+				"check network connectivity and retry: rimba update",
+			)
 		}
 		defer updater.CleanupTempDir(newBinary)
 
 		if err := updater.PrepareBinary(newBinary); err != nil {
-			return fmt.Errorf("preparing binary: %w", err)
+			return errhint.WithFix(fmt.Errorf("preparing binary: %w", err), retryUpdateHint)
 		}
 
 		currentBinary, err := os.Executable()
 		if err != nil {
-			return fmt.Errorf("locating current binary: %w", err)
+			return errhint.WithFix(
+				fmt.Errorf("locating current binary: %w", err),
+				"reinstall rimba: https://github.com/lugassawan/rimba#installation",
+			)
 		}
 		currentBinary, err = filepath.EvalSymlinks(currentBinary)
 		if err != nil {
-			return fmt.Errorf("resolving binary path: %w", err)
+			return errhint.WithFix(
+				fmt.Errorf("resolving binary path: %w", err),
+				"reinstall rimba: https://github.com/lugassawan/rimba#installation",
+			)
 		}
 
 		s.Update("Installing...")
 		installedBinary := currentBinary
 		if err := updater.Replace(currentBinary, newBinary); err != nil {
 			if !updater.IsPermissionError(err) {
-				return fmt.Errorf("replacing binary: %w", err)
+				return errhint.WithFix(fmt.Errorf("replacing binary: %w", err), retryUpdateHint)
 			}
 
 			// Install to user-writable directory instead
 			s.Stop()
 			userDir, dirErr := updater.UserInstallDir()
 			if dirErr != nil {
-				return fmt.Errorf("getting user install dir: %w", dirErr)
+				return errhint.WithFix(
+					fmt.Errorf("getting user install dir: %w", dirErr),
+					"set HOME or XDG_DATA_HOME and retry: rimba update",
+				)
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Cannot write to %s. Installing to %s instead.\n",
 				filepath.Dir(currentBinary), userDir)
 
 			if mkErr := os.MkdirAll(userDir, 0750); mkErr != nil {
-				return fmt.Errorf("creating install dir: %w", mkErr)
+				return errhint.WithFix(
+					fmt.Errorf("creating install dir: %w", mkErr),
+					"check write permissions for ~/.local/bin and retry: rimba update",
+				)
 			}
 
 			installedBinary = filepath.Join(userDir, "rimba")
@@ -99,17 +120,26 @@ refresh). Set RIMBA_QUIET=1 to suppress the tip.`,
 				// First install to this directory — write directly
 				src, readErr := os.ReadFile(newBinary)
 				if readErr != nil {
-					return fmt.Errorf("reading new binary: %w", readErr)
+					return errhint.WithFix(fmt.Errorf("reading new binary: %w", readErr), retryUpdateHint)
 				}
 				if writeErr := os.WriteFile(installedBinary, src, 0755); writeErr != nil { //nolint:gosec // executable binary
-					return fmt.Errorf("writing binary: %w", writeErr)
+					return errhint.WithFix(
+						fmt.Errorf("writing binary: %w", writeErr),
+						fmt.Sprintf("check write permissions for %s and retry: rimba update", userDir),
+					)
 				}
 			} else if err := updater.Replace(installedBinary, newBinary); err != nil {
-				return fmt.Errorf("replacing binary: %w", err)
+				return errhint.WithFix(
+					fmt.Errorf("replacing binary: %w", err),
+					fmt.Sprintf("check write permissions for %s and retry: rimba update", userDir),
+				)
 			}
 
 			if pathErr := updater.EnsurePath(userDir); pathErr != nil {
-				return fmt.Errorf("updating PATH: %w", pathErr)
+				return errhint.WithFix(
+					fmt.Errorf("updating PATH: %w", pathErr),
+					fmt.Sprintf("add %s to PATH manually: export PATH=\"%s:$PATH\"", userDir, userDir),
+				)
 			}
 		}
 
@@ -118,7 +148,10 @@ refresh). Set RIMBA_QUIET=1 to suppress the tip.`,
 		// Verify the new binary works
 		out, err := exec.Command(filepath.Clean(installedBinary), "version").Output() //nolint:gosec // path comes from os.Executable
 		if err != nil {
-			return fmt.Errorf("verifying new binary: %w", err)
+			return errhint.WithFix(
+				fmt.Errorf("verifying new binary: %w", err),
+				fmt.Sprintf("the new binary at %s may be corrupt — retry: rimba update", installedBinary),
+			)
 		}
 
 		fmt.Fprintf(cmd.OutOrStdout(), "Updated successfully: %s\n", strings.TrimSpace(string(out)))

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -101,7 +101,7 @@ refresh). Set RIMBA_QUIET=1 to suppress the tip.`,
 			if dirErr != nil {
 				return errhint.WithFix(
 					fmt.Errorf("getting user install dir: %w", dirErr),
-					"set HOME or XDG_DATA_HOME and retry: rimba update",
+					"set HOME to your user home directory and retry: rimba update",
 				)
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Cannot write to %s. Installing to %s instead.\n",

--- a/internal/operations/rename.go
+++ b/internal/operations/rename.go
@@ -53,7 +53,7 @@ func RenameWorktree(r git.Runner, wt resolver.WorktreeInfo, newTask, wtDir strin
 		return RenameResult{}, errhint.WithFix(
 			fmt.Errorf("failed to rename branch %q → %q: %w\nWorktree moved back to %s",
 				wt.Branch, newBranch, err, wt.Path),
-			fmt.Sprintf("retry the branch rename: git branch -m %s %s", wt.Branch, newBranch),
+			fmt.Sprintf("retry: git branch -m %s %s", wt.Branch, newBranch),
 		)
 	}
 

--- a/internal/operations/rename.go
+++ b/internal/operations/rename.go
@@ -31,7 +31,7 @@ func RenameWorktree(r git.Runner, wt resolver.WorktreeInfo, newTask, wtDir strin
 	if git.BranchExists(r, newBranch) {
 		return RenameResult{}, errhint.WithFix(
 			fmt.Errorf("branch %q already exists", newBranch),
-			fmt.Sprintf("choose a different task name, or remove the existing branch: git branch -D %s", newBranch),
+			"choose a different task name, or remove the existing branch: git branch -D "+newBranch,
 		)
 	}
 

--- a/internal/operations/rename.go
+++ b/internal/operations/rename.go
@@ -38,7 +38,10 @@ func RenameWorktree(r git.Runner, wt resolver.WorktreeInfo, newTask, wtDir strin
 	newPath := resolver.WorktreePath(wtDir, newBranch)
 
 	if err := git.MoveWorktree(r, wt.Path, newPath, force); err != nil {
-		return RenameResult{}, err
+		return RenameResult{}, errhint.WithFix(
+			fmt.Errorf("failed to move worktree: %w", err),
+			"unlock the worktree if locked: git worktree unlock "+wt.Path+", then retry: rimba rename",
+		)
 	}
 
 	if err := git.RenameBranch(r, wt.Branch, newBranch); err != nil {

--- a/internal/operations/rename.go
+++ b/internal/operations/rename.go
@@ -3,6 +3,7 @@ package operations
 import (
 	"fmt"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/resolver"
 )
@@ -28,7 +29,10 @@ func RenameWorktree(r git.Runner, wt resolver.WorktreeInfo, newTask, wtDir strin
 	newBranch := resolver.FullBranchName(svc, matchedPrefix, newTask)
 
 	if git.BranchExists(r, newBranch) {
-		return RenameResult{}, fmt.Errorf("branch %q already exists", newBranch)
+		return RenameResult{}, errhint.WithFix(
+			fmt.Errorf("branch %q already exists", newBranch),
+			fmt.Sprintf("choose a different task name, or remove the existing branch: git branch -D %s", newBranch),
+		)
 	}
 
 	newPath := resolver.WorktreePath(wtDir, newBranch)
@@ -39,11 +43,18 @@ func RenameWorktree(r git.Runner, wt resolver.WorktreeInfo, newTask, wtDir strin
 
 	if err := git.RenameBranch(r, wt.Branch, newBranch); err != nil {
 		if rbErr := git.MoveWorktree(r, newPath, wt.Path, force); rbErr != nil {
-			return RenameResult{}, fmt.Errorf("failed to rename branch %q → %q: %w\nRollback failed — worktree is at %s: %w\nTo recover: git worktree move %s %s && git branch -m %s %s",
-				wt.Branch, newBranch, err, newPath, rbErr, newPath, wt.Path, wt.Branch, newBranch)
+			return RenameResult{}, errhint.WithFix(
+				fmt.Errorf("failed to rename branch %q → %q: %w\nRollback failed — worktree is at %s: %w",
+					wt.Branch, newBranch, err, newPath, rbErr),
+				fmt.Sprintf("git worktree move %s %s && git branch -m %s %s",
+					newPath, wt.Path, wt.Branch, newBranch),
+			)
 		}
-		return RenameResult{}, fmt.Errorf("failed to rename branch %q → %q: %w\nWorktree moved back to %s\nTo retry: git branch -m %s %s",
-			wt.Branch, newBranch, err, wt.Path, wt.Branch, newBranch)
+		return RenameResult{}, errhint.WithFix(
+			fmt.Errorf("failed to rename branch %q → %q: %w\nWorktree moved back to %s",
+				wt.Branch, newBranch, err, wt.Path),
+			fmt.Sprintf("retry the branch rename: git branch -m %s %s", wt.Branch, newBranch),
+		)
 	}
 
 	return RenameResult{

--- a/internal/operations/rename_test.go
+++ b/internal/operations/rename_test.go
@@ -64,6 +64,12 @@ func TestRenameWorktreeBranchExists(t *testing.T) {
 	if !strings.Contains(err.Error(), "already exists") {
 		t.Errorf("error = %q, want 'already exists'", err.Error())
 	}
+	if !strings.Contains(err.Error(), "To fix:") {
+		t.Errorf("error = %q, want 'To fix:' hint", err.Error())
+	}
+	if !strings.Contains(err.Error(), "git branch -D") {
+		t.Errorf("error = %q, want 'git branch -D' hint fragment", err.Error())
+	}
 }
 
 func TestRenameWorktreeMoveFails(t *testing.T) {
@@ -117,6 +123,12 @@ func TestRenameWorktreeBranchRenameFails(t *testing.T) {
 	if !strings.Contains(err.Error(), "moved back") {
 		t.Errorf("error = %q, want 'moved back' (rollback confirmation)", err.Error())
 	}
+	if !strings.Contains(err.Error(), "To fix:") {
+		t.Errorf("error = %q, want 'To fix:' hint", err.Error())
+	}
+	if !strings.Contains(err.Error(), "git branch -m") {
+		t.Errorf("error = %q, want 'git branch -m' hint fragment", err.Error())
+	}
 	if moveCount != 2 {
 		t.Errorf("expected 2 worktree move calls (forward + rollback), got %d", moveCount)
 	}
@@ -154,89 +166,6 @@ func TestRenameWorktreeBranchRenameFailsRollbackFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "Rollback failed") {
 		t.Errorf("error = %q, want 'Rollback failed'", err.Error())
-	}
-}
-
-func TestRenameWorktreeBranchExistsHint(t *testing.T) {
-	r := &mockRunner{
-		run: func(args ...string) (string, error) {
-			if len(args) >= 1 && args[0] == cmdRevParse {
-				return "", nil // BranchExists returns true
-			}
-			return "", nil
-		},
-		runInDir: noopRunInDir,
-	}
-
-	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	_, err := RenameWorktree(r, wt, "auth", wtDir, false)
-	if err == nil {
-		t.Fatal("expected error for existing branch")
-	}
-	if !strings.Contains(err.Error(), "To fix:") {
-		t.Errorf("error = %q, want 'To fix:' hint", err.Error())
-	}
-	if !strings.Contains(err.Error(), "git branch -D") {
-		t.Errorf("error = %q, want 'git branch -D' hint fragment", err.Error())
-	}
-}
-
-func TestRenameWorktreeBranchRenameFailsHint(t *testing.T) {
-	r := &mockRunner{
-		run: func(args ...string) (string, error) {
-			if len(args) >= 1 && args[0] == cmdRevParse {
-				return "", errGitFailed
-			}
-			if len(args) >= 2 && args[0] == cmdWorktree && args[1] == cmdMove {
-				return "", nil
-			}
-			if len(args) >= 2 && args[0] == "branch" && args[1] == "-m" {
-				return "", errors.New(errRenameFailed)
-			}
-			return "", nil
-		},
-		runInDir: noopRunInDir,
-	}
-
-	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	_, err := RenameWorktree(r, wt, "auth", wtDir, false)
-	if err == nil {
-		t.Fatal("expected error from branch rename failure")
-	}
-	if !strings.Contains(err.Error(), "To fix:") {
-		t.Errorf("error = %q, want 'To fix:' hint", err.Error())
-	}
-	if !strings.Contains(err.Error(), "git branch -m") {
-		t.Errorf("error = %q, want 'git branch -m' hint fragment", err.Error())
-	}
-}
-
-func TestRenameWorktreeBranchRenameFailsRollbackFailsHint(t *testing.T) {
-	moveCount := 0
-	r := &mockRunner{
-		run: func(args ...string) (string, error) {
-			if len(args) >= 1 && args[0] == cmdRevParse {
-				return "", errGitFailed
-			}
-			if len(args) >= 2 && args[0] == cmdWorktree && args[1] == cmdMove {
-				moveCount++
-				if moveCount == 2 {
-					return "", errors.New("rollback move failed")
-				}
-				return "", nil
-			}
-			if len(args) >= 2 && args[0] == "branch" && args[1] == "-m" {
-				return "", errors.New(errRenameFailed)
-			}
-			return "", nil
-		},
-		runInDir: noopRunInDir,
-	}
-
-	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	_, err := RenameWorktree(r, wt, "auth", wtDir, false)
-	if err == nil {
-		t.Fatal("expected error from branch rename + rollback failure")
 	}
 	if !strings.Contains(err.Error(), "To fix:") {
 		t.Errorf("error = %q, want 'To fix:' hint", err.Error())

--- a/internal/operations/rename_test.go
+++ b/internal/operations/rename_test.go
@@ -91,6 +91,12 @@ func TestRenameWorktreeMoveFails(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error from move failure")
 	}
+	if !strings.Contains(err.Error(), "To fix:") {
+		t.Errorf("error = %q, want 'To fix:' hint", err.Error())
+	}
+	if !strings.Contains(err.Error(), "git worktree unlock") {
+		t.Errorf("error = %q, want 'git worktree unlock' hint fragment", err.Error())
+	}
 }
 
 func TestRenameWorktreeBranchRenameFails(t *testing.T) {

--- a/internal/operations/rename_test.go
+++ b/internal/operations/rename_test.go
@@ -157,6 +157,95 @@ func TestRenameWorktreeBranchRenameFailsRollbackFails(t *testing.T) {
 	}
 }
 
+func TestRenameWorktreeBranchExistsHint(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == cmdRevParse {
+				return "", nil // BranchExists returns true
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
+	_, err := RenameWorktree(r, wt, "auth", wtDir, false)
+	if err == nil {
+		t.Fatal("expected error for existing branch")
+	}
+	if !strings.Contains(err.Error(), "To fix:") {
+		t.Errorf("error = %q, want 'To fix:' hint", err.Error())
+	}
+	if !strings.Contains(err.Error(), "git branch -D") {
+		t.Errorf("error = %q, want 'git branch -D' hint fragment", err.Error())
+	}
+}
+
+func TestRenameWorktreeBranchRenameFailsHint(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == cmdRevParse {
+				return "", errGitFailed
+			}
+			if len(args) >= 2 && args[0] == cmdWorktree && args[1] == cmdMove {
+				return "", nil
+			}
+			if len(args) >= 2 && args[0] == "branch" && args[1] == "-m" {
+				return "", errors.New(errRenameFailed)
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
+	_, err := RenameWorktree(r, wt, "auth", wtDir, false)
+	if err == nil {
+		t.Fatal("expected error from branch rename failure")
+	}
+	if !strings.Contains(err.Error(), "To fix:") {
+		t.Errorf("error = %q, want 'To fix:' hint", err.Error())
+	}
+	if !strings.Contains(err.Error(), "git branch -m") {
+		t.Errorf("error = %q, want 'git branch -m' hint fragment", err.Error())
+	}
+}
+
+func TestRenameWorktreeBranchRenameFailsRollbackFailsHint(t *testing.T) {
+	moveCount := 0
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == cmdRevParse {
+				return "", errGitFailed
+			}
+			if len(args) >= 2 && args[0] == cmdWorktree && args[1] == cmdMove {
+				moveCount++
+				if moveCount == 2 {
+					return "", errors.New("rollback move failed")
+				}
+				return "", nil
+			}
+			if len(args) >= 2 && args[0] == "branch" && args[1] == "-m" {
+				return "", errors.New(errRenameFailed)
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
+	_, err := RenameWorktree(r, wt, "auth", wtDir, false)
+	if err == nil {
+		t.Fatal("expected error from branch rename + rollback failure")
+	}
+	if !strings.Contains(err.Error(), "To fix:") {
+		t.Errorf("error = %q, want 'To fix:' hint", err.Error())
+	}
+	if !strings.Contains(err.Error(), "git worktree move") {
+		t.Errorf("error = %q, want 'git worktree move' hint fragment", err.Error())
+	}
+}
+
 func TestRenameWorktreeNoPrefixMatch(t *testing.T) {
 	// Branch without a recognized prefix falls back to default prefix
 	r := &mockRunner{

--- a/tests/e2e/init_test.go
+++ b/tests/e2e/init_test.go
@@ -190,6 +190,24 @@ func TestInitFailsOutsideGitRepo(t *testing.T) {
 	rimbaFail(t, dir, "init")
 }
 
+func TestInitGitignoreWriteFailHint(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupRepo(t)
+	// Pre-create a read-only .gitignore so EnsureGitignore fails to write it.
+	gitignorePath := filepath.Join(repo, gitignoreFile)
+	if err := os.WriteFile(gitignorePath, []byte("node_modules\n"), 0444); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(gitignorePath, 0644) }) //nolint:errcheck // cleanup best-effort
+
+	r := rimbaFail(t, repo, "init")
+	assertContains(t, r.Stderr, "To fix:")
+	assertContains(t, r.Stderr, ".gitignore")
+}
+
 func TestInitWithAgentsFlag(t *testing.T) {
 	if testing.Short() {
 		t.Skip(skipE2E)

--- a/tests/e2e/rename_test.go
+++ b/tests/e2e/rename_test.go
@@ -127,6 +127,8 @@ func TestRenameFailsBranchExists(t *testing.T) {
 
 	r := rimbaFail(t, repo, "rename", taskBrExist, taskBrExistNew)
 	assertContains(t, r.Stderr, "already exists")
+	assertContains(t, r.Stderr, "To fix:")
+	assertContains(t, r.Stderr, "git branch -D")
 }
 
 func TestRenamePartialFailRollback(t *testing.T) {
@@ -154,6 +156,7 @@ func TestRenamePartialFailRollback(t *testing.T) {
 	// Error should report the branch rename failure and successful rollback.
 	assertContains(t, r.Stderr, "failed to rename branch")
 	assertContains(t, r.Stderr, "moved back")
+	assertContains(t, r.Stderr, "To fix:")
 	assertContains(t, r.Stderr, "git branch -m")
 
 	// Worktree should be back at its original path (rollback succeeded).


### PR DESCRIPTION
## Summary

- Wrap 9 bare `fmt.Errorf` sites in `cmd/init.go` with `errhint.WithFix`; extract `localConfigHint` and `gitignoreHint` package-level consts for repeated messages
- Hoist hand-rolled `\nTo recover:` / `\nTo retry:` strings out of `internal/operations/rename.go` into `errhint.WithFix`; wrap the branch-already-exists site; augment existing unit tests and e2e cases to assert `"To fix:"` + hint fragment
- Wrap 13 bare `fmt.Errorf` sites in `cmd/update.go` (network, binary, PATH stages); extract `retryUpdateHint` const; no new tests — orchestration lacks FS/process seams (tracked in #195)

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] E2E tests pass (`make test-e2e`)

## Issue

Closes #172
