### PR TITLE
[feat] add branch:<branch> task shape for worktree promotion

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -26,25 +26,31 @@ const (
 )
 
 var prArgRe = regexp.MustCompile(`^pr:(\d+)$`)
+var branchArgRe = regexp.MustCompile(`^branch:(.+)$`)
 
 var newGHRunner = gh.Default
 
 var addCmd = &cobra.Command{
-	Use:   "add <task|pr:<num>> or add <service>/<task>",
-	Short: "Create a new worktree for a task or GitHub PR",
+	Use:   "add <task|pr:<num>|branch:<branch>> or add <service>/<task>",
+	Short: "Create a new worktree for a task, GitHub PR, or promote the current branch",
 	Long: `Create a worktree, copy files, install dependencies, and run hooks.
 Use <service>/<task> to scope to a specific service in a monorepo.
 Use pr:<num> to create a worktree from a GitHub PR's head branch.
+Use branch:<branch> to promote the current branch into its own worktree,
+transferring any dirty working-tree state via git stash.
 
   rimba add my-feature
   rimba add my-feature --bugfix          # Use bugfix/ prefix
   rimba add auth-api/my-feature          # Monorepo service scope
   rimba add pr:123                       # Create worktree from PR #123
   rimba add pr:123 --task review/auth    # Override auto-derived task name
+  rimba add branch:feature/my-feature   # Promote current branch to worktree
 
 pr:<num> requires gh installed and authenticated. For cross-fork PRs, rimba adds a
 gh-fork-<owner> remote automatically. Without --task, the task name is derived as
-review/<num>-<slug>. The --task flag is only valid in pr:<num> mode.`,
+review/<num>-<slug>. The --task flag is only valid in pr:<num> mode.
+branch:<branch> requires that <branch> is the currently checked-out branch in the
+main repo and is not the default branch. --source is not valid in branch: mode.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.FromContext(cmd.Context())
@@ -66,6 +72,16 @@ review/<num>-<slug>. The --task flag is only valid in pr:<num> mode.`,
 		if m := prArgRe.FindStringSubmatch(args[0]); m != nil {
 			prNum, _ := strconv.Atoi(m[1])
 			return runAddPR(cmd, r, newGHRunner(), prNum, postOpts, s)
+		}
+
+		if m := branchArgRe.FindStringSubmatch(args[0]); m != nil {
+			if cmd.Flags().Changed(flagSource) {
+				return errhint.WithFix(
+					errors.New("--source is not valid in branch: mode"),
+					"remove the --source flag: branch: promotes an existing branch, not a new one",
+				)
+			}
+			return runAddBranch(cmd, r, cfg, repoRoot, m[1])
 		}
 
 		if cmd.Flags().Changed(flagTask) {
@@ -139,6 +155,25 @@ func runAddTask(cmd *cobra.Command, r git.Runner, arg string, cfg *config.Config
 	}
 	printWorktreeResult(cmd, header, result)
 
+	return nil
+}
+
+func runAddBranch(cmd *cobra.Command, r git.Runner, cfg *config.Config, repoRoot, branch string) error {
+	s := spinner.New(spinnerOpts(cmd))
+	defer s.Stop()
+
+	wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
+	s.Start("Promoting branch to worktree...")
+	wtPath, err := operations.PromoteBranch(cmd.Context(), wtDir, r, repoRoot, branch)
+	if err != nil {
+		return err
+	}
+	s.Stop()
+
+	out := cmd.OutOrStdout()
+	fmt.Fprintf(out, "Promoted branch %q to worktree\n", branch)
+	fmt.Fprintf(out, "  Branch: %s\n", branch)
+	fmt.Fprintf(out, "  Path:   %s\n", wtPath)
 	return nil
 }
 

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -10,11 +10,24 @@ import (
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/testutil"
+	"github.com/spf13/cobra"
 )
 
 const (
 	prCmdAuth = "auth"
 	prCmdPR   = "pr"
+
+	// branch: promote mode constants
+	branchFeatureX     = "feature/x"
+	stashSHACmd        = "deadbeef123"
+	cmdStash           = "stash"
+	cmdSwitch          = "switch"
+	gitSubcmdStashPush = "push"
+	gitSubcmdStashAppl = "apply"
+	gitSubcmdStashDrop = "drop"
+	cmdFlagVerify      = "--verify"
+	cmdFlagShort       = "--short"
+	stashListLineCmd   = stashSHACmd + " stash@{0}"
 )
 
 // makeWorktreeGitRunner builds a mockRunner that simulates a successful worktree creation.
@@ -324,5 +337,415 @@ func TestAddWithService(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "service: api") {
 		t.Errorf("output = %q, want 'service: api'", buf.String())
+	}
+}
+
+// addBranchFlags registers the flags required by addCmd.RunE for branch: mode.
+func addBranchFlags(cmd *cobra.Command) {
+	cmd.Flags().StringP(flagSource, "s", "", "")
+	cmd.Flags().Bool(flagSkipDeps, false, "")
+	cmd.Flags().Bool(flagSkipHooks, false, "")
+}
+
+// branchPromoteRunFn is the Run closure for happy-path branch promotion tests.
+func branchPromoteRunFn(repoDir string) func(args ...string) (string, error) {
+	porcelain := wtPrefix + repoDir + headMainBlock
+	return func(args ...string) (string, error) {
+		switch {
+		case len(args) >= 2 && args[1] == cmdGitCommonDir:
+			return filepath.Join(repoDir, ".git"), nil
+		case len(args) >= 1 && args[0] == cmdSymbolicRef:
+			return refsRemotesOriginMain, nil
+		case len(args) >= 2 && args[0] == cmdRevParse && args[1] == cmdFlagVerify:
+			return "", nil
+		case len(args) >= 2 && args[0] == cmdWorktreeTest && args[1] == cmdList:
+			return porcelain, nil
+		case len(args) >= 3 && args[0] == cmdWorktreeTest && args[1] == gitSubcmdWorktreeAdd:
+			_ = os.MkdirAll(args[2], 0o755)
+			return "", nil
+		}
+		return "", nil
+	}
+}
+
+// branchRunInDirIdentity handles symbolic-ref and status matches; reports the result and whether it matched.
+func branchRunInDirIdentity(dirty bool, args []string) (string, bool) {
+	switch {
+	case len(args) >= 2 && args[0] == cmdSymbolicRef && args[1] == cmdFlagShort:
+		return branchFeatureX, true
+	case len(args) >= 2 && args[0] == cmdStatus && args[1] == "--porcelain":
+		if dirty {
+			return dirtyOutput, true
+		}
+		return "", true
+	}
+	return "", false
+}
+
+// branchRunInDirStashA handles push / rev-parse / switch operations.
+func branchRunInDirStashA(args []string) (string, bool) {
+	switch {
+	case len(args) >= 3 && args[0] == cmdStash && args[1] == gitSubcmdStashPush:
+		return "", true
+	case len(args) >= 2 && args[0] == cmdRevParse && args[1] == "stash@{0}":
+		return stashSHACmd, true
+	case len(args) >= 2 && args[0] == cmdSwitch:
+		return "", true
+	}
+	return "", false
+}
+
+// branchRunInDirStashB handles stash list / apply / drop operations.
+func branchRunInDirStashB(args []string) (string, bool) {
+	switch {
+	case len(args) >= 3 && args[0] == cmdStash && args[1] == cmdList:
+		return stashListLineCmd, true
+	case len(args) >= 3 && args[0] == cmdStash && args[1] == gitSubcmdStashAppl:
+		return "", true
+	case len(args) >= 3 && args[0] == cmdStash && args[1] == gitSubcmdStashDrop:
+		return "", true
+	}
+	return "", false
+}
+
+// branchRunInDirStash handles happy-path stash operations; reports result and whether it matched.
+func branchRunInDirStash(args []string) (string, bool) {
+	if out, ok := branchRunInDirStashA(args); ok {
+		return out, ok
+	}
+	return branchRunInDirStashB(args)
+}
+
+// branchPromoteRunInDirFn is the RunInDir closure for happy-path branch promotion tests.
+func branchPromoteRunInDirFn(dirty bool) func(dir string, args ...string) (string, error) {
+	return func(_ string, args ...string) (string, error) {
+		if out, ok := branchRunInDirIdentity(dirty, args); ok {
+			return out, nil
+		}
+		out, _ := branchRunInDirStash(args)
+		return out, nil
+	}
+}
+
+// makeBranchPromoteRunner builds a mock runner for the full PromoteBranch happy path.
+func makeBranchPromoteRunner(repoDir string, dirty bool) *mockRunner {
+	return &mockRunner{
+		run:      branchPromoteRunFn(repoDir),
+		runInDir: branchPromoteRunInDirFn(dirty),
+	}
+}
+
+func TestAddBranchPromoteDirty(t *testing.T) {
+	repoDir := t.TempDir()
+	wtDir := filepath.Join(repoDir, "worktrees")
+	_ = os.MkdirAll(wtDir, 0755)
+	cfg := &config.Config{WorktreeDir: "worktrees"}
+	wtPath := filepath.Join(wtDir, "feature-x")
+
+	restore := overrideNewRunner(makeBranchPromoteRunner(repoDir, true))
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	addBranchFlags(cmd)
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	if err := addCmd.RunE(cmd, []string{"branch:" + branchFeatureX}); err != nil {
+		t.Fatalf("addCmd.RunE: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Promoted branch") {
+		t.Errorf("output %q missing 'Promoted branch'", out)
+	}
+	if !strings.Contains(out, wtPath) {
+		t.Errorf("output %q missing worktree path %q", out, wtPath)
+	}
+}
+
+func TestAddBranchPromoteClean(t *testing.T) {
+	repoDir := t.TempDir()
+	_ = os.MkdirAll(filepath.Join(repoDir, "worktrees"), 0755)
+	cfg := &config.Config{WorktreeDir: "worktrees"}
+
+	restore := overrideNewRunner(makeBranchPromoteRunner(repoDir, false))
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	addBranchFlags(cmd)
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	if err := addCmd.RunE(cmd, []string{"branch:" + branchFeatureX}); err != nil {
+		t.Fatalf("addCmd.RunE clean: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Promoted branch") {
+		t.Errorf("output %q missing 'Promoted branch'", buf.String())
+	}
+}
+
+func TestAddBranchRejectsExplicitSource(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{WorktreeDir: "worktrees"}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdGitCommonDir {
+				return filepath.Join(repoDir, ".git"), nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	addBranchFlags(cmd)
+	_ = cmd.Flags().Set(flagSource, "develop")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := addCmd.RunE(cmd, []string{"branch:" + branchFeatureX})
+	if err == nil {
+		t.Fatal("expected error for --source with branch: mode")
+	}
+	if !strings.Contains(err.Error(), "--source is not valid in branch: mode") {
+		t.Errorf("error %q should mention --source", err)
+	}
+}
+
+func TestAddBranchRejectsMain(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{WorktreeDir: "worktrees"}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[1] == cmdGitCommonDir:
+				return filepath.Join(repoDir, ".git"), nil
+			case len(args) >= 1 && args[0] == cmdSymbolicRef:
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	addBranchFlags(cmd)
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := addCmd.RunE(cmd, []string{"branch:main"})
+	if err == nil {
+		t.Fatal("expected error for branch:main")
+	}
+	if !strings.Contains(err.Error(), "cannot promote default branch") {
+		t.Errorf("error %q should mention 'cannot promote default branch'", err)
+	}
+}
+
+func TestAddBranchRejectsBranchMissing(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{WorktreeDir: "worktrees"}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[1] == cmdGitCommonDir:
+				return filepath.Join(repoDir, ".git"), nil
+			case len(args) >= 1 && args[0] == cmdSymbolicRef:
+				return refsRemotesOriginMain, nil
+			case len(args) >= 2 && args[0] == cmdRevParse && args[1] == cmdFlagVerify:
+				return "", errGitFailed // BranchExists → false
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	addBranchFlags(cmd)
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := addCmd.RunE(cmd, []string{"branch:" + branchFeatureX})
+	if err == nil {
+		t.Fatal("expected error for missing branch")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error %q should mention 'does not exist'", err)
+	}
+}
+
+// nonHeadBranchRunInDirFn is the RunInDir closure for TestAddBranchRejectsNonHead.
+// HEAD is main, not the feature branch being promoted.
+func nonHeadBranchRunInDirFn() func(dir string, args ...string) (string, error) {
+	return func(_ string, args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == cmdSymbolicRef && args[1] == cmdFlagShort {
+			return branchMain, nil
+		}
+		return "", nil
+	}
+}
+
+func TestAddBranchRejectsNonHead(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{WorktreeDir: "worktrees"}
+
+	r := &mockRunner{
+		run:      branchPromoteRunFn(repoDir),
+		runInDir: nonHeadBranchRunInDirFn(),
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	addBranchFlags(cmd)
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := addCmd.RunE(cmd, []string{"branch:" + branchFeatureX})
+	if err == nil {
+		t.Fatal("expected error for non-HEAD branch")
+	}
+	if !strings.Contains(err.Error(), "is not the current branch") {
+		t.Errorf("error %q should mention 'is not the current branch'", err)
+	}
+}
+
+func TestAddBranchRejectsAlreadyInWorktree(t *testing.T) {
+	repoDir := t.TempDir()
+	cfg := &config.Config{WorktreeDir: "worktrees"}
+	otherWtPath := "/some/other/worktree"
+	porcelain := wtPrefix + repoDir + headMainBlock + "\nworktree " + otherWtPath + "\nHEAD def\nbranch refs/heads/" + branchFeatureX + "\n"
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 2 && args[1] == cmdGitCommonDir:
+				return filepath.Join(repoDir, ".git"), nil
+			case len(args) >= 1 && args[0] == cmdSymbolicRef:
+				return refsRemotesOriginMain, nil
+			case len(args) >= 2 && args[0] == cmdRevParse && args[1] == cmdFlagVerify:
+				return "", nil
+			case len(args) >= 2 && args[0] == cmdWorktreeTest && args[1] == cmdList:
+				return porcelain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	addBranchFlags(cmd)
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := addCmd.RunE(cmd, []string{"branch:" + branchFeatureX})
+	if err == nil {
+		t.Fatal("expected error for branch already in worktree")
+	}
+	if !strings.Contains(err.Error(), "already checked out in worktree") {
+		t.Errorf("error %q should mention 'already checked out in worktree'", err)
+	}
+}
+
+// pathExistsBranchRunInDirFn is the RunInDir closure for TestAddBranchRejectsPathExists.
+// HEAD is the feature branch (validation passes up to the path check).
+func pathExistsBranchRunInDirFn() func(dir string, args ...string) (string, error) {
+	return func(_ string, args ...string) (string, error) {
+		if len(args) >= 2 && args[0] == cmdSymbolicRef && args[1] == cmdFlagShort {
+			return branchFeatureX, nil
+		}
+		return "", nil
+	}
+}
+
+func TestAddBranchRejectsPathExists(t *testing.T) {
+	repoDir := t.TempDir()
+	wtDir := filepath.Join(repoDir, "worktrees")
+	existingPath := filepath.Join(wtDir, "feature-x")
+	_ = os.MkdirAll(existingPath, 0o755)
+	cfg := &config.Config{WorktreeDir: "worktrees"}
+
+	r := &mockRunner{
+		run:      branchPromoteRunFn(repoDir),
+		runInDir: pathExistsBranchRunInDirFn(),
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	addBranchFlags(cmd)
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := addCmd.RunE(cmd, []string{"branch:" + branchFeatureX})
+	if err == nil {
+		t.Fatal("expected error for existing path")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error %q should mention 'already exists'", err)
+	}
+}
+
+// conflictRunInDirStash handles stash ops with apply-conflict simulation; returns (out, err, matched).
+func conflictRunInDirStash(stashDropped *bool, args []string) (string, error, bool) {
+	switch {
+	case len(args) >= 3 && args[0] == cmdStash && args[1] == gitSubcmdStashPush:
+		return "", nil, true
+	case len(args) >= 2 && args[0] == cmdRevParse && args[1] == "stash@{0}":
+		return stashSHACmd, nil, true
+	case len(args) >= 2 && args[0] == cmdSwitch:
+		return "", nil, true
+	case len(args) >= 3 && args[0] == cmdStash && args[1] == gitSubcmdStashAppl:
+		return "", errGitFailed, true // simulate conflict
+	case len(args) >= 3 && args[0] == cmdStash && args[1] == gitSubcmdStashDrop:
+		*stashDropped = true
+		return "", nil, true
+	}
+	return "", nil, false
+}
+
+// conflictBranchRunInDirFn is the RunInDir closure for TestAddBranchStashApplyConflict.
+func conflictBranchRunInDirFn(stashDropped *bool) func(dir string, args ...string) (string, error) {
+	return func(_ string, args ...string) (string, error) {
+		if out, ok := branchRunInDirIdentity(true, args); ok {
+			return out, nil
+		}
+		out, err, _ := conflictRunInDirStash(stashDropped, args)
+		return out, err
+	}
+}
+
+func TestAddBranchStashApplyConflict(t *testing.T) {
+	repoDir := t.TempDir()
+	wtDir := filepath.Join(repoDir, "worktrees")
+	_ = os.MkdirAll(wtDir, 0755)
+	cfg := &config.Config{WorktreeDir: "worktrees"}
+	stashDropped := false
+
+	r := &mockRunner{
+		run:      branchPromoteRunFn(repoDir),
+		runInDir: conflictBranchRunInDirFn(&stashDropped),
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	addBranchFlags(cmd)
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	err := addCmd.RunE(cmd, []string{"branch:" + branchFeatureX})
+	if err == nil {
+		t.Fatal("expected error from stash conflict")
+	}
+	if !strings.Contains(err.Error(), "stash apply had conflicts") {
+		t.Errorf("error %q should mention 'stash apply had conflicts'", err)
+	}
+	if !strings.Contains(err.Error(), stashSHACmd) {
+		t.Errorf("error %q should contain the stash SHA", err)
+	}
+	if stashDropped {
+		t.Error("stash should NOT be dropped on conflict")
 	}
 }

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -33,6 +33,25 @@ func RenameBranch(r Runner, oldBranch, newBranch string) error {
 	return err
 }
 
+// CurrentBranch returns the short branch name checked out in the given directory.
+// Returns an error with a hint if HEAD is detached.
+func CurrentBranch(r Runner, dir string) (string, error) {
+	out, err := r.RunInDir(dir, "symbolic-ref", "--short", "HEAD")
+	if err != nil {
+		return "", errhint.WithFix(
+			fmt.Errorf("could not determine current branch: %w", err),
+			"checkout a branch first: git checkout <branch>",
+		)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// Checkout switches the working tree in dir to the given branch.
+func Checkout(r Runner, dir, branch string) error {
+	_, err := r.RunInDir(dir, "switch", branch)
+	return err
+}
+
 // IsDirty returns true if the working tree at the given directory has uncommitted changes.
 func IsDirty(r Runner, dir string) (bool, error) {
 	out, err := r.RunInDir(dir, "status", "--porcelain")

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -247,3 +247,75 @@ func TestIsSquashMergedIntegrationNotMerged(t *testing.T) {
 		t.Error("expected unmerged branch to not be detected as squash-merged")
 	}
 }
+
+func TestCurrentBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	branch, err := git.CurrentBranch(r, repo)
+	if err != nil {
+		t.Fatalf("CurrentBranch: %v", err)
+	}
+	if branch != "main" {
+		t.Errorf("CurrentBranch = %q, want %q", branch, "main")
+	}
+}
+
+func TestCurrentBranchAfterSwitch(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	testutil.GitCmd(t, repo, "checkout", "-b", "feature/cur-branch-test")
+
+	branch, err := git.CurrentBranch(r, repo)
+	if err != nil {
+		t.Fatalf("CurrentBranch after switch: %v", err)
+	}
+	if branch != "feature/cur-branch-test" {
+		t.Errorf("CurrentBranch = %q, want %q", branch, "feature/cur-branch-test")
+	}
+}
+
+func TestCheckout(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	testutil.GitCmd(t, repo, "branch", "feature/checkout-test")
+
+	if err := git.Checkout(r, repo, "feature/checkout-test"); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
+
+	branch, err := git.CurrentBranch(r, repo)
+	if err != nil {
+		t.Fatalf("CurrentBranch after Checkout: %v", err)
+	}
+	if branch != "feature/checkout-test" {
+		t.Errorf("branch after Checkout = %q, want %q", branch, "feature/checkout-test")
+	}
+}
+
+func TestCheckoutError(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	if err := git.Checkout(r, repo, "nonexistent-branch"); err == nil {
+		t.Error("expected error for nonexistent branch")
+	}
+}

--- a/internal/git/stash.go
+++ b/internal/git/stash.go
@@ -1,0 +1,53 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+)
+
+// StashPushAndRef stashes all changes (including untracked files) with the given message
+// and returns the stash object SHA so it can be applied or dropped by reference later.
+func StashPushAndRef(r Runner, dir, message string) (string, error) {
+	if _, err := r.RunInDir(dir, "stash", "push", "-u", "-m", message); err != nil {
+		return "", fmt.Errorf("stash push: %w", err)
+	}
+	sha, err := r.RunInDir(dir, "rev-parse", "stash@{0}")
+	if err != nil {
+		return "", fmt.Errorf("resolve stash ref: %w", err)
+	}
+	return strings.TrimSpace(sha), nil
+}
+
+// StashApply applies the stash identified by sha in the given directory.
+// git stash apply accepts commit SHAs directly.
+// On conflict the error wraps the stderr output so conflict markers surface to the caller.
+func StashApply(r Runner, dir, sha string) error {
+	_, err := r.RunInDir(dir, "stash", "apply", sha)
+	return err
+}
+
+// StashDrop drops the stash entry whose commit SHA matches sha.
+// git stash drop requires stash@{N} form; this function resolves the SHA to the ref first.
+func StashDrop(r Runner, dir, sha string) error {
+	ref, err := stashRefBySHA(r, dir, sha)
+	if err != nil {
+		return err
+	}
+	_, err = r.RunInDir(dir, "stash", "drop", ref)
+	return err
+}
+
+// stashRefBySHA walks the stash list to find the stash@{N} ref matching sha.
+func stashRefBySHA(r Runner, dir, sha string) (string, error) {
+	out, err := r.RunInDir(dir, "stash", "list", "--format=%H %gd")
+	if err != nil {
+		return "", fmt.Errorf("stash list: %w", err)
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		parts := strings.SplitN(strings.TrimSpace(line), " ", 2)
+		if len(parts) == 2 && parts[0] == sha {
+			return parts[1], nil
+		}
+	}
+	return "", fmt.Errorf("stash entry %s not found in stash list", sha)
+}

--- a/internal/git/stash_test.go
+++ b/internal/git/stash_test.go
@@ -1,0 +1,89 @@
+package git_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+func TestStashPushAndRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+	testutil.CreateFile(t, repo, "dirty.txt", "dirty content")
+
+	sha, err := git.StashPushAndRef(r, repo, "test stash")
+	if err != nil {
+		t.Fatalf("StashPushAndRef: %v", err)
+	}
+	if sha == "" {
+		t.Error("expected non-empty SHA")
+	}
+	if strings.Contains(sha, "\n") {
+		t.Errorf("SHA should not contain newline: %q", sha)
+	}
+}
+
+func TestStashApply(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+	testutil.CreateFile(t, repo, "stash-apply.txt", "content")
+
+	sha, err := git.StashPushAndRef(r, repo, "apply test")
+	if err != nil {
+		t.Fatalf("StashPushAndRef: %v", err)
+	}
+
+	dirty, err := git.IsDirty(r, repo)
+	if err != nil {
+		t.Fatalf("IsDirty: %v", err)
+	}
+	if dirty {
+		t.Error("repo should be clean after stash push")
+	}
+
+	if err := git.StashApply(r, repo, sha); err != nil {
+		t.Fatalf("StashApply: %v", err)
+	}
+
+	dirty, err = git.IsDirty(r, repo)
+	if err != nil {
+		t.Fatalf("IsDirty after apply: %v", err)
+	}
+	if !dirty {
+		t.Error("repo should be dirty after stash apply")
+	}
+}
+
+func TestStashDrop(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+	testutil.CreateFile(t, repo, "stash-drop.txt", "content")
+
+	sha, err := git.StashPushAndRef(r, repo, "drop test")
+	if err != nil {
+		t.Fatalf("StashPushAndRef: %v", err)
+	}
+
+	if err := git.StashDrop(r, repo, sha); err != nil {
+		t.Fatalf("StashDrop: %v", err)
+	}
+
+	stashList := testutil.GitCmd(t, repo, "stash", "list")
+	if strings.TrimSpace(stashList) != "" {
+		t.Errorf("stash list should be empty after drop, got: %s", stashList)
+	}
+}

--- a/internal/operations/add_branch.go
+++ b/internal/operations/add_branch.go
@@ -48,11 +48,13 @@ func PromoteBranch(_ context.Context, worktreeDir string, r git.Runner, repoRoot
 	}
 
 	if err := git.AddWorktreeFromBranch(r, wtPath, branch); err != nil {
-		if restoreErr := restoreStash(r, repoRoot, stashSHA); restoreErr != nil {
-			return "", fmt.Errorf("create worktree: %w; also failed to restore stash: %w", err, restoreErr)
-		}
+		// Switch back first while the tree is still clean, then restore the stash.
+		// Reversing this order would make the switch fail (dirty tree).
 		if switchErr := git.Checkout(r, repoRoot, branch); switchErr != nil {
 			return "", fmt.Errorf("create worktree: %w; also failed to restore HEAD to %s: %w", err, branch, switchErr)
+		}
+		if restoreErr := restoreStash(r, repoRoot, stashSHA); restoreErr != nil {
+			return "", fmt.Errorf("create worktree: %w; also failed to restore stash: %w", err, restoreErr)
 		}
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
@@ -113,7 +115,9 @@ func restoreStash(r git.Runner, dir, sha string) error {
 	if err := git.StashApply(r, dir, sha); err != nil {
 		return fmt.Errorf("your changes are preserved in stash %s — find it with: git stash list (look for 'rimba: promote ...') then: git stash apply stash@{N}: %w", sha, err)
 	}
-	_ = git.StashDrop(r, dir, sha)
+	if dropErr := git.StashDrop(r, dir, sha); dropErr != nil {
+		return fmt.Errorf("stash applied but could not drop entry %s (clean up manually: git stash list, then git stash drop stash@{N}): %w", sha, dropErr)
+	}
 	return nil
 }
 

--- a/internal/operations/add_branch.go
+++ b/internal/operations/add_branch.go
@@ -1,0 +1,124 @@
+package operations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/lugassawan/rimba/internal/errhint"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/resolver"
+)
+
+// PromoteBranch moves the main repo's current branch into its own worktree,
+// transferring any dirty working-tree state via git stash push / apply.
+// worktreeDir must be an absolute path to the directory that holds worktrees.
+func PromoteBranch(_ context.Context, worktreeDir string, r git.Runner, repoRoot, branch string) (string, error) {
+	defaultBranch, err := validateForPromotion(r, repoRoot, branch)
+	if err != nil {
+		return "", err
+	}
+
+	wtPath := resolver.WorktreePath(worktreeDir, branch)
+	if _, err := os.Stat(wtPath); err == nil {
+		return "", errhint.WithFix(
+			fmt.Errorf("worktree path already exists: %s", wtPath),
+			"remove it first or choose a different branch name",
+		)
+	}
+
+	dirty, err := git.IsDirty(r, repoRoot)
+	if err != nil {
+		return "", err
+	}
+	var stashSHA string
+	if dirty {
+		stashSHA, err = git.StashPushAndRef(r, repoRoot, "rimba: promote "+branch)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if err := git.Checkout(r, repoRoot, defaultBranch); err != nil {
+		restoreStash(r, repoRoot, stashSHA)
+		return "", fmt.Errorf("switch to %s: %w", defaultBranch, err)
+	}
+
+	if err := git.AddWorktreeFromBranch(r, wtPath, branch); err != nil {
+		restoreStash(r, repoRoot, stashSHA)
+		if switchErr := git.Checkout(r, repoRoot, branch); switchErr != nil {
+			return "", fmt.Errorf("create worktree: %w; also failed to restore HEAD to %s: %w", err, branch, switchErr)
+		}
+		return "", fmt.Errorf("create worktree: %w", err)
+	}
+
+	if stashSHA != "" {
+		return wtPath, applyStashToWorktree(r, wtPath, stashSHA)
+	}
+	return wtPath, nil
+}
+
+// validateForPromotion checks pre-conditions and returns the resolved default branch.
+func validateForPromotion(r git.Runner, repoRoot, branch string) (string, error) {
+	defaultBranch, err := git.DefaultBranch(r)
+	if err != nil {
+		return "", err
+	}
+	if branch == defaultBranch {
+		return "", errhint.WithFix(
+			fmt.Errorf("cannot promote default branch %q", branch),
+			"checkout a feature branch first: git checkout <branch>",
+		)
+	}
+	if !git.BranchExists(r, branch) {
+		return "", errhint.WithFix(
+			fmt.Errorf("branch %q does not exist", branch),
+			"create the branch first: git checkout -b "+branch,
+		)
+	}
+	entries, err := git.ListWorktrees(r)
+	if err != nil {
+		return "", err
+	}
+	if entry := git.FindEntry(entries, branch); entry != nil && entry.Path != repoRoot {
+		return "", errhint.WithFix(
+			fmt.Errorf("branch %q is already checked out in worktree %s", branch, entry.Path),
+			"use that worktree: cd "+entry.Path,
+		)
+	}
+	current, err := git.CurrentBranch(r, repoRoot)
+	if err != nil {
+		return "", err
+	}
+	if current != branch {
+		return "", errhint.WithFix(
+			fmt.Errorf("branch %q is not the current branch (HEAD is %q)", branch, current),
+			"switch to it first: git checkout "+branch,
+		)
+	}
+	return defaultBranch, nil
+}
+
+// restoreStash re-applies and drops a stash entry to undo a failed mid-operation stash push.
+// No-ops when sha is empty.
+func restoreStash(r git.Runner, dir, sha string) {
+	if sha == "" {
+		return
+	}
+	_ = git.StashApply(r, dir, sha)
+	_ = git.StashDrop(r, dir, sha)
+}
+
+// applyStashToWorktree applies a stash to the worktree. On conflict, the stash entry
+// is preserved so the user can resolve manually.
+func applyStashToWorktree(r git.Runner, wtPath, sha string) error {
+	if err := git.StashApply(r, wtPath, sha); err != nil {
+		return errhint.WithFix(
+			errors.New("stash apply had conflicts"),
+			fmt.Sprintf("resolve conflicts in %s, then: git stash drop %s", wtPath, sha),
+		)
+	}
+	_ = git.StashDrop(r, wtPath, sha)
+	return nil
+}

--- a/internal/operations/add_branch.go
+++ b/internal/operations/add_branch.go
@@ -111,7 +111,7 @@ func restoreStash(r git.Runner, dir, sha string) error {
 		return nil
 	}
 	if err := git.StashApply(r, dir, sha); err != nil {
-		return fmt.Errorf("your changes are preserved in stash %s — apply manually with: git stash list && git stash apply stash@{0}: %w", sha, err)
+		return fmt.Errorf("your changes are preserved in stash %s — find it with: git stash list (look for 'rimba: promote ...') then: git stash apply stash@{N}: %w", sha, err)
 	}
 	_ = git.StashDrop(r, dir, sha)
 	return nil
@@ -123,7 +123,7 @@ func applyStashToWorktree(r git.Runner, wtPath, sha string) error {
 	if err := git.StashApply(r, wtPath, sha); err != nil {
 		return errhint.WithFix(
 			errors.New("stash apply had conflicts"),
-			fmt.Sprintf("resolve conflicts in %s (stash ref: %s), then: git stash list && git stash drop stash@{0}", wtPath, sha),
+			fmt.Sprintf("resolve conflicts in %s (stash SHA: %s), then: git stash list (find 'rimba: promote ...' entry) && git stash drop stash@{N}", wtPath, sha),
 		)
 	}
 	_ = git.StashDrop(r, wtPath, sha)

--- a/internal/operations/add_branch.go
+++ b/internal/operations/add_branch.go
@@ -41,12 +41,16 @@ func PromoteBranch(_ context.Context, worktreeDir string, r git.Runner, repoRoot
 	}
 
 	if err := git.Checkout(r, repoRoot, defaultBranch); err != nil {
-		restoreStash(r, repoRoot, stashSHA)
+		if restoreErr := restoreStash(r, repoRoot, stashSHA); restoreErr != nil {
+			return "", fmt.Errorf("switch to %s: %w; also failed to restore stash: %w", defaultBranch, err, restoreErr)
+		}
 		return "", fmt.Errorf("switch to %s: %w", defaultBranch, err)
 	}
 
 	if err := git.AddWorktreeFromBranch(r, wtPath, branch); err != nil {
-		restoreStash(r, repoRoot, stashSHA)
+		if restoreErr := restoreStash(r, repoRoot, stashSHA); restoreErr != nil {
+			return "", fmt.Errorf("create worktree: %w; also failed to restore stash: %w", err, restoreErr)
+		}
 		if switchErr := git.Checkout(r, repoRoot, branch); switchErr != nil {
 			return "", fmt.Errorf("create worktree: %w; also failed to restore HEAD to %s: %w", err, branch, switchErr)
 		}
@@ -101,13 +105,16 @@ func validateForPromotion(r git.Runner, repoRoot, branch string) (string, error)
 }
 
 // restoreStash re-applies and drops a stash entry to undo a failed mid-operation stash push.
-// No-ops when sha is empty.
-func restoreStash(r git.Runner, dir, sha string) {
+// No-ops when sha is empty. Returns an error if the apply fails (stash entry is preserved).
+func restoreStash(r git.Runner, dir, sha string) error {
 	if sha == "" {
-		return
+		return nil
 	}
-	_ = git.StashApply(r, dir, sha)
+	if err := git.StashApply(r, dir, sha); err != nil {
+		return fmt.Errorf("your changes are preserved in stash %s — apply manually with: git stash list && git stash apply stash@{0}: %w", sha, err)
+	}
 	_ = git.StashDrop(r, dir, sha)
+	return nil
 }
 
 // applyStashToWorktree applies a stash to the worktree. On conflict, the stash entry
@@ -116,7 +123,7 @@ func applyStashToWorktree(r git.Runner, wtPath, sha string) error {
 	if err := git.StashApply(r, wtPath, sha); err != nil {
 		return errhint.WithFix(
 			errors.New("stash apply had conflicts"),
-			fmt.Sprintf("resolve conflicts in %s, then: git stash drop %s", wtPath, sha),
+			fmt.Sprintf("resolve conflicts in %s (stash ref: %s), then: git stash list && git stash drop stash@{0}", wtPath, sha),
 		)
 	}
 	_ = git.StashDrop(r, wtPath, sha)

--- a/internal/operations/add_branch_test.go
+++ b/internal/operations/add_branch_test.go
@@ -300,6 +300,80 @@ func TestPromoteBranchRejectsPathExists(t *testing.T) {
 	}
 }
 
+// wtAddFailsRunFn is the Run closure for TestPromoteBranchWorktreeAddFails.
+func wtAddFailsRunFn(repoRoot string) func(args ...string) (string, error) {
+	porcelain := "worktree " + repoRoot + "\nHEAD abc\nbranch refs/heads/main\n"
+	return func(args ...string) (string, error) {
+		switch {
+		case len(args) >= 1 && args[0] == gitCmdSymbolicRef:
+			return refsRemotesOriginMain, nil
+		case len(args) >= 2 && args[0] == cmdRevParse && args[1] == flagVerifyOpt:
+			return "", nil
+		case len(args) >= 2 && args[0] == gitCmdWorktree && args[1] == gitSubcmdList:
+			return porcelain, nil
+		case len(args) >= 2 && args[0] == gitCmdWorktree && args[1] == gitSubcmdAdd:
+			return "", errGitFailed
+		}
+		return "", nil
+	}
+}
+
+// wtAddFailsRunInDirFn records switch and stash-apply operations so tests can verify ordering.
+func wtAddFailsRunInDirFn(ops *[]string) func(dir string, args ...string) (string, error) {
+	return func(_ string, args ...string) (string, error) {
+		if out, ok := promoteRunInDirIdentity(true, args); ok {
+			return out, nil
+		}
+		if len(args) >= 2 && args[0] == gitCmdSwitch {
+			*ops = append(*ops, "switch:"+args[1])
+		}
+		if len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdApply {
+			*ops = append(*ops, "stash:apply")
+		}
+		out, _ := promoteRunInDirStash(args)
+		return out, nil
+	}
+}
+
+func TestPromoteBranchWorktreeAddFails(t *testing.T) {
+	repoRoot := t.TempDir()
+	wtDir := filepath.Join(t.TempDir(), "worktrees")
+	var ops []string
+
+	r := &mockRunner{
+		run:      wtAddFailsRunFn(repoRoot),
+		runInDir: wtAddFailsRunInDirFn(&ops),
+	}
+
+	_, err := PromoteBranch(context.Background(), wtDir, r, repoRoot, branchFeatureX)
+	if err == nil {
+		t.Fatal("expected error when worktree add fails")
+	}
+	if !strings.Contains(err.Error(), "create worktree") {
+		t.Errorf("error %q should mention 'create worktree'", err)
+	}
+	if strings.Contains(err.Error(), "failed to restore") {
+		t.Errorf("rollback should succeed; error %q should not mention restore failure", err)
+	}
+	// Verify switch-back happens before stash-apply: switching while the tree is clean
+	// avoids git refusing the checkout due to uncommitted changes.
+	switchIdx, applyIdx := -1, -1
+	for i, op := range ops {
+		if op == "switch:"+branchFeatureX {
+			switchIdx = i
+		}
+		if op == "stash:apply" {
+			applyIdx = i
+		}
+	}
+	if switchIdx == -1 || applyIdx == -1 {
+		t.Fatalf("expected switch-back and stash-apply in rollback; got ops: %v", ops)
+	}
+	if switchIdx > applyIdx {
+		t.Errorf("switch-back (idx %d) must precede stash-apply (idx %d); got ops: %v", switchIdx, applyIdx, ops)
+	}
+}
+
 // conflictRunFn is the Run closure for TestPromoteBranchStashApplyConflict.
 func conflictRunFn(porcelain, wtDir string) func(args ...string) (string, error) {
 	return func(args ...string) (string, error) {

--- a/internal/operations/add_branch_test.go
+++ b/internal/operations/add_branch_test.go
@@ -1,0 +1,375 @@
+package operations
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	branchFeatureX    = "feature/x"
+	stashSHATest      = "abc123def456"
+	gitCmdStash       = "stash"
+	gitCmdSwitch      = "switch"
+	gitCmdSymbolicRef = "symbolic-ref"
+	gitSubcmdPush     = "push"
+	gitSubcmdApply    = "apply"
+	gitSubcmdDrop     = "drop"
+	flagVerifyOpt     = "--verify"
+	flagShortOpt      = "--short"
+	gitSubcmdList     = "list"
+
+	stashListLine = stashSHATest + " stash@{0}"
+)
+
+// promoteRunFn returns a Run closure for the happy-path promote mock.
+// It returns refsRemotesOriginMain for symbolic-ref, nil for BranchExists,
+// the porcelain worktree list, and creates the worktree dir on worktree add.
+func promoteRunFn(repoRoot string, makeWtDir bool) func(args ...string) (string, error) {
+	porcelain := "worktree " + repoRoot + "\nHEAD abc\nbranch refs/heads/main\n"
+	return func(args ...string) (string, error) {
+		switch {
+		case len(args) >= 1 && args[0] == gitCmdSymbolicRef:
+			return refsRemotesOriginMain, nil
+		case len(args) >= 2 && args[0] == cmdRevParse && args[1] == flagVerifyOpt:
+			return "", nil // BranchExists → true
+		case len(args) >= 2 && args[0] == gitCmdWorktree && args[1] == gitSubcmdList:
+			return porcelain, nil
+		case len(args) >= 2 && args[0] == gitCmdWorktree && args[1] == gitSubcmdAdd:
+			if makeWtDir {
+				_ = os.MkdirAll(args[2], 0o755)
+			}
+			return "", nil
+		}
+		return "", nil
+	}
+}
+
+// promoteRunInDirIdentity handles symbolic-ref and status matches; reports result and whether matched.
+func promoteRunInDirIdentity(dirty bool, args []string) (string, bool) {
+	switch {
+	case len(args) >= 2 && args[0] == gitCmdSymbolicRef && args[1] == flagShortOpt:
+		return branchFeatureX, true
+	case len(args) >= 2 && args[0] == gitCmdStatus && args[1] == "--porcelain":
+		if dirty {
+			return "M file.txt", true
+		}
+		return "", true
+	}
+	return "", false
+}
+
+// promoteRunInDirStashA handles push / rev-parse / switch operations.
+func promoteRunInDirStashA(args []string) (string, bool) {
+	switch {
+	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdPush:
+		return "", true
+	case len(args) >= 2 && args[0] == cmdRevParse && args[1] == "stash@{0}":
+		return stashSHATest, true
+	case len(args) >= 2 && args[0] == gitCmdSwitch:
+		return "", true
+	}
+	return "", false
+}
+
+// promoteRunInDirStashB handles stash list / apply / drop operations.
+func promoteRunInDirStashB(args []string) (string, bool) {
+	switch {
+	case len(args) >= 3 && args[0] == gitCmdStash && args[1] == gitSubcmdList:
+		return stashListLine, true
+	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdApply:
+		return "", true
+	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdDrop:
+		return "", true
+	}
+	return "", false
+}
+
+// promoteRunInDirStash handles happy-path stash operations; reports result and whether matched.
+func promoteRunInDirStash(args []string) (string, bool) {
+	if out, ok := promoteRunInDirStashA(args); ok {
+		return out, ok
+	}
+	return promoteRunInDirStashB(args)
+}
+
+// promoteRunInDirFn returns a RunInDir closure for the happy-path promote mock.
+func promoteRunInDirFn(dirty bool) func(dir string, args ...string) (string, error) {
+	return func(_ string, args ...string) (string, error) {
+		if out, ok := promoteRunInDirIdentity(dirty, args); ok {
+			return out, nil
+		}
+		out, _ := promoteRunInDirStash(args)
+		return out, nil
+	}
+}
+
+// buildPromoteRunner assembles a happy-path mockRunner for PromoteBranch.
+func buildPromoteRunner(t *testing.T, repoRoot string, dirty bool, makeWtDir bool) *mockRunner {
+	t.Helper()
+	return &mockRunner{
+		run:      promoteRunFn(repoRoot, makeWtDir),
+		runInDir: promoteRunInDirFn(dirty),
+	}
+}
+
+func TestPromoteBranchDirty(t *testing.T) {
+	repoRoot := t.TempDir()
+	wtDir := filepath.Join(t.TempDir(), "worktrees")
+	wtPath := filepath.Join(wtDir, "feature-x")
+
+	r := buildPromoteRunner(t, repoRoot, true, true)
+
+	got, err := PromoteBranch(context.Background(), wtDir, r, repoRoot, branchFeatureX)
+	if err != nil {
+		t.Fatalf("PromoteBranch: %v", err)
+	}
+	if got != wtPath {
+		t.Errorf("got path %q, want %q", got, wtPath)
+	}
+}
+
+func TestPromoteBranchClean(t *testing.T) {
+	repoRoot := t.TempDir()
+	wtDir := filepath.Join(t.TempDir(), "worktrees")
+	wtPath := filepath.Join(wtDir, "feature-x")
+
+	r := buildPromoteRunner(t, repoRoot, false, true)
+
+	got, err := PromoteBranch(context.Background(), wtDir, r, repoRoot, branchFeatureX)
+	if err != nil {
+		t.Fatalf("PromoteBranch clean: %v", err)
+	}
+	if got != wtPath {
+		t.Errorf("got path %q, want %q", got, wtPath)
+	}
+}
+
+func TestPromoteBranchRejectsDefaultBranch(t *testing.T) {
+	repoRoot := t.TempDir()
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitCmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	_, err := PromoteBranch(context.Background(), t.TempDir(), r, repoRoot, branchMain)
+	if err == nil {
+		t.Fatal("expected error for default branch")
+	}
+	if !strings.Contains(err.Error(), "cannot promote default branch") {
+		t.Errorf("error %q should mention 'cannot promote default branch'", err)
+	}
+}
+
+func TestPromoteBranchRejectsBranchMissing(t *testing.T) {
+	repoRoot := t.TempDir()
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitCmdSymbolicRef {
+				return refsRemotesOriginMain, nil
+			}
+			return "", errGitFailed // BranchExists → false
+		},
+		runInDir: noopRunInDir,
+	}
+
+	_, err := PromoteBranch(context.Background(), t.TempDir(), r, repoRoot, branchFeatureX)
+	if err == nil {
+		t.Fatal("expected error for missing branch")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error %q should mention 'does not exist'", err)
+	}
+}
+
+func TestPromoteBranchRejectsAlreadyInWorktree(t *testing.T) {
+	repoRoot := t.TempDir()
+	otherWtPath := "/some/other/worktree"
+	porcelain := "worktree " + repoRoot + "\nHEAD abc\nbranch refs/heads/main\n\nworktree " + otherWtPath + "\nHEAD def\nbranch refs/heads/" + branchFeatureX + "\n"
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case len(args) >= 1 && args[0] == gitCmdSymbolicRef:
+				return refsRemotesOriginMain, nil
+			case len(args) >= 2 && args[0] == cmdRevParse && args[1] == flagVerifyOpt:
+				return "", nil
+			case len(args) >= 1 && args[0] == gitCmdWorktree:
+				return porcelain, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	_, err := PromoteBranch(context.Background(), t.TempDir(), r, repoRoot, branchFeatureX)
+	if err == nil {
+		t.Fatal("expected error for branch already in worktree")
+	}
+	if !strings.Contains(err.Error(), "already checked out in worktree") {
+		t.Errorf("error %q should mention 'already checked out in worktree'", err)
+	}
+}
+
+// nonHeadRunFn is the Run closure for TestPromoteBranchRejectsNonHead.
+func nonHeadRunFn(porcelain string) func(args ...string) (string, error) {
+	return func(args ...string) (string, error) {
+		switch {
+		case len(args) >= 1 && args[0] == gitCmdSymbolicRef:
+			return refsRemotesOriginMain, nil
+		case len(args) >= 2 && args[0] == cmdRevParse && args[1] == flagVerifyOpt:
+			return "", nil
+		case len(args) >= 1 && args[0] == gitCmdWorktree:
+			return porcelain, nil
+		}
+		return "", nil
+	}
+}
+
+func TestPromoteBranchRejectsNonHead(t *testing.T) {
+	repoRoot := t.TempDir()
+	porcelain := "worktree " + repoRoot + "\nHEAD abc\nbranch refs/heads/main\n"
+
+	r := &mockRunner{
+		run: nonHeadRunFn(porcelain),
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == gitCmdSymbolicRef && args[1] == flagShortOpt {
+				return branchMain, nil // HEAD is main, not feature/x
+			}
+			return "", nil
+		},
+	}
+
+	_, err := PromoteBranch(context.Background(), t.TempDir(), r, repoRoot, branchFeatureX)
+	if err == nil {
+		t.Fatal("expected error for non-head branch")
+	}
+	if !strings.Contains(err.Error(), "is not the current branch") {
+		t.Errorf("error %q should mention 'is not the current branch'", err)
+	}
+}
+
+// pathExistsRunFn is the Run closure for TestPromoteBranchRejectsPathExists.
+func pathExistsRunFn(porcelain string) func(args ...string) (string, error) {
+	return func(args ...string) (string, error) {
+		switch {
+		case len(args) >= 1 && args[0] == gitCmdSymbolicRef:
+			return refsRemotesOriginMain, nil
+		case len(args) >= 2 && args[0] == cmdRevParse && args[1] == flagVerifyOpt:
+			return "", nil
+		case len(args) >= 1 && args[0] == gitCmdWorktree:
+			return porcelain, nil
+		}
+		return "", nil
+	}
+}
+
+func TestPromoteBranchRejectsPathExists(t *testing.T) {
+	repoRoot := t.TempDir()
+	wtDir := t.TempDir()
+	existingPath := filepath.Join(wtDir, "feature-x")
+	if err := os.MkdirAll(existingPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	porcelain := "worktree " + repoRoot + "\nHEAD abc\nbranch refs/heads/main\n"
+
+	r := &mockRunner{
+		run: pathExistsRunFn(porcelain),
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == gitCmdSymbolicRef && args[1] == flagShortOpt {
+				return branchFeatureX, nil
+			}
+			return "", nil
+		},
+	}
+
+	_, err := PromoteBranch(context.Background(), wtDir, r, repoRoot, branchFeatureX)
+	if err == nil {
+		t.Fatal("expected error for existing path")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error %q should mention 'already exists'", err)
+	}
+}
+
+// conflictRunFn is the Run closure for TestPromoteBranchStashApplyConflict.
+func conflictRunFn(porcelain, wtDir string) func(args ...string) (string, error) {
+	return func(args ...string) (string, error) {
+		switch {
+		case len(args) >= 1 && args[0] == gitCmdSymbolicRef:
+			return refsRemotesOriginMain, nil
+		case len(args) >= 2 && args[0] == cmdRevParse && args[1] == flagVerifyOpt:
+			return "", nil
+		case len(args) >= 2 && args[0] == gitCmdWorktree && args[1] == gitSubcmdList:
+			return porcelain, nil
+		case len(args) >= 2 && args[0] == gitCmdWorktree && args[1] == gitSubcmdAdd:
+			wtPath := filepath.Join(wtDir, "feature-x")
+			_ = os.MkdirAll(wtPath, 0o755)
+			return "", nil
+		}
+		return "", nil
+	}
+}
+
+// conflictStash handles stash ops with apply-conflict simulation; returns (out, err, matched).
+func conflictStash(stashDropped *bool, args []string) (string, error, bool) {
+	switch {
+	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdPush:
+		return "", nil, true
+	case len(args) >= 2 && args[0] == cmdRevParse && args[1] == "stash@{0}":
+		return stashSHATest, nil, true
+	case len(args) >= 2 && args[0] == gitCmdSwitch:
+		return "", nil, true
+	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdApply:
+		return "", errors.New("CONFLICT: merge conflict"), true
+	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdDrop:
+		*stashDropped = true
+		return "", nil, true
+	}
+	return "", nil, false
+}
+
+// conflictRunInDirFn is the RunInDir closure for TestPromoteBranchStashApplyConflict.
+func conflictRunInDirFn(stashDropped *bool) func(dir string, args ...string) (string, error) {
+	return func(_ string, args ...string) (string, error) {
+		if out, ok := promoteRunInDirIdentity(true, args); ok {
+			return out, nil
+		}
+		out, err, _ := conflictStash(stashDropped, args)
+		return out, err
+	}
+}
+
+func TestPromoteBranchStashApplyConflict(t *testing.T) {
+	repoRoot := t.TempDir()
+	wtDir := t.TempDir()
+	porcelain := "worktree " + repoRoot + "\nHEAD abc\nbranch refs/heads/main\n"
+	stashDropped := false
+
+	r := &mockRunner{
+		run:      conflictRunFn(porcelain, wtDir),
+		runInDir: conflictRunInDirFn(&stashDropped),
+	}
+
+	_, err := PromoteBranch(context.Background(), wtDir, r, repoRoot, branchFeatureX)
+	if err == nil {
+		t.Fatal("expected error from stash apply conflict")
+	}
+	if !strings.Contains(err.Error(), "stash apply had conflicts") {
+		t.Errorf("error %q should mention 'stash apply had conflicts'", err)
+	}
+	if !strings.Contains(err.Error(), stashSHATest) {
+		t.Errorf("error %q should contain the stash SHA for recovery", err)
+	}
+	if stashDropped {
+		t.Error("stash should NOT be dropped on conflict")
+	}
+}

--- a/tests/e2e/add_test.go
+++ b/tests/e2e/add_test.go
@@ -3,12 +3,15 @@ package e2e_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/testutil"
 )
+
+const branchPromoteMe = "feature/promote-me"
 
 func TestAddCreatesWorktree(t *testing.T) {
 	if testing.Short() {
@@ -441,4 +444,124 @@ func saveConfig(t *testing.T, repo string, cfg *config.Config) {
 	if err := config.Save(filepath.Join(dir, teamFile), cfg); err != nil {
 		t.Fatalf("save config: %v", err)
 	}
+}
+
+// --- branch: promote tests ---
+
+func TestAddBranchPromoteDirty(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupCleanInitializedRepo(t)
+
+	// Create the branch and switch to it.
+	testutil.GitCmd(t, repo, "checkout", "-b", branchPromoteMe)
+
+	// Dirty state: one staged file + one untracked file.
+	testutil.CreateFile(t, repo, "staged.txt", "staged content")
+	testutil.GitCmd(t, repo, "add", "staged.txt")
+	testutil.CreateFile(t, repo, "untracked.txt", "untracked content")
+
+	r := rimbaSuccess(t, repo, "add", "branch:"+branchPromoteMe)
+	assertContains(t, r.Stdout, "Promoted branch")
+
+	// Main repo must be clean and on main.
+	headBranch := strings.TrimSpace(testutil.GitCmd(t, repo, "rev-parse", "--abbrev-ref", "HEAD"))
+	if headBranch != branchMain {
+		t.Errorf("main repo HEAD = %q, want %q", headBranch, branchMain)
+	}
+	status := strings.TrimSpace(testutil.GitCmd(t, repo, "status", "--porcelain"))
+	if status != "" {
+		t.Errorf("main repo should be clean after promotion, got:\n%s", status)
+	}
+
+	// Worktree directory must exist and contain promoted files.
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	wtPath := resolver.WorktreePath(wtDir, branchPromoteMe)
+	assertFileExists(t, wtPath)
+	assertFileExists(t, filepath.Join(wtPath, "staged.txt"))
+	assertFileExists(t, filepath.Join(wtPath, "untracked.txt"))
+
+	// Stash must be empty — StashDrop must have cleaned up.
+	stashList := strings.TrimSpace(testutil.GitCmd(t, repo, "stash", "list"))
+	if stashList != "" {
+		t.Errorf("stash should be empty after promotion, got:\n%s", stashList)
+	}
+}
+
+func TestAddBranchPromoteClean(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupCleanInitializedRepo(t)
+	testutil.GitCmd(t, repo, "checkout", "-b", branchPromoteMe)
+
+	rimbaSuccess(t, repo, "add", "branch:"+branchPromoteMe)
+
+	headBranch := strings.TrimSpace(testutil.GitCmd(t, repo, "rev-parse", "--abbrev-ref", "HEAD"))
+	if headBranch != branchMain {
+		t.Errorf("main repo HEAD = %q, want %q", headBranch, branchMain)
+	}
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	wtPath := resolver.WorktreePath(wtDir, branchPromoteMe)
+	assertFileExists(t, wtPath)
+
+	// Verify the worktree's HEAD is on the feature branch.
+	wtBranch := strings.TrimSpace(testutil.GitCmd(t, wtPath, "rev-parse", "--abbrev-ref", "HEAD"))
+	if wtBranch != branchPromoteMe {
+		t.Errorf("worktree HEAD = %q, want %q", wtBranch, branchPromoteMe)
+	}
+}
+
+func TestAddBranchRefusesMain(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupCleanInitializedRepo(t)
+
+	r := rimbaFail(t, repo, "add", "branch:main")
+	assertContains(t, r.Stderr, "cannot promote default branch")
+}
+
+func TestAddBranchRefusesNonHead(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupCleanInitializedRepo(t)
+	// Create branch but stay on main.
+	testutil.GitCmd(t, repo, "branch", branchPromoteMe)
+
+	r := rimbaFail(t, repo, "add", "branch:"+branchPromoteMe)
+	assertContains(t, r.Stderr, "is not the current branch")
+}
+
+func TestAddBranchRefusesAlreadyPromoted(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupCleanInitializedRepo(t)
+	testutil.GitCmd(t, repo, "checkout", "-b", branchPromoteMe)
+	rimbaSuccess(t, repo, "add", "branch:"+branchPromoteMe)
+
+	// Switch back to the feature branch (it's no longer checked out in main repo).
+	// Try to promote again — should fail because the branch is already in a worktree.
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	wtPath := resolver.WorktreePath(wtDir, branchPromoteMe)
+
+	// The second attempt from the worktree itself would fail differently; instead
+	// try from a fresh checkout context. The branch is now in the worktree so any
+	// rimba add branch: call for it should fail with "already checked out".
+	// We test by switching back to main and creating the branch again (impossible since
+	// the branch is checked out in worktree). Instead, test from the worktree dir:
+	r := rimbaFail(t, wtPath, "add", "branch:"+branchPromoteMe)
+	assertContains(t, r.Stderr, "already checked out in worktree")
 }


### PR DESCRIPTION
## Summary
- Adds `rimba add branch:<branch>` as a new task shape that promotes the main repo's current HEAD branch into its own worktree
- Transfers dirty working-tree state (staged + unstaged + untracked files) via `git stash push -u` → switch main to default branch → `git worktree add` → `git stash apply` in the new worktree
- On stash-apply conflict, the stash entry is preserved and the user gets an `errhint.WithFix` recovery hint pointing to the new worktree path
- Validates pre-conditions: branch must be HEAD, must not be default branch, must not already be in another worktree, target path must not exist
- Rejects `--source` flag when `branch:` mode is used (semantically meaningless)
- Worktree path derives from branch name via the same `resolver.WorktreePath` / `DirName` helpers as `rimba add <task>`, so the path is symmetric

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

New unit tests added:
- `internal/git/stash_test.go` — `TestStashPushAndRef`, `TestStashApply`, `TestStashDrop`
- `internal/git/branch_test.go` — `TestCurrentBranch`, `TestCurrentBranchAfterSwitch`, `TestCheckout`, `TestCheckoutError`
- `internal/operations/add_branch_test.go` — dirty/clean promotion, all refusal cases, stash-conflict path
- `cmd/add_test.go` — branch: dispatch, dirty/clean, `--source` rejection, all refusal cases, stash-conflict path
- `tests/e2e/add_test.go` — `TestAddBranchPromoteDirty`, `TestAddBranchPromoteClean`, `TestAddBranchRefusesMain`, `TestAddBranchRefusesNonHead`, `TestAddBranchRefusesAlreadyPromoted`

## Issue

Closes #194