### PR TITLE
[chore] Ignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ local.properties
 
 # Worktrees
 .worktrees/
+
+# Claude Code runtime files
+.claude/scheduled_tasks.lock
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Add `.claude/scheduled_tasks.lock` and `.claude/worktrees/` to `.gitignore` — Claude Code runtime files that have no place in version control

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

## Issue

N/A