### PR TITLE
[feat] Scripting affordances: --dry-run on destructive cmds and --skip-deps/--skip-hooks on rename

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/hint"
+	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/spf13/cobra"
 )
@@ -16,8 +16,10 @@ const (
 var archiveCmd = &cobra.Command{
 	Use:   "archive <task>",
 	Short: "Archive a worktree (remove directory, keep branch)",
-	Long:  "Removes the worktree directory but preserves the local branch for later restoration with `rimba restore`.",
-	Args:  cobra.ExactArgs(1),
+	Long:  "Removes the worktree directory but preserves the local branch for later restoration with `rimba restore`. Use --dry-run to preview what would be archived without making changes.",
+	Example: `  rimba archive auth           # archive worktree, keep branch
+  rimba archive auth --dry-run # preview without archiving`,
+	Args: cobra.ExactArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -33,23 +35,40 @@ var archiveCmd = &cobra.Command{
 			return err
 		}
 
+		force, _ := cmd.Flags().GetBool(flagForce)
+		dryRun, _ := cmd.Flags().GetBool(flagDryRun)
+
 		hint.New(cmd, hintPainter(cmd)).
 			Add(flagForce, hintForceArchive).
+			Add(flagDryRun, hintDryRun).
 			Show()
 
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
 
-		force, _ := cmd.Flags().GetBool(flagForce)
 		s.Start("Archiving worktree...")
-		if err := git.RemoveWorktree(r, wt.Path, force); err != nil {
+		result, err := operations.ArchiveWorktree(r, operations.ArchiveParams{
+			Path:   wt.Path,
+			Branch: wt.Branch,
+			Force:  force,
+			DryRun: dryRun,
+		})
+		if err != nil {
 			return err
 		}
 		s.Stop()
 
+		if dryRun {
+			out := cmd.OutOrStdout()
+			for _, step := range result.Plan.Steps {
+				fmt.Fprintf(out, "[dry-run] %s\n", step)
+			}
+			return nil
+		}
+
 		out := cmd.OutOrStdout()
-		fmt.Fprintf(out, "Archived worktree: %s\n", wt.Path)
-		fmt.Fprintf(out, "  Branch preserved: %s\n", wt.Branch)
+		fmt.Fprintf(out, "Archived worktree: %s\n", result.Path)
+		fmt.Fprintf(out, "  Branch preserved: %s\n", result.Branch)
 		fmt.Fprintf(out, "  To restore: rimba restore %s\n", task)
 		return nil
 	},
@@ -57,5 +76,6 @@ var archiveCmd = &cobra.Command{
 
 func init() {
 	archiveCmd.Flags().BoolP(flagForce, "f", false, "Force archival even if worktree is dirty")
+	archiveCmd.Flags().Bool(flagDryRun, false, "Preview what would be archived without making changes")
 	rootCmd.AddCommand(archiveCmd)
 }

--- a/cmd/archive_test.go
+++ b/cmd/archive_test.go
@@ -37,6 +37,40 @@ func TestArchiveSuccess(t *testing.T) {
 	}
 }
 
+func TestArchiveDryRun(t *testing.T) {
+	worktreeRemoved := false
+	restore := overrideNewRunner(&mockRunner{
+		run: func(args ...string) (string, error) {
+			if args[0] == cmdWorktreeTest && args[1] == cmdRemove {
+				worktreeRemoved = true
+			}
+			switch {
+			case args[0] == cmdRevParse && args[1] == cmdShowToplevel:
+				return repoPath, nil
+			case args[0] == cmdWorktreeTest && args[1] == cmdList:
+				return wtRepo + headMainBlock + "\n" +
+					wtFeatureLogin + "\n" + headDEF456 + "\n" + branchRefFeatureLogin + "\n", nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	})
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().Bool(flagDryRun, false, "")
+	_ = cmd.Flags().Set(flagDryRun, "true")
+	if err := archiveCmd.RunE(cmd, []string{taskLogin}); err != nil {
+		t.Fatalf("archiveCmd.RunE: %v", err)
+	}
+	if worktreeRemoved {
+		t.Error("worktree must not be removed in dry-run mode")
+	}
+	if !strings.Contains(buf.String(), "[dry-run]") {
+		t.Errorf("output = %q, want '[dry-run]' prefix", buf.String())
+	}
+}
+
 func TestArchiveNotFound(t *testing.T) {
 	restore := overrideNewRunner(&mockRunner{
 		run: func(args ...string) (string, error) {

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -14,7 +14,6 @@ import (
 )
 
 const (
-	flagDryRun = "dry-run"
 	flagMerged = "merged"
 	flagStale  = "stale"
 

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -98,6 +98,8 @@ var duplicateCmd = &cobra.Command{
 		}
 
 		dryRun, _ := cmd.Flags().GetBool(flagDryRun)
+		skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
+		skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
 
 		hint.New(cmd, hintPainter(cmd)).
 			Add(flagSkipDeps, hintSkipDeps).
@@ -112,11 +114,9 @@ var duplicateCmd = &cobra.Command{
 			if len(cfg.CopyFiles) > 0 {
 				fmt.Fprintf(out, "[dry-run] would copy files: %v\n", cfg.CopyFiles)
 			}
-			skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
 			if !skipDeps {
 				fmt.Fprintf(out, "[dry-run] would install deps\n")
 			}
-			skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
 			if !skipHooks && len(cfg.PostCreate) > 0 {
 				fmt.Fprintf(out, "[dry-run] would run post-create hooks\n")
 			}
@@ -133,8 +133,6 @@ var duplicateCmd = &cobra.Command{
 		}
 
 		// Post-create setup: copy files, deps, hooks
-		skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
-		skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
 		var configModules []config.ModuleConfig
 		if cfg.Deps != nil {
 			configModules = cfg.Deps.Modules

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -25,8 +25,11 @@ const (
 var duplicateCmd = &cobra.Command{
 	Use:   "duplicate <task>",
 	Short: "Create a new worktree from an existing worktree",
-	Long:  "Creates a new worktree branched from an existing worktree's branch, inheriting its prefix. Auto-suffixes with -1, -2, etc. unless --as is provided.",
-	Args:  cobra.ExactArgs(1),
+	Long:  "Creates a new worktree branched from an existing worktree's branch, inheriting its prefix. Auto-suffixes with -1, -2, etc. unless --as is provided. Use --dry-run to preview what would be created without making changes.",
+	Example: `  rimba duplicate auth             # duplicate auth worktree (auto-suffix)
+  rimba duplicate auth --as copy    # duplicate with custom name
+  rimba duplicate auth --dry-run    # preview without duplicating`,
+	Args: cobra.ExactArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -94,11 +97,31 @@ var duplicateCmd = &cobra.Command{
 			return fmt.Errorf("worktree path already exists: %s", wtPath)
 		}
 
+		dryRun, _ := cmd.Flags().GetBool(flagDryRun)
+
 		hint.New(cmd, hintPainter(cmd)).
 			Add(flagSkipDeps, hintSkipDeps).
 			Add(flagSkipHooks, hintSkipHooks).
 			Add(flagAs, hintAs).
+			Add(flagDryRun, hintDryRun).
 			Show()
+
+		if dryRun {
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "[dry-run] would create worktree: %s (branch %s from %s)\n", wtPath, newBranch, wt.Branch)
+			if len(cfg.CopyFiles) > 0 {
+				fmt.Fprintf(out, "[dry-run] would copy files: %v\n", cfg.CopyFiles)
+			}
+			skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
+			if !skipDeps {
+				fmt.Fprintf(out, "[dry-run] would install deps\n")
+			}
+			skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
+			if !skipHooks && len(cfg.PostCreate) > 0 {
+				fmt.Fprintf(out, "[dry-run] would run post-create hooks\n")
+			}
+			return nil
+		}
 
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
@@ -159,5 +182,6 @@ func init() {
 	duplicateCmd.Flags().String(flagAs, "", "Custom name for the duplicate worktree")
 	duplicateCmd.Flags().Bool(flagSkipDeps, false, "Skip dependency detection and installation")
 	duplicateCmd.Flags().Bool(flagSkipHooks, false, "Skip post-create hooks")
+	duplicateCmd.Flags().Bool(flagDryRun, false, "Preview what would be duplicated without making changes")
 	rootCmd.AddCommand(duplicateCmd)
 }

--- a/cmd/duplicate_test.go
+++ b/cmd/duplicate_test.go
@@ -265,6 +265,70 @@ func TestDuplicateWorktreePathAlreadyExists(t *testing.T) {
 	}
 }
 
+func TestDuplicateDryRun(t *testing.T) {
+	repoDir := t.TempDir()
+	wtDir := filepath.Join(repoDir, "worktrees")
+	_ = os.MkdirAll(wtDir, 0755)
+	cfg := &config.Config{DefaultSource: branchMain, WorktreeDir: "worktrees"}
+
+	worktreeOut := strings.Join([]string{
+		wtPrefix + repoDir,
+		headABC123,
+		branchRefMain,
+		"",
+		wtFeatureLogin,
+		headDEF456,
+		branchRefFeatureLogin,
+		"",
+	}, "\n")
+
+	addWorktreeCalled := false
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdGitCommonDir {
+				return filepath.Join(repoDir, ".git"), nil
+			}
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdRevParse {
+				return "", errGitFailed // BranchExists returns false
+			}
+			return worktreeOut, nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == cmdWorktreeTest && args[1] == "add" {
+				addWorktreeCalled = true
+			}
+			return "", nil
+		},
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().String(flagAs, "", "")
+	cmd.Flags().Bool(flagSkipDeps, false, "")
+	cmd.Flags().Bool(flagSkipHooks, false, "")
+	cmd.Flags().Bool(flagDryRun, false, "")
+	_ = cmd.Flags().Set(flagDryRun, "true")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	if err := duplicateCmd.RunE(cmd, []string{"login"}); err != nil {
+		t.Fatalf("duplicateCmd.RunE: %v", err)
+	}
+	if addWorktreeCalled {
+		t.Error("git worktree add must not be called in dry-run mode")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[dry-run]") {
+		t.Errorf("output = %q, want '[dry-run]' prefix", out)
+	}
+	if strings.Contains(out, "Duplicated worktree") {
+		t.Errorf("output = %q, must not contain 'Duplicated worktree' in dry-run", out)
+	}
+}
+
 func TestDuplicateWorktreeNotFound(t *testing.T) {
 	repoDir := t.TempDir()
 	cfg := &config.Config{DefaultSource: branchMain, WorktreeDir: "worktrees"}

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -25,8 +25,11 @@ const (
 var mergeCmd = &cobra.Command{
 	Use:   "merge <source-task>",
 	Short: "Merge a worktree branch into main or another worktree",
-	Long:  "Merges the source worktree's branch into main (default) or another worktree. Auto-deletes the source when merging to main unless --keep is set. Keeps the source when merging between worktrees unless --delete is set.",
-	Args:  cobra.ExactArgs(1),
+	Long:  "Merges the source worktree's branch into main (default) or another worktree. Auto-deletes the source when merging to main unless --keep is set. Keeps the source when merging between worktrees unless --delete is set. Use --dry-run to preview what would happen without making changes.",
+	Example: `  rimba merge auth             # merge auth into main
+  rimba merge auth --keep      # merge but keep the worktree
+  rimba merge auth --dry-run   # preview without merging`,
+	Args: cobra.ExactArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -52,11 +55,13 @@ var mergeCmd = &cobra.Command{
 		noFF, _ := cmd.Flags().GetBool(flagNoFF)
 		keep, _ := cmd.Flags().GetBool(flagKeep)
 		del, _ := cmd.Flags().GetBool(flagDelete)
+		dryRun, _ := cmd.Flags().GetBool(flagDryRun)
 
 		hint.New(cmd, hintPainter(cmd)).
 			Add(flagNoFF, hintNoFF).
 			Add(flagKeep, hintKeep).
 			Add(flagInto, hintInto).
+			Add(flagDryRun, hintDryRun).
 			Show()
 
 		s := spinner.New(spinnerOpts(cmd))
@@ -73,12 +78,21 @@ var mergeCmd = &cobra.Command{
 			NoFF:          noFF,
 			Keep:          keep,
 			Delete:        del,
+			DryRun:        dryRun,
 		}, func(msg string) { s.Update(msg) })
 		if err != nil {
 			return err
 		}
 
 		s.Stop()
+
+		if dryRun {
+			out := cmd.OutOrStdout()
+			for _, step := range result.Plan.Steps {
+				fmt.Fprintf(out, "[dry-run] %s\n", step)
+			}
+			return nil
+		}
 
 		fmt.Fprintf(cmd.OutOrStdout(), "Merged %s into %s\n", result.SourceBranch, result.TargetLabel)
 
@@ -102,6 +116,7 @@ func init() {
 	mergeCmd.Flags().Bool(flagNoFF, false, "Force a merge commit (no fast-forward)")
 	mergeCmd.Flags().Bool(flagKeep, false, "Keep source worktree after merging into main")
 	mergeCmd.Flags().Bool(flagDelete, false, "Delete source worktree after merging into another worktree")
+	mergeCmd.Flags().Bool(flagDryRun, false, "Preview what would be merged/cleaned up without making changes")
 	mergeCmd.MarkFlagsMutuallyExclusive(flagKeep, flagDelete)
 
 	_ = mergeCmd.RegisterFlagCompletionFunc(flagInto, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -404,6 +404,33 @@ func TestMergeTargetDirtyInto(t *testing.T) {
 	}
 }
 
+func TestMergeDryRun(t *testing.T) {
+	cfg := &config.Config{DefaultSource: branchMain, WorktreeDir: defaultRelativeWtDir}
+	r := mergeTestRunner(nil)
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().String(flagInto, "", "")
+	cmd.Flags().Bool(flagNoFF, false, "")
+	cmd.Flags().Bool(flagKeep, false, "")
+	cmd.Flags().Bool(flagDelete, false, "")
+	cmd.Flags().Bool(flagDryRun, false, "")
+	_ = cmd.Flags().Set(flagDryRun, "true")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	if err := mergeCmd.RunE(cmd, []string{"login"}); err != nil {
+		t.Fatalf(fatalMergeRunE, err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[dry-run]") {
+		t.Errorf("output = %q, want '[dry-run]' prefix", out)
+	}
+	if strings.Contains(out, "Merged feature/login") {
+		t.Errorf("output = %q, must not contain 'Merged' in dry-run mode", out)
+	}
+}
+
 func TestMergeWithNoFF(t *testing.T) {
 	cfg := &config.Config{DefaultSource: branchMain, WorktreeDir: defaultRelativeWtDir}
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -20,8 +20,11 @@ const (
 var removeCmd = &cobra.Command{
 	Use:   "remove <task>",
 	Short: "Remove a worktree and delete its branch",
-	Long:  "Removes the worktree for the given task and deletes the local branch. Use --keep-branch to preserve the branch.",
-	Args:  cobra.ExactArgs(1),
+	Long:  "Removes the worktree for the given task and deletes the local branch. Use --keep-branch to preserve the branch. Use --dry-run to preview what would be removed without making changes.",
+	Example: `  rimba remove auth             # remove worktree and branch
+  rimba remove auth --keep-branch  # preserve the local branch
+  rimba remove auth --dry-run   # preview without removing`,
+	Args: cobra.ExactArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -40,10 +43,21 @@ var removeCmd = &cobra.Command{
 		hint.New(cmd, hintPainter(cmd)).
 			Add(flagKeepBranch, hintKeepBranch).
 			Add(flagForce, hintForceRm).
+			Add(flagDryRun, hintDryRun).
 			Show()
 
 		keepBranch, _ := cmd.Flags().GetBool(flagKeepBranch)
 		force, _ := cmd.Flags().GetBool(flagForce)
+		dryRun, _ := cmd.Flags().GetBool(flagDryRun)
+
+		if dryRun {
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "[dry-run] would remove worktree: %s\n", wt.Path)
+			if !keepBranch {
+				fmt.Fprintf(out, "[dry-run] would delete branch: %s\n", wt.Branch)
+			}
+			return nil
+		}
 
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
@@ -75,5 +89,6 @@ var removeCmd = &cobra.Command{
 func init() {
 	removeCmd.Flags().BoolP(flagKeepBranch, "k", false, "Keep the local branch after removing the worktree")
 	removeCmd.Flags().BoolP(flagForce, "f", false, "Force removal even if worktree is dirty")
+	removeCmd.Flags().Bool(flagDryRun, false, "Preview what would be removed without making changes")
 	rootCmd.AddCommand(removeCmd)
 }

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -102,6 +102,32 @@ func TestRemoveWorktreeFails(t *testing.T) {
 	}
 }
 
+func TestRemoveDryRun(t *testing.T) {
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return removeWorktreeOut, nil },
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().Bool(flagKeepBranch, false, "")
+	cmd.Flags().Bool(flagForce, false, "")
+	cmd.Flags().Bool(flagDryRun, false, "")
+	_ = cmd.Flags().Set(flagDryRun, "true")
+
+	if err := removeCmd.RunE(cmd, []string{"login"}); err != nil {
+		t.Fatalf("removeCmd.RunE: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[dry-run]") {
+		t.Errorf("output = %q, want '[dry-run]' prefix", out)
+	}
+	if strings.Contains(out, "Removed worktree") {
+		t.Errorf("output = %q, must not contain 'Removed worktree' in dry-run mode", out)
+	}
+}
+
 func TestRemoveBranchDeleteFails(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/hint"
 	"github.com/lugassawan/rimba/internal/operations"
+	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/spf13/cobra"
 )
@@ -14,8 +16,11 @@ import (
 var renameCmd = &cobra.Command{
 	Use:   "rename <task> <new-task>",
 	Short: "Rename a worktree's task, branch, and directory",
-	Long:  "Renames the worktree for the given task, updating its branch name and directory to match the new task name.",
-	Args:  cobra.ExactArgs(2),
+	Long:  "Renames the worktree for the given task, updating its branch name and directory to match the new task name. Use --skip-deps to skip dependency refresh and --skip-hooks to skip post-rename hooks.",
+	Example: `  rimba rename auth auth-v2                    # rename auth worktree
+  rimba rename auth auth-v2 --skip-hooks       # skip post-rename hooks
+  rimba rename auth auth-v2 --skip-deps        # skip dep refresh`,
+	Args: cobra.ExactArgs(2),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			return completeWorktreeTasks(cmd, toComplete), cobra.ShellCompDirectiveNoFileComp
@@ -43,6 +48,13 @@ var renameCmd = &cobra.Command{
 		_, newTask = operations.ResolveTaskInput(newTask, repoRoot)
 
 		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
+		skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
+		skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
+
+		hint.New(cmd, hintPainter(cmd)).
+			Add(flagSkipDeps, hintSkipDeps).
+			Add(flagSkipHooks, hintSkipHooksRename).
+			Show()
 
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
@@ -50,7 +62,27 @@ var renameCmd = &cobra.Command{
 		force, _ := cmd.Flags().GetBool(flagForce)
 		s.Start("Renaming worktree...")
 
-		if _, err := operations.RenameWorktree(r, wt, newTask, wtDir, force); err != nil {
+		result, err := operations.RenameWorktree(r, wt, newTask, wtDir, force)
+		if err != nil {
+			return err
+		}
+
+		prefixes := resolver.AllPrefixes()
+		svc, _, _ := resolver.ServiceFromBranch(wt.Branch, prefixes)
+		var configModules []config.ModuleConfig
+		if cfg.Deps != nil {
+			configModules = cfg.Deps.Modules
+		}
+		if _, err := operations.PostRenameSetup(r, operations.PostRenameParams{
+			WtPath:        result.NewPath,
+			Service:       svc,
+			SkipDeps:      skipDeps,
+			AutoDetect:    cfg.IsAutoDetectDeps(),
+			ConfigModules: configModules,
+			SkipHooks:     skipHooks,
+			PostRename:    cfg.PostRename,
+			Concurrency:   cfg.DepsConcurrency(),
+		}, func(msg string) { s.Update(msg) }); err != nil {
 			return err
 		}
 
@@ -62,5 +94,7 @@ var renameCmd = &cobra.Command{
 
 func init() {
 	renameCmd.Flags().BoolP(flagForce, "f", false, "Force rename even if worktree is locked")
+	renameCmd.Flags().Bool(flagSkipDeps, false, "Skip dependency refresh after rename")
+	renameCmd.Flags().Bool(flagSkipHooks, false, "Skip post-rename hooks")
 	rootCmd.AddCommand(renameCmd)
 }

--- a/cmd/rename_test.go
+++ b/cmd/rename_test.go
@@ -130,6 +130,123 @@ func TestRenameWorktreeNotFound(t *testing.T) {
 	}
 }
 
+func makeRenameWorktreeOut(repoDir string) string {
+	return strings.Join([]string{
+		wtPrefix + repoDir,
+		headABC123,
+		branchRefMain,
+		"",
+		wtFeatureLogin,
+		headDEF456,
+		branchRefFeatureLogin,
+		"",
+	}, "\n")
+}
+
+func makeRenameRunner(repoDir, worktreeOut string) *mockRunner {
+	return &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdGitCommonDir {
+				return filepath.Join(repoDir, ".git"), nil
+			}
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoDir, nil
+			}
+			if len(args) >= 1 && args[0] == cmdRevParse {
+				return "", errGitFailed
+			}
+			return worktreeOut, nil
+		},
+		runInDir: noopRunInDir,
+	}
+}
+
+func TestRenameRunsHooksWhenConfigured(t *testing.T) {
+	// WorktreeDir must be relative; cmd layer joins it with repoRoot.
+	// new branch = feature/auth → new path = <repoDir>/wt/feature-auth
+	repoDir := t.TempDir()
+	newWtPath := filepath.Join(repoDir, "wt", "feature-auth")
+	_ = os.MkdirAll(newWtPath, 0755)
+	marker := filepath.Join(repoDir, "hook-ran")
+
+	cfg := &config.Config{
+		WorktreeDir:   "wt",
+		DefaultSource: branchMain,
+		PostRename:    []string{"touch " + marker},
+	}
+	worktreeOut := makeRenameWorktreeOut(repoDir)
+	restore := overrideNewRunner(makeRenameRunner(repoDir, worktreeOut))
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().Bool(flagSkipDeps, false, "")
+	cmd.Flags().Bool(flagSkipHooks, false, "")
+	_ = cmd.Flags().Set(flagSkipDeps, "true")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	if err := renameCmd.RunE(cmd, []string{"login", "auth"}); err != nil {
+		t.Fatalf("renameCmd.RunE: %v", err)
+	}
+	if _, err := os.Stat(marker); os.IsNotExist(err) {
+		t.Error("post-rename hook did not run; expected marker file to be created")
+	}
+}
+
+func TestRenameSkipHooks(t *testing.T) {
+	repoDir := t.TempDir()
+	hookDir := t.TempDir()
+	marker := filepath.Join(hookDir, "hook-ran")
+	cfg := &config.Config{
+		WorktreeDir:   hookDir,
+		DefaultSource: branchMain,
+		PostRename:    []string{"touch " + marker},
+	}
+	worktreeOut := makeRenameWorktreeOut(repoDir)
+	restore := overrideNewRunner(makeRenameRunner(repoDir, worktreeOut))
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().Bool(flagSkipDeps, false, "")
+	cmd.Flags().Bool(flagSkipHooks, false, "")
+	_ = cmd.Flags().Set(flagSkipDeps, "true")
+	_ = cmd.Flags().Set(flagSkipHooks, "true")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	if err := renameCmd.RunE(cmd, []string{"login", "auth"}); err != nil {
+		t.Fatalf("renameCmd.RunE: %v", err)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("post-rename hook must not run when --skip-hooks is set")
+	}
+	if !strings.Contains(buf.String(), "Renamed worktree") {
+		t.Errorf("output = %q, want 'Renamed worktree'", buf.String())
+	}
+}
+
+func TestRenameSkipDeps(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{WorktreeDir: defaultRelativeWtDir, DefaultSource: branchMain}
+	worktreeOut := makeRenameWorktreeOut(repoDir)
+	restore := overrideNewRunner(makeRenameRunner(repoDir, worktreeOut))
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().BoolP("force", "f", false, "")
+	cmd.Flags().Bool(flagSkipDeps, false, "")
+	cmd.Flags().Bool(flagSkipHooks, false, "")
+	_ = cmd.Flags().Set(flagSkipDeps, "true")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	if err := renameCmd.RunE(cmd, []string{"login", "auth"}); err != nil {
+		t.Fatalf("renameCmd.RunE: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Renamed worktree") {
+		t.Errorf("output = %q, want 'Renamed worktree'", buf.String())
+	}
+}
+
 func TestRenameMoveFails(t *testing.T) {
 	repoDir := t.TempDir()
 	cfg := &config.Config{WorktreeDir: defaultRelativeWtDir, DefaultSource: branchMain}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 const (
 	flagDebug        = "debug"
 	flagDetail       = "detail"
+	flagDryRun       = "dry-run"
 	flagForce        = "force"
 	flagJSON         = "json"
 	flagNoColor      = "no-color"
@@ -23,8 +24,10 @@ const (
 	flagStaleDays    = "stale-days"
 	defaultStaleDays = 14
 
-	hintSkipDeps  = "Skip dependency installation (faster, but requires manual install)"
-	hintSkipHooks = "Skip post-create hooks (faster, but automation won't run)"
+	hintDryRun          = "Preview what would be done without making changes"
+	hintSkipDeps        = "Skip dependency installation (faster, but requires manual install)"
+	hintSkipHooks       = "Skip post-create hooks (faster, but automation won't run)"
+	hintSkipHooksRename = "Skip post-rename hooks (faster, but automation won't run)"
 )
 
 // commandName stores the resolved command name for JSON error reporting.

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -34,6 +34,7 @@ type syncContext struct {
 	cfg      *config.Config
 	s        *spinner.Spinner
 	repoRoot string
+	dryRun   bool
 	res      *syncResult // used by syncAll goroutines
 	mu       sync.Mutex  // guards res and output in syncAll
 }
@@ -48,8 +49,11 @@ type syncResult struct {
 var syncCmd = &cobra.Command{
 	Use:   "sync [task]",
 	Short: "Sync worktree(s) with the main branch",
-	Long:  "Rebases (or merges) worktree branches onto the latest main branch and pushes the result. Use --no-push to skip pushing. Use --all to sync all eligible worktrees, or specify a single task.",
-	Args:  cobra.MaximumNArgs(1),
+	Long:  "Rebases (or merges) worktree branches onto the latest main branch and pushes the result. Use --no-push to skip pushing. Use --all to sync all eligible worktrees. Use --dry-run to preview what would be synced without making changes.",
+	Example: `  rimba sync auth             # rebase auth onto main
+  rimba sync --all            # sync all eligible worktrees
+  rimba sync auth --dry-run   # preview without syncing`,
+	Args: cobra.MaximumNArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -64,6 +68,7 @@ var syncCmd = &cobra.Command{
 		useMerge, _ := cmd.Flags().GetBool(flagSyncMerge)
 		includeInherited, _ := cmd.Flags().GetBool(flagIncludeInherited)
 		noPush, _ := cmd.Flags().GetBool(flagNoPush)
+		dryRun, _ := cmd.Flags().GetBool(flagDryRun)
 		push := !noPush
 
 		if !all && len(args) == 0 {
@@ -75,16 +80,21 @@ var syncCmd = &cobra.Command{
 			Add(flagSyncMerge, hintSyncMerge).
 			Add(flagIncludeInherited, hintIncludeInherited).
 			Add(flagNoPush, hintNoPush).
+			Add(flagDryRun, hintDryRun).
 			Show()
 
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
 
 		// Fetch latest from origin (non-fatal if no remote configured)
-		s.Start("Fetching from origin...")
-		if err := git.Fetch(r, "origin"); err != nil {
-			s.Stop()
-			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: fetch failed (no remote?): continuing with local state\n")
+		if dryRun {
+			fmt.Fprintln(cmd.OutOrStdout(), "[dry-run] would fetch origin")
+		} else {
+			s.Start("Fetching from origin...")
+			if err := git.Fetch(r, "origin"); err != nil {
+				s.Stop()
+				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: fetch failed (no remote?): continuing with local state\n")
+			}
 		}
 
 		repoRoot, err := git.MainRepoRoot(r)
@@ -98,7 +108,7 @@ var syncCmd = &cobra.Command{
 		}
 
 		prefixes := resolver.AllPrefixes()
-		sc := &syncContext{cmd: cmd, r: r, cfg: cfg, s: s, repoRoot: repoRoot}
+		sc := &syncContext{cmd: cmd, r: r, cfg: cfg, s: s, repoRoot: repoRoot, dryRun: dryRun}
 
 		if all {
 			return syncAll(sc, worktrees, prefixes, useMerge, includeInherited, push)
@@ -112,6 +122,7 @@ func init() {
 	syncCmd.Flags().Bool(flagSyncMerge, false, "Use merge instead of rebase")
 	syncCmd.Flags().Bool(flagIncludeInherited, false, "Include inherited/duplicate worktrees when using --all")
 	syncCmd.Flags().Bool(flagNoPush, false, "Skip pushing after sync")
+	syncCmd.Flags().Bool(flagDryRun, false, "Preview what would be synced without making changes")
 
 	rootCmd.AddCommand(syncCmd)
 }
@@ -132,6 +143,11 @@ func syncOne(sc *syncContext, input string, worktrees []resolver.WorktreeInfo, p
 			fmt.Errorf("worktree %q has uncommitted changes", task),
 			"Commit or stash changes before syncing: cd "+wt.Path,
 		)
+	}
+
+	if sc.dryRun {
+		printSyncDryRun(sc.cmd, wt.Branch, sc.cfg.DefaultSource, useMerge, push)
+		return nil
 	}
 
 	verb := "Rebasing"
@@ -195,11 +211,20 @@ func syncAll(sc *syncContext, worktrees []resolver.WorktreeInfo, prefixes []stri
 	wg.Wait()
 
 	sc.s.Stop()
-	printSyncSummary(sc.cmd, sc.cfg.DefaultSource, useMerge, sc.res)
+	if !sc.dryRun {
+		printSyncSummary(sc.cmd, sc.cfg.DefaultSource, useMerge, sc.res)
+	}
 	return nil
 }
 
 func syncWorktree(sc *syncContext, mainBranch string, wt resolver.WorktreeInfo, useMerge, push bool) {
+	if sc.dryRun {
+		sc.mu.Lock()
+		defer sc.mu.Unlock()
+		printSyncDryRun(sc.cmd, wt.Branch, mainBranch, useMerge, push)
+		return
+	}
+
 	sr := operations.SyncWorktree(sc.r, mainBranch, wt, useMerge, push)
 
 	sc.mu.Lock()
@@ -232,6 +257,17 @@ func syncWorktree(sc *syncContext, mainBranch string, wt resolver.WorktreeInfo, 
 			}
 			sc.res.failures = append(sc.res.failures, fmt.Sprintf("  %s: push failed: %s\n    To resolve: %s", sr.Branch, sr.PushError, pushHint))
 		}
+	}
+}
+
+func printSyncDryRun(cmd *cobra.Command, branch, mainBranch string, useMerge, push bool) {
+	verb := "rebase"
+	if useMerge {
+		verb = "merge"
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "[dry-run] would %s %s onto %s\n", verb, branch, mainBranch)
+	if push {
+		fmt.Fprintf(cmd.OutOrStdout(), "[dry-run] would push %s to origin\n", branch)
 	}
 }
 

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -515,6 +515,57 @@ func TestPrintSyncSummary(t *testing.T) {
 	})
 }
 
+func TestSyncOneDryRun(t *testing.T) {
+	worktrees := testSyncWorktrees()
+	cmd, buf := newTestCmd()
+	rebaseCalled := false
+	r := &mockRunner{
+		run: func(_ ...string) (string, error) { return "", nil },
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == cmdRebase {
+				rebaseCalled = true
+			}
+			return "", nil
+		},
+	}
+	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd), dryRun: true}
+
+	if err := syncOne(sc, "login", worktrees, testSyncPrefixes(), false, true); err != nil {
+		t.Fatalf("syncOne: %v", err)
+	}
+	if rebaseCalled {
+		t.Error("rebase must not be called in dry-run mode")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[dry-run]") {
+		t.Errorf("output = %q, want '[dry-run]' prefix", out)
+	}
+	if strings.Contains(out, "Rebased") {
+		t.Errorf("output = %q, must not contain 'Rebased' in dry-run", out)
+	}
+}
+
+func TestSyncAllDryRun(t *testing.T) {
+	worktrees := testSyncWorktrees()
+	cmd, buf := newTestCmd()
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", nil },
+		runInDir: noopRunInDir,
+	}
+	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd), dryRun: true}
+
+	if err := syncAll(sc, worktrees, testSyncPrefixes(), false, false, true); err != nil {
+		t.Fatalf("syncAll: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[dry-run]") {
+		t.Errorf("output = %q, want '[dry-run]' lines", out)
+	}
+	if strings.Contains(out, "Rebased") {
+		t.Errorf("output = %q, must not contain 'Rebased' in dry-run", out)
+	}
+}
+
 func TestSyncWorktreeSkipWarningOnStderr(t *testing.T) {
 	var outBuf, errBuf bytes.Buffer
 	cmd := &cobra.Command{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	DefaultSource string   `toml:"default_source,omitempty"`
 	CopyFiles     []string `toml:"copy_files"`
 	PostCreate    []string `toml:"post_create,omitempty"`
+	PostRename    []string `toml:"post_rename,omitempty"`
 
 	Deps *DepsConfig       `toml:"deps,omitempty"`
 	Open map[string]string `toml:"open,omitempty"`
@@ -154,6 +155,9 @@ func Merge(team, local *Config) *Config {
 	}
 	if local.PostCreate != nil {
 		merged.PostCreate = local.PostCreate
+	}
+	if local.PostRename != nil {
+		merged.PostRename = local.PostRename
 	}
 	if local.Deps != nil {
 		merged.Deps = local.Deps

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -260,10 +260,12 @@ func TestMergeSliceReplaces(t *testing.T) {
 		DefaultSource: testDefaultBranch,
 		CopyFiles:     []string{".env", ".envrc"},
 		PostCreate:    []string{"make build"},
+		PostRename:    []string{"echo team-rename"},
 	}
 	local := &config.Config{
 		CopyFiles:  []string{".env.local"},
 		PostCreate: []string{"npm install", "npm run build"},
+		PostRename: []string{"echo local-rename"},
 	}
 
 	merged := config.Merge(team, local)
@@ -272,6 +274,22 @@ func TestMergeSliceReplaces(t *testing.T) {
 	}
 	if !reflect.DeepEqual(merged.PostCreate, []string{"npm install", "npm run build"}) {
 		t.Errorf("PostCreate = %v, want [npm install, npm run build]", merged.PostCreate)
+	}
+	if !reflect.DeepEqual(merged.PostRename, []string{"echo local-rename"}) {
+		t.Errorf("PostRename = %v, want [echo local-rename]", merged.PostRename)
+	}
+}
+
+func TestMergePostRenameNilPreservesTeam(t *testing.T) {
+	team := &config.Config{
+		WorktreeDir: "../wt",
+		PostRename:  []string{"echo team-hook"},
+	}
+	local := &config.Config{} // nil PostRename — team value should survive
+
+	merged := config.Merge(team, local)
+	if !reflect.DeepEqual(merged.PostRename, []string{"echo team-hook"}) {
+		t.Errorf("PostRename = %v, want [echo team-hook]", merged.PostRename)
 	}
 }
 

--- a/internal/operations/archive.go
+++ b/internal/operations/archive.go
@@ -1,0 +1,41 @@
+package operations
+
+import (
+	"fmt"
+
+	"github.com/lugassawan/rimba/internal/git"
+)
+
+// ArchiveParams holds the inputs for an archive operation.
+type ArchiveParams struct {
+	Path   string
+	Branch string
+	Force  bool
+	DryRun bool
+}
+
+// ArchiveResult holds the outcome of an archive operation.
+type ArchiveResult struct {
+	Path   string
+	Branch string
+	Plan   *Plan
+}
+
+// ArchiveWorktree removes the worktree directory while preserving the local branch.
+func ArchiveWorktree(r git.Runner, params ArchiveParams) (ArchiveResult, error) {
+	plan := &Plan{DryRun: params.DryRun}
+	result := ArchiveResult{
+		Path:   params.Path,
+		Branch: params.Branch,
+		Plan:   plan,
+	}
+
+	desc := fmt.Sprintf("remove worktree: %s (branch %s preserved)", params.Path, params.Branch)
+	if err := plan.Do(desc, func() error {
+		return git.RemoveWorktree(r, params.Path, params.Force)
+	}); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}

--- a/internal/operations/archive_test.go
+++ b/internal/operations/archive_test.go
@@ -1,0 +1,81 @@
+package operations
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestArchiveWorktreeSuccess(t *testing.T) {
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", nil },
+		runInDir: noopRunInDir,
+	}
+
+	result, err := ArchiveWorktree(r, ArchiveParams{
+		Path:   pathWtFeatureLogin,
+		Branch: branchFeature,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Path != pathWtFeatureLogin {
+		t.Errorf("path=%q, want %q", result.Path, pathWtFeatureLogin)
+	}
+	if result.Branch != branchFeature {
+		t.Errorf("branch=%q, want %q", result.Branch, branchFeature)
+	}
+	if result.Plan == nil {
+		t.Fatal("expected Plan to be non-nil")
+	}
+	if result.Plan.DryRun {
+		t.Error("expected Plan.DryRun=false for real run")
+	}
+}
+
+func TestArchiveWorktreeDryRun(t *testing.T) {
+	gitCalled := false
+	r := &mockRunner{
+		run: func(_ ...string) (string, error) {
+			gitCalled = true
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	result, err := ArchiveWorktree(r, ArchiveParams{
+		Path:   pathWtFeatureLogin,
+		Branch: branchFeature,
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gitCalled {
+		t.Error("git must not be called in dry-run mode")
+	}
+	if result.Plan == nil || !result.Plan.DryRun {
+		t.Fatal("expected Plan.DryRun=true")
+	}
+	if len(result.Plan.Steps) == 0 {
+		t.Fatal("expected at least one planned step")
+	}
+	if !strings.Contains(result.Plan.Steps[0], pathWtFeatureLogin) {
+		t.Errorf("step should mention worktree path, got: %v", result.Plan.Steps)
+	}
+}
+
+func TestArchiveWorktreeError(t *testing.T) {
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", errors.New("locked") },
+		runInDir: noopRunInDir,
+	}
+
+	_, err := ArchiveWorktree(r, ArchiveParams{
+		Path:   pathWtFeatureLogin,
+		Branch: branchFeature,
+	})
+	if err == nil {
+		t.Fatal("expected error from git failure")
+	}
+}

--- a/internal/operations/merge.go
+++ b/internal/operations/merge.go
@@ -33,7 +33,7 @@ type MergeResult struct {
 	SourceRemoved   bool  // true only if both worktree removed and branch deleted
 	WorktreeRemoved bool  // true if worktree was removed (branch may still exist)
 	RemoveError     error // non-nil if cleanup failed
-	Plan            *Plan // non-nil when DryRun=true; records steps that would execute
+	Plan            *Plan // always non-nil on a successful return; records steps that were (or would be) executed
 }
 
 // dirtyResult holds the outcome of an IsDirty check.

--- a/internal/operations/merge.go
+++ b/internal/operations/merge.go
@@ -21,6 +21,7 @@ type MergeParams struct {
 	NoFF          bool
 	Keep          bool
 	Delete        bool
+	DryRun        bool
 }
 
 // MergeResult holds the outcome of a merge operation.
@@ -32,6 +33,7 @@ type MergeResult struct {
 	SourceRemoved   bool  // true only if both worktree removed and branch deleted
 	WorktreeRemoved bool  // true if worktree was removed (branch may still exist)
 	RemoveError     error // non-nil if cleanup failed
+	Plan            *Plan // non-nil when DryRun=true; records steps that would execute
 }
 
 // dirtyResult holds the outcome of an IsDirty check.
@@ -72,14 +74,16 @@ func MergeWorktree(r git.Runner, params MergeParams, onProgress progress.Func) (
 		targetLabel = target.Branch
 	}
 
+	plan := &Plan{DryRun: params.DryRun}
 	result := MergeResult{
 		SourceBranch:  source.Branch,
 		SourcePath:    source.Path,
 		TargetLabel:   targetLabel,
 		MergingToMain: mergingToMain,
+		Plan:          plan,
 	}
 
-	// Concurrent dirty checks
+	// Concurrent dirty checks (always run — read-only pre-flight)
 	progress.Notify(onProgress, "Checking for uncommitted changes...")
 	if err := checkDirty(r, source.Path, targetDir, params.SourceTask, params.IntoTask, mergingToMain, targetLabel); err != nil {
 		return result, err
@@ -87,7 +91,10 @@ func MergeWorktree(r git.Runner, params MergeParams, onProgress progress.Func) (
 
 	// Execute merge
 	progress.Notify(onProgress, "Merging...")
-	if err := git.Merge(r, targetDir, source.Branch, params.NoFF); err != nil {
+	mergeDesc := fmt.Sprintf("merge %s into %s", source.Branch, targetLabel)
+	if err := plan.Do(mergeDesc, func() error {
+		return git.Merge(r, targetDir, source.Branch, params.NoFF)
+	}); err != nil {
 		return result, errhint.WithFix(
 			fmt.Errorf("merge failed: %w", err),
 			fmt.Sprintf("resolve conflicts in %s, commit, then re-run rimba merge", targetDir),
@@ -98,7 +105,12 @@ func MergeWorktree(r git.Runner, params MergeParams, onProgress progress.Func) (
 	shouldDelete := (mergingToMain && !params.Keep) || (!mergingToMain && params.Delete)
 	if shouldDelete {
 		progress.Notify(onProgress, "Removing worktree...")
-		wtRemoved, brDeleted, rmErr := removeAndCleanup(r, source.Path, source.Branch)
+		var wtRemoved, brDeleted bool
+		rmErr := plan.Do("remove worktree: "+source.Path, func() error {
+			var err error
+			wtRemoved, brDeleted, err = removeAndCleanup(r, source.Path, source.Branch)
+			return err
+		})
 		result.WorktreeRemoved = wtRemoved
 		result.SourceRemoved = wtRemoved && brDeleted
 		if rmErr != nil {

--- a/internal/operations/merge_test.go
+++ b/internal/operations/merge_test.go
@@ -347,6 +347,39 @@ func TestMergeWorktreeSourceDirtyCheckError(t *testing.T) {
 	}
 }
 
+func TestMergeWorktreeDryRun(t *testing.T) {
+	r := mergeRunner(nil)
+
+	result, err := MergeWorktree(r, MergeParams{
+		SourceTask: "login",
+		RepoRoot:   "/repo",
+		MainBranch: "main",
+		DryRun:     true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.SourceRemoved {
+		t.Error("expected source NOT removed in dry-run mode")
+	}
+	if result.Plan == nil {
+		t.Fatal("expected Plan to be non-nil in dry-run mode")
+	}
+	if len(result.Plan.Steps) == 0 {
+		t.Error("expected at least one planned step")
+	}
+	hasMerge := false
+	for _, s := range result.Plan.Steps {
+		if strings.Contains(s, "merge") {
+			hasMerge = true
+			break
+		}
+	}
+	if !hasMerge {
+		t.Errorf("expected a merge step in plan, got: %v", result.Plan.Steps)
+	}
+}
+
 func TestMergeWorktreeTargetDirtyCheckError(t *testing.T) {
 	wt := mergeWorktreeList()
 	r := &mockRunner{

--- a/internal/operations/plan.go
+++ b/internal/operations/plan.go
@@ -1,0 +1,17 @@
+package operations
+
+// Plan records planned steps and gates their execution under dry-run mode.
+type Plan struct {
+	DryRun bool
+	Steps  []string
+}
+
+// Do appends desc to Steps. When DryRun is false, action is also called and
+// its error returned. When DryRun is true, action is skipped and nil returned.
+func (p *Plan) Do(desc string, action func() error) error {
+	p.Steps = append(p.Steps, desc)
+	if p.DryRun {
+		return nil
+	}
+	return action()
+}

--- a/internal/operations/plan_test.go
+++ b/internal/operations/plan_test.go
@@ -1,0 +1,61 @@
+package operations
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPlanDoDryRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		dryRun     bool
+		wantCalled bool
+	}{
+		{"skips action when DryRun=true", true, false},
+		{"executes action when DryRun=false", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Plan{DryRun: tt.dryRun}
+			called := false
+			err := p.Do("step", func() error {
+				called = true
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if called != tt.wantCalled {
+				t.Errorf("called=%v, want %v", called, tt.wantCalled)
+			}
+			if len(p.Steps) != 1 || p.Steps[0] != "step" {
+				t.Errorf("steps=%v, want [step]", p.Steps)
+			}
+		})
+	}
+}
+
+func TestPlanDoPropagatesError(t *testing.T) {
+	p := &Plan{DryRun: false}
+	wantErr := errors.New("boom")
+	err := p.Do("failing step", func() error { return wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error=%v, want %v", err, wantErr)
+	}
+	if len(p.Steps) != 1 {
+		t.Fatalf("expected step recorded even on error, got %v", p.Steps)
+	}
+}
+
+func TestPlanDoAccumulatesSteps(t *testing.T) {
+	p := &Plan{DryRun: true}
+	for _, desc := range []string{"a", "b", "c"} {
+		d := desc
+		if err := p.Do(d, func() error { return nil }); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if len(p.Steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d: %v", len(p.Steps), p.Steps)
+	}
+}

--- a/internal/operations/post_rename.go
+++ b/internal/operations/post_rename.go
@@ -1,6 +1,8 @@
 package operations
 
 import (
+	"fmt"
+
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/deps"
 	"github.com/lugassawan/rimba/internal/git"
@@ -33,7 +35,7 @@ func PostRenameSetup(r git.Runner, params PostRenameParams, onProgress progress.
 		progress.Notify(onProgress, "Refreshing dependencies...")
 		wtEntries, err := git.ListWorktrees(r)
 		if err != nil {
-			return result, err
+			return result, fmt.Errorf("failed to list worktrees for dependency refresh: %w", err)
 		}
 		dp := DepsParams{
 			WtPath:        params.WtPath,

--- a/internal/operations/post_rename.go
+++ b/internal/operations/post_rename.go
@@ -1,0 +1,55 @@
+package operations
+
+import (
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/deps"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/progress"
+)
+
+// PostRenameParams holds the inputs for the post-rename setup sequence.
+type PostRenameParams struct {
+	WtPath        string
+	Service       string
+	SkipDeps      bool
+	AutoDetect    bool
+	ConfigModules []config.ModuleConfig
+	SkipHooks     bool
+	PostRename    []string
+	Concurrency   int
+}
+
+// PostRenameResult holds the outcome of the post-rename setup sequence.
+type PostRenameResult struct {
+	DepsResults []deps.InstallResult
+	HookResults []deps.HookResult
+}
+
+// PostRenameSetup runs the post-rename sequence: refresh deps and run hooks.
+func PostRenameSetup(r git.Runner, params PostRenameParams, onProgress progress.Func) (PostRenameResult, error) {
+	var result PostRenameResult
+
+	if !params.SkipDeps {
+		progress.Notify(onProgress, "Refreshing dependencies...")
+		wtEntries, err := git.ListWorktrees(r)
+		if err != nil {
+			return result, err
+		}
+		dp := DepsParams{
+			WtPath:        params.WtPath,
+			Service:       params.Service,
+			AutoDetect:    params.AutoDetect,
+			ConfigModules: params.ConfigModules,
+			Entries:       wtEntries,
+			Concurrency:   params.Concurrency,
+		}
+		result.DepsResults = InstallDeps(r, dp, onProgress)
+	}
+
+	if !params.SkipHooks && len(params.PostRename) > 0 {
+		progress.Notify(onProgress, "Running post-rename hooks...")
+		result.HookResults = RunPostCreateHooks(params.WtPath, params.PostRename, onProgress)
+	}
+
+	return result, nil
+}

--- a/internal/operations/post_rename_test.go
+++ b/internal/operations/post_rename_test.go
@@ -1,0 +1,104 @@
+package operations
+
+import (
+	"testing"
+)
+
+func newNoopRunner() *mockRunner {
+	return &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", nil },
+		runInDir: noopRunInDir,
+	}
+}
+
+func TestPostRenameSetupSkipAll(t *testing.T) {
+	params := PostRenameParams{
+		WtPath:     "/wt/feature/auth",
+		SkipDeps:   true,
+		SkipHooks:  true,
+		PostRename: []string{"echo hook"},
+	}
+	res, err := PostRenameSetup(newNoopRunner(), params, nil)
+	if err != nil {
+		t.Fatalf("PostRenameSetup: %v", err)
+	}
+	if len(res.DepsResults) != 0 {
+		t.Errorf("expected no deps results when SkipDeps=true, got %d", len(res.DepsResults))
+	}
+	if len(res.HookResults) != 0 {
+		t.Errorf("expected no hook results when SkipHooks=true, got %d", len(res.HookResults))
+	}
+}
+
+func TestPostRenameSetupRunsHooks(t *testing.T) {
+	hookDir := t.TempDir()
+	params := PostRenameParams{
+		WtPath:     hookDir,
+		SkipDeps:   true,
+		SkipHooks:  false,
+		PostRename: []string{"echo hook-ran"},
+	}
+	res, err := PostRenameSetup(newNoopRunner(), params, nil)
+	if err != nil {
+		t.Fatalf("PostRenameSetup: %v", err)
+	}
+	if len(res.HookResults) != 1 {
+		t.Fatalf("expected 1 hook result, got %d", len(res.HookResults))
+	}
+	if res.HookResults[0].Error != nil {
+		t.Errorf("hook error = %v, want nil", res.HookResults[0].Error)
+	}
+}
+
+func TestPostRenameSetupNoHooksWhenEmpty(t *testing.T) {
+	params := PostRenameParams{
+		WtPath:     "/wt/feature/auth",
+		SkipDeps:   true,
+		SkipHooks:  false,
+		PostRename: nil,
+	}
+	res, err := PostRenameSetup(newNoopRunner(), params, nil)
+	if err != nil {
+		t.Fatalf("PostRenameSetup: %v", err)
+	}
+	if len(res.HookResults) != 0 {
+		t.Errorf("expected no hook results when PostRename is empty, got %d", len(res.HookResults))
+	}
+}
+
+func TestPostRenameSetupHookFailure(t *testing.T) {
+	hookDir := t.TempDir()
+	params := PostRenameParams{
+		WtPath:     hookDir,
+		SkipDeps:   true,
+		SkipHooks:  false,
+		PostRename: []string{"false"},
+	}
+	res, err := PostRenameSetup(newNoopRunner(), params, nil)
+	if err != nil {
+		t.Fatalf("PostRenameSetup: %v", err)
+	}
+	if len(res.HookResults) != 1 {
+		t.Fatalf("expected 1 hook result, got %d", len(res.HookResults))
+	}
+	if res.HookResults[0].Error == nil {
+		t.Error("expected hook failure, got nil error")
+	}
+}
+
+func TestPostRenameSetupDepsNoop(t *testing.T) {
+	// Non-existent path: deps.ResolveModules returns nil → no-op
+	params := PostRenameParams{
+		WtPath:     "/nonexistent/path/that/does/not/exist",
+		SkipDeps:   false,
+		AutoDetect: true,
+		SkipHooks:  true,
+	}
+	res, err := PostRenameSetup(newNoopRunner(), params, nil)
+	if err != nil {
+		t.Fatalf("PostRenameSetup: %v", err)
+	}
+	if len(res.DepsResults) != 0 {
+		t.Errorf("expected no deps results for non-existent path, got %d", len(res.DepsResults))
+	}
+}

--- a/tests/e2e/archive_test.go
+++ b/tests/e2e/archive_test.go
@@ -83,6 +83,26 @@ func TestArchiveDirtyFails(t *testing.T) {
 	rimbaFail(t, repo, "archive", "dirty-fail")
 }
 
+func TestArchiveDryRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", taskArchive+"-dry", flagSkipDepsE2E, flagSkipHooksE2E)
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.BranchName(defaultPrefix, taskArchive+"-dry")
+	wtPath := resolver.WorktreePath(wtDir, branch)
+
+	r := rimbaSuccess(t, repo, "archive", taskArchive+"-dry", flagDryRunE2E)
+	assertContains(t, r.Stdout, "[dry-run]")
+
+	// Worktree must still exist after dry-run
+	assertFileExists(t, wtPath)
+}
+
 func TestArchiveRestoreRoundTrip(t *testing.T) {
 	if testing.Short() {
 		t.Skip(skipE2E)

--- a/tests/e2e/duplicate_test.go
+++ b/tests/e2e/duplicate_test.go
@@ -218,3 +218,27 @@ func TestDuplicateMain(t *testing.T) {
 	r := rimbaFail(t, repo, "duplicate", "main")
 	assertContains(t, r.Stderr, "cannot duplicate the default branch")
 }
+
+func TestDuplicateDryRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", taskDupA, flagSkipDepsE2E, flagSkipHooksE2E)
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+
+	r := rimbaSuccess(t, repo, "duplicate", taskDupA, flagDryRunE2E)
+	assertContains(t, r.Stdout, "[dry-run]")
+
+	// No new worktree should have been created (only taskDupA's dir exists)
+	entries, err := os.ReadDir(wtDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 worktree dir, got %d — dry-run must not create a new worktree", len(entries))
+	}
+}

--- a/tests/e2e/merge_test.go
+++ b/tests/e2e/merge_test.go
@@ -217,3 +217,30 @@ func TestMergeTargetNotFound(t *testing.T) {
 	r := rimbaFail(t, repo, "merge", "merge-no-tgt-src", flagInto, "ghost-target")
 	assertContains(t, r.Stderr, "not found")
 }
+
+func TestMergeDryRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupCleanInitializedRepo(t)
+	mergeSetup(t, repo, "merge-dry-src")
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	srcBranch := resolver.BranchName(defaultPrefix, "merge-dry-src")
+	srcPath := resolver.WorktreePath(wtDir, srcBranch)
+	logBefore := testutil.GitCmd(t, repo, "log", "--oneline", "-1")
+
+	r := rimbaSuccess(t, repo, "merge", "merge-dry-src", flagDryRunE2E)
+	assertContains(t, r.Stdout, "[dry-run]")
+
+	// Source worktree must still exist (not removed)
+	assertFileExists(t, srcPath)
+
+	// No new commit on main
+	logAfter := testutil.GitCmd(t, repo, "log", "--oneline", "-1")
+	if logBefore != logAfter {
+		t.Errorf("dry-run must not create a commit: before=%q after=%q", logBefore, logAfter)
+	}
+}

--- a/tests/e2e/remove_test.go
+++ b/tests/e2e/remove_test.go
@@ -127,3 +127,29 @@ func TestRemoveFailsNoArgs(t *testing.T) {
 	repo := setupInitializedRepo(t)
 	rimbaFail(t, repo, "remove")
 }
+
+func TestRemoveDryRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", taskRm, flagSkipDepsE2E, flagSkipHooksE2E)
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.BranchName(defaultPrefix, taskRm)
+	wtPath := resolver.WorktreePath(wtDir, branch)
+
+	r := rimbaSuccess(t, repo, "remove", taskRm, flagDryRunE2E)
+	assertContains(t, r.Stdout, "[dry-run]")
+
+	// Worktree must still exist after dry-run
+	assertFileExists(t, wtPath)
+
+	// Branch must still exist
+	out := testutil.GitCmd(t, repo, "branch", flagBranchList)
+	if !strings.Contains(out, defaultPrefix+taskRm) {
+		t.Errorf("expected branch %s%s to still exist after dry-run", defaultPrefix, taskRm)
+	}
+}

--- a/tests/e2e/rename_test.go
+++ b/tests/e2e/rename_test.go
@@ -181,3 +181,38 @@ func TestRenameFailsOneArg(t *testing.T) {
 	repo := setupInitializedRepo(t)
 	rimbaFail(t, repo, "rename", "some-task")
 }
+
+func TestRenamePostRenameHookRuns(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	cfg := loadConfig(t, repo)
+	marker := filepath.Join(repo, "hook-ran.txt")
+	cfg.PostRename = []string{"touch " + marker}
+	saveConfig(t, repo, cfg)
+
+	rimbaSuccess(t, repo, "add", "hook-src", flagSkipDepsE2E, flagSkipHooksE2E)
+	rimbaSuccess(t, repo, "rename", "hook-src", "hook-dst", flagSkipDepsE2E)
+
+	assertFileExists(t, marker)
+}
+
+func TestRenameSkipHooksSkipsPostRenameHook(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	cfg := loadConfig(t, repo)
+	marker := filepath.Join(repo, "hook-ran.txt")
+	cfg.PostRename = []string{"touch " + marker}
+	saveConfig(t, repo, cfg)
+
+	rimbaSuccess(t, repo, "add", "hook-skip-src", flagSkipDepsE2E, flagSkipHooksE2E)
+	rimbaSuccess(t, repo, "rename", "hook-skip-src", "hook-skip-dst",
+		flagSkipDepsE2E, flagSkipHooksE2E)
+
+	assertFileNotExists(t, marker)
+}

--- a/tests/e2e/sync_test.go
+++ b/tests/e2e/sync_test.go
@@ -465,3 +465,34 @@ func TestSyncFetchWarningOnStderr(t *testing.T) {
 	assertContains(t, r.Stderr, "Warning: fetch failed")
 	assertNotContains(t, r.Stdout, "Warning: fetch failed")
 }
+
+func TestSyncDryRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, wtPath := syncSetup(t, "sync-dry")
+	headBefore := testutil.GitCmd(t, wtPath, "rev-parse", "HEAD")
+
+	r := rimbaSuccess(t, repo, "sync", "sync-dry", flagDryRunE2E)
+	assertContains(t, r.Stdout, "[dry-run]")
+
+	// Worktree HEAD must not have moved
+	headAfter := testutil.GitCmd(t, wtPath, "rev-parse", "HEAD")
+	if headBefore != headAfter {
+		t.Errorf("dry-run must not rebase: HEAD changed from %q to %q", headBefore, headAfter)
+	}
+}
+
+func TestSyncAllDryRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupCleanInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "sync-all-dry-1")
+	rimbaSuccess(t, repo, "add", "sync-all-dry-2")
+
+	r := rimbaSuccess(t, repo, "sync", "--all", flagDryRunE2E)
+	assertContains(t, r.Stdout, "[dry-run]")
+}

--- a/tests/e2e/sync_test.go
+++ b/tests/e2e/sync_test.go
@@ -493,6 +493,21 @@ func TestSyncAllDryRun(t *testing.T) {
 	rimbaSuccess(t, repo, "add", "sync-all-dry-1")
 	rimbaSuccess(t, repo, "add", "sync-all-dry-2")
 
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	wt1 := resolver.WorktreePath(wtDir, resolver.BranchName(defaultPrefix, "sync-all-dry-1"))
+	wt2 := resolver.WorktreePath(wtDir, resolver.BranchName(defaultPrefix, "sync-all-dry-2"))
+
+	head1Before := testutil.GitCmd(t, wt1, "rev-parse", "HEAD")
+	head2Before := testutil.GitCmd(t, wt2, "rev-parse", "HEAD")
+
 	r := rimbaSuccess(t, repo, "sync", "--all", flagDryRunE2E)
 	assertContains(t, r.Stdout, "[dry-run]")
+
+	if got := testutil.GitCmd(t, wt1, "rev-parse", "HEAD"); got != head1Before {
+		t.Errorf("dry-run must not rebase sync-all-dry-1: HEAD changed from %q to %q", head1Before, got)
+	}
+	if got := testutil.GitCmd(t, wt2, "rev-parse", "HEAD"); got != head2Before {
+		t.Errorf("dry-run must not rebase sync-all-dry-2: HEAD changed from %q to %q", head2Before, got)
+	}
 }


### PR DESCRIPTION
## Summary

- Add `--dry-run` to `merge`, `sync`, `remove`, `archive`, and `duplicate` — prints each planned operation prefixed with `[dry-run]`, exits 0, writes no git state
- Add `--skip-deps` and `--skip-hooks` to `rename`, backed by a new `PostRenameSetup` that refreshes deps and runs `post_rename` hooks configured in `.rimba/settings.toml`
- Introduce shared `Plan.Do(desc, action)` helper in `internal/operations/plan.go` to gate writes uniformly across destructive commands
- Refactor `archive` through new `operations.ArchiveWorktree` so all commands share the same `operations.*` shape
- Promote `flagDryRun`/`hintDryRun` to `cmd/root.go` so the flag is declared consistently across all six commands
- Add `PostRename []string` config field and `operations.PostRenameSetup` mirroring the existing `PostCreateSetup` pattern

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

Smoke-tested manually:
- `rimba remove <task> --dry-run` prints `[dry-run]` lines and leaves worktree intact
- `rimba merge <task> --dry-run` prints plan lines, `git log` unchanged after
- `rimba sync --dry-run` / `sync --all --dry-run` skips fetch, prints per-worktree plan
- `rimba archive <task> --dry-run` prints plan, worktree still exists
- `rimba duplicate <task> --dry-run` prints would-create/copy/deps/hooks plan, no new worktree
- `rimba rename X Y --skip-hooks` / `--skip-deps` skips the respective steps

## Issue

Closes #174