### PR TITLE
[docs] cobra/cmd UX sweep: Example fields, restore help, version Go runtime, flag casing

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -39,18 +39,17 @@ Use pr:<num> to create a worktree from a GitHub PR's head branch.
 Use branch:<branch> to promote the current branch into its own worktree,
 transferring any dirty working-tree state via git stash.
 
-  rimba add my-feature
-  rimba add my-feature --bugfix          # Use bugfix/ prefix
-  rimba add auth-api/my-feature          # Monorepo service scope
-  rimba add pr:123                       # Create worktree from PR #123
-  rimba add pr:123 --task review/auth    # Override auto-derived task name
-  rimba add branch:feature/my-feature   # Promote current branch to worktree
-
 pr:<num> requires gh installed and authenticated. For cross-fork PRs, rimba adds a
 gh-fork-<owner> remote automatically. Without --task, the task name is derived as
 review/<num>-<slug>. The --task flag is only valid in pr:<num> mode.
 branch:<branch> requires that <branch> is the currently checked-out branch in the
 main repo and is not the default branch. --source is not valid in branch: mode.`,
+	Example: `  rimba add my-feature
+  rimba add my-feature --bugfix          # use bugfix/ prefix
+  rimba add auth-api/my-feature          # monorepo service scope
+  rimba add pr:123                       # create worktree from PR #123
+  rimba add pr:123 --task review/auth    # override auto-derived task name
+  rimba add branch:feature/my-feature   # promote current branch to worktree`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.FromContext(cmd.Context())
@@ -212,10 +211,10 @@ func buildPostCreateOptions(cfg *config.Config, repoRoot string, skipDeps, skipH
 
 func init() {
 	addPrefixFlags(addCmd)
-	addCmd.Flags().StringP(flagSource, "s", "", "Source branch to create worktree from (default from config)")
-	addCmd.Flags().String(flagTask, "", "Override auto-derived task name (pr:<num> mode only)")
-	addCmd.Flags().Bool(flagSkipDeps, false, "Skip dependency detection and installation")
-	addCmd.Flags().Bool(flagSkipHooks, false, "Skip post-create hooks")
+	addCmd.Flags().StringP(flagSource, "s", "", "source branch to create worktree from (default from config)")
+	addCmd.Flags().String(flagTask, "", "override auto-derived task name (pr:<num> mode only)")
+	addCmd.Flags().Bool(flagSkipDeps, false, "skip dependency detection and installation")
+	addCmd.Flags().Bool(flagSkipHooks, false, "skip post-create hooks")
 	_ = addCmd.RegisterFlagCompletionFunc(flagSource, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completeBranchNames(cmd, toComplete), cobra.ShellCompDirectiveNoFileComp
 	})

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -75,7 +75,7 @@ var archiveCmd = &cobra.Command{
 }
 
 func init() {
-	archiveCmd.Flags().BoolP(flagForce, "f", false, "Force archival even if worktree is dirty")
-	archiveCmd.Flags().Bool(flagDryRun, false, "Preview what would be archived without making changes")
+	archiveCmd.Flags().BoolP(flagForce, "f", false, "force archival even if worktree is dirty")
+	archiveCmd.Flags().Bool(flagDryRun, false, "preview what would be archived without making changes")
 	rootCmd.AddCommand(archiveCmd)
 }

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -24,9 +24,12 @@ const (
 )
 
 var cleanCmd = &cobra.Command{
-	Use:         "clean",
-	Short:       "Prune stale worktree references or remove merged worktrees",
-	Long:        "Runs git worktree prune to clean up stale references. Use --merged to detect and remove worktrees whose branches have been merged into main.",
+	Use:   "clean",
+	Short: "Prune stale worktree references or remove merged worktrees",
+	Long:  "Runs git worktree prune to clean up stale references. Use --merged to detect and remove worktrees whose branches have been merged into main.",
+	Example: `  rimba clean
+  rimba clean --merged
+  rimba clean --stale --stale-days 7`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
@@ -45,11 +48,11 @@ var cleanCmd = &cobra.Command{
 }
 
 func init() {
-	cleanCmd.Flags().Bool(flagDryRun, false, "Show what would be pruned/removed without making changes")
-	cleanCmd.Flags().Bool(flagMerged, false, "Remove worktrees whose branches are merged into main")
-	cleanCmd.Flags().Bool(flagStale, false, "Remove worktrees with no recent commits")
-	cleanCmd.Flags().Int(flagStaleDays, defaultStaleDays, "Number of days to consider a worktree stale (used with --stale)")
-	cleanCmd.Flags().Bool(flagForce, false, "Skip confirmation prompt when used with --merged or --stale")
+	cleanCmd.Flags().Bool(flagDryRun, false, "show what would be pruned/removed without making changes")
+	cleanCmd.Flags().Bool(flagMerged, false, "remove worktrees whose branches are merged into main")
+	cleanCmd.Flags().Bool(flagStale, false, "remove worktrees with no recent commits")
+	cleanCmd.Flags().Int(flagStaleDays, defaultStaleDays, "number of days to consider a worktree stale (used with --stale)")
+	cleanCmd.Flags().Bool(flagForce, false, "skip confirmation prompt when used with --merged or --stale")
 
 	cleanCmd.MarkFlagsMutuallyExclusive(flagMerged, flagStale)
 

--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -18,34 +18,11 @@ var completionCmd = &cobra.Command{
 	ValidArgs:   []string{"bash", "zsh", "fish", "powershell"},
 	Args:        cobra.ExactArgs(1),
 	Annotations: map[string]string{"skipConfig": "true"},
-	Long: `Generate shell completion scripts for rimba.
-
-Bash:
-  # Load for the current session:
-  source <(rimba completion bash)
-
-  # Install permanently (Linux):
-  rimba completion bash > /etc/bash_completion.d/rimba
-
-  # Install permanently (macOS with Homebrew bash-completion@2):
-  rimba completion bash > "$(brew --prefix)/etc/bash_completion.d/rimba"
-
-Zsh:
-  # Load for the current session:
-  source <(rimba completion zsh)
-
-  # Install permanently:
-  rimba completion zsh > "${fpath[1]}/_rimba"
-
-Fish:
-  rimba completion fish > ~/.config/fish/completions/rimba.fish
-
-PowerShell:
-  rimba completion powershell | Out-String | Invoke-Expression
-
-  # To load completions for every new session:
-  rimba completion powershell > rimba.ps1
-  # then source rimba.ps1 from your PowerShell profile`,
+	Long:        "Generate shell completion scripts for rimba.",
+	Example: `  rimba completion bash          # load: source <(rimba completion bash)
+  rimba completion zsh           # load: source <(rimba completion zsh)
+  rimba completion fish          # install: rimba completion fish > ~/.config/fish/completions/rimba.fish
+  rimba completion powershell    # load: rimba completion powershell | Out-String | Invoke-Expression`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		out := cmd.OutOrStdout()
 		switch args[0] {

--- a/cmd/conflict_check.go
+++ b/cmd/conflict_check.go
@@ -32,6 +32,8 @@ var conflictCheckCmd = &cobra.Command{
 	Use:   "conflict-check",
 	Short: "Detect file overlaps between worktree branches",
 	Long:  "Scans all active worktrees and reports files modified in multiple branches, indicating potential merge conflicts.",
+	Example: `  rimba conflict-check
+  rimba conflict-check --dry-merge`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cfg := config.FromContext(cmd.Context())
 

--- a/cmd/conventions_test.go
+++ b/cmd/conventions_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"testing"
+	"unicode"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// allCommands returns cmd and all its descendants recursively.
+func allCommands(c *cobra.Command) []*cobra.Command {
+	result := make([]*cobra.Command, 0, 1+len(c.Commands()))
+	result = append(result, c)
+	for _, sub := range c.Commands() {
+		result = append(result, allCommands(sub)...)
+	}
+	return result
+}
+
+func TestFlagUsageIsLowercase(t *testing.T) {
+	for _, c := range allCommands(rootCmd) {
+		c.LocalFlags().VisitAll(func(f *pflag.Flag) {
+			if f.Hidden || f.Usage == "" {
+				return
+			}
+			first := rune(f.Usage[0])
+			if unicode.IsUpper(first) {
+				t.Errorf("command %q flag --%s: Usage starts with uppercase %q (must be lowercase): %q",
+					c.CommandPath(), f.Name, string(first), f.Usage)
+			}
+		})
+	}
+}
+
+func TestExamplePresent(t *testing.T) {
+	for _, c := range allCommands(rootCmd) {
+		if !c.Runnable() {
+			continue
+		}
+		if c.Example == "" {
+			t.Errorf("runnable command %q has no Example field", c.CommandPath())
+		}
+	}
+}

--- a/cmd/conventions_test.go
+++ b/cmd/conventions_test.go
@@ -20,6 +20,9 @@ func allCommands(c *cobra.Command) []*cobra.Command {
 
 func TestFlagUsageIsLowercase(t *testing.T) {
 	for _, c := range allCommands(rootCmd) {
+		// LocalFlags covers this command's own Flags() and PersistentFlags(),
+		// but not flags inherited from ancestor commands — those are validated
+		// when the ancestor command is processed in the outer loop.
 		c.LocalFlags().VisitAll(func(f *pflag.Flag) {
 			if f.Hidden || f.Usage == "" {
 				return

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -28,8 +28,9 @@ var depsCmd = &cobra.Command{
 }
 
 var depsStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show detected modules and lockfile hashes for all worktrees",
+	Use:     "status",
+	Short:   "Show detected modules and lockfile hashes for all worktrees",
+	Example: "  rimba deps status",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.FromContext(cmd.Context())
 
@@ -124,9 +125,10 @@ var depsStatusCmd = &cobra.Command{
 }
 
 var depsInstallCmd = &cobra.Command{
-	Use:   "install <task>",
-	Short: "Install dependencies for a specific worktree",
-	Args:  cobra.ExactArgs(1),
+	Use:     "install <task>",
+	Short:   "Install dependencies for a specific worktree",
+	Example: "  rimba deps install auth",
+	Args:    cobra.ExactArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -177,9 +177,9 @@ var duplicateCmd = &cobra.Command{
 }
 
 func init() {
-	duplicateCmd.Flags().String(flagAs, "", "Custom name for the duplicate worktree")
-	duplicateCmd.Flags().Bool(flagSkipDeps, false, "Skip dependency detection and installation")
-	duplicateCmd.Flags().Bool(flagSkipHooks, false, "Skip post-create hooks")
-	duplicateCmd.Flags().Bool(flagDryRun, false, "Preview what would be duplicated without making changes")
+	duplicateCmd.Flags().String(flagAs, "", "custom name for the duplicate worktree")
+	duplicateCmd.Flags().Bool(flagSkipDeps, false, "skip dependency detection and installation")
+	duplicateCmd.Flags().Bool(flagSkipHooks, false, "skip post-create hooks")
+	duplicateCmd.Flags().Bool(flagDryRun, false, "preview what would be duplicated without making changes")
 	rootCmd.AddCommand(duplicateCmd)
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -35,7 +35,9 @@ var execCmd = &cobra.Command{
 	Use:   "exec <command>",
 	Short: "Run a shell command across worktrees",
 	Long:  "Executes a shell command in parallel across matching worktrees. Use --all to target all worktrees, or --type to filter by prefix type.",
-	Args:  cobra.ExactArgs(1),
+	Example: `  rimba exec --all "git status"
+  rimba exec --type bugfix "npm test"`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := execReadFlags(cmd)
 		if err := execValidateFlags(opts); err != nil {

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -17,8 +17,9 @@ var hookCmd = &cobra.Command{
 }
 
 var hookInstallCmd = &cobra.Command{
-	Use:   "install",
-	Short: "Install post-merge and pre-commit hooks",
+	Use:     "install",
+	Short:   "Install post-merge and pre-commit hooks",
+	Example: "  rimba hook install",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
 
@@ -59,8 +60,9 @@ var hookInstallCmd = &cobra.Command{
 }
 
 var hookUninstallCmd = &cobra.Command{
-	Use:   "uninstall",
-	Short: "Remove post-merge and pre-commit hooks",
+	Use:     "uninstall",
+	Short:   "Remove post-merge and pre-commit hooks",
+	Example: "  rimba hook uninstall",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
 
@@ -102,8 +104,9 @@ var hookUninstallCmd = &cobra.Command{
 }
 
 var hookStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show hook status",
+	Use:     "status",
+	Short:   "Show hook status",
+	Example: "  rimba hook status",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -37,6 +37,10 @@ const (
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize rimba in the current repository",
+	Example: `  rimba init
+  rimba init --personal
+  rimba init --agents
+  rimba init -g`,
 	Long: `Detects the repository root and sets up the .rimba/ config directory with
 settings.toml (team-shared) and settings.local.toml (personal overrides).
 
@@ -281,11 +285,11 @@ func printSection(cmd *cobra.Command, title string, tier installTier, results []
 
 func init() {
 	rootCmd.AddCommand(initCmd)
-	initCmd.Flags().Bool(flagPersonal, false, "Gitignore the .rimba/ directory (for solo developers)")
-	initCmd.Flags().BoolP(flagGlobal, "g", false, "Install rimba agent files at user level (~/)")
-	initCmd.Flags().Bool(flagAgents, false, "Install rimba agent files in this project (committed to repo)")
-	initCmd.Flags().Bool(flagLocal, false, "With --agents, install as project-local (gitignored)")
-	initCmd.Flags().Bool(flagUninstall, false, "Remove agent files: use with -g, --agents, or --agents --local")
+	initCmd.Flags().Bool(flagPersonal, false, "gitignore the .rimba/ directory (for solo developers)")
+	initCmd.Flags().BoolP(flagGlobal, "g", false, "install rimba agent files at user level (~/)")
+	initCmd.Flags().Bool(flagAgents, false, "install rimba agent files in this project (committed to repo)")
+	initCmd.Flags().Bool(flagLocal, false, "with --agents, install as project-local (gitignored)")
+	initCmd.Flags().Bool(flagUninstall, false, "remove agent files: use with -g, --agents, or --agents --local")
 	initCmd.MarkFlagsMutuallyExclusive(flagGlobal, flagAgents)
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -36,15 +36,14 @@ var listCmd = &cobra.Command{
 Use --full to show branch, path, and (when gh is installed and authenticated) PR number
 and CI rollup. CI symbols: ✓ success · ● pending · ✗ failure · – unknown.
 
-  rimba list                     # Compact view
-  rimba list --full              # All columns including PR/CI
-  rimba list --type bugfix       # Filter by prefix type
-  rimba list --service auth-api  # Filter by service (monorepo)
-  rimba list --dirty             # Only worktrees with uncommitted changes
-  rimba list --behind            # Only worktrees behind upstream
-  rimba list --archived          # Archived branches (no active worktree)
-
 --archived is mutually exclusive with --type, --dirty, --behind, and --full.`,
+	Example: `  rimba list                     # compact view
+  rimba list --full              # all columns including PR/CI
+  rimba list --type bugfix       # filter by prefix type
+  rimba list --service auth-api  # filter by service (monorepo)
+  rimba list --dirty             # only worktrees with uncommitted changes
+  rimba list --behind            # only worktrees behind upstream
+  rimba list --archived          # archived branches (no active worktree)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := listReadFlags(cmd)
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -31,9 +31,11 @@ type logEntry struct {
 }
 
 var logCmd = &cobra.Command{
-	Use:         "log",
-	Short:       "Show last commit from each worktree, sorted by recency",
-	Long:        "Displays the most recent commit from each worktree, sorted from newest to oldest.",
+	Use:   "log",
+	Short: "Show last commit from each worktree, sorted by recency",
+	Long:  "Displays the most recent commit from each worktree, sorted from newest to oldest.",
+	Example: `  rimba log
+  rimba log --since 7d --limit 10`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
@@ -99,8 +101,8 @@ var logCmd = &cobra.Command{
 }
 
 func init() {
-	logCmd.Flags().Int(flagLimit, 0, "Maximum number of entries to show (0 = all)")
-	logCmd.Flags().String(flagSince, "", "Show entries since duration (e.g. 7d, 2w, 3h)")
+	logCmd.Flags().Int(flagLimit, 0, "maximum number of entries to show (0 = all)")
+	logCmd.Flags().String(flagSince, "", "show entries since duration (e.g. 7d, 2w, 3h)")
 	rootCmd.AddCommand(logCmd)
 }
 

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -11,8 +11,9 @@ import (
 )
 
 var mcpCmd = &cobra.Command{
-	Use:   "mcp",
-	Short: "Start MCP server for AI tool integration",
+	Use:     "mcp",
+	Short:   "Start MCP server for AI tool integration",
+	Example: "  rimba mcp",
 	Long: `Starts a Model Context Protocol (MCP) server over stdio.
 
 Any MCP-compatible client can connect to this server to discover and invoke

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -112,11 +112,11 @@ var mergeCmd = &cobra.Command{
 }
 
 func init() {
-	mergeCmd.Flags().String(flagInto, "", "Target worktree task to merge into (default: main/repo root)")
-	mergeCmd.Flags().Bool(flagNoFF, false, "Force a merge commit (no fast-forward)")
-	mergeCmd.Flags().Bool(flagKeep, false, "Keep source worktree after merging into main")
-	mergeCmd.Flags().Bool(flagDelete, false, "Delete source worktree after merging into another worktree")
-	mergeCmd.Flags().Bool(flagDryRun, false, "Preview what would be merged/cleaned up without making changes")
+	mergeCmd.Flags().String(flagInto, "", "target worktree task to merge into (default: main/repo root)")
+	mergeCmd.Flags().Bool(flagNoFF, false, "force a merge commit (no fast-forward)")
+	mergeCmd.Flags().Bool(flagKeep, false, "keep source worktree after merging into main")
+	mergeCmd.Flags().Bool(flagDelete, false, "delete source worktree after merging into another worktree")
+	mergeCmd.Flags().Bool(flagDryRun, false, "preview what would be merged/cleaned up without making changes")
 	mergeCmd.MarkFlagsMutuallyExclusive(flagKeep, flagDelete)
 
 	_ = mergeCmd.RegisterFlagCompletionFunc(flagInto, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/merge_plan.go
+++ b/cmd/merge_plan.go
@@ -14,9 +14,10 @@ import (
 )
 
 var mergePlanCmd = &cobra.Command{
-	Use:   "merge-plan",
-	Short: "Recommend optimal merge order",
-	Long:  "Analyzes file overlaps between worktree branches and recommends a merge order that minimizes conflicts.",
+	Use:     "merge-plan",
+	Short:   "Recommend optimal merge order",
+	Long:    "Analyzes file overlaps between worktree branches and recommends a merge order that minimizes conflicts.",
+	Example: "  rimba merge-plan",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cfg := config.FromContext(cmd.Context())
 

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -25,19 +25,17 @@ var openCmd = &cobra.Command{
 	Short: "Open a worktree or run a command inside it",
 	Long: `Prints the worktree path for the given task, or executes a command inside it.
 
-Examples:
-  rimba open my-task              # Print worktree path
-  cd $(rimba open my-task)        # Navigate to worktree
-  rimba open my-task --ide        # Run the 'ide' shortcut
-  rimba open my-task --agent      # Run the 'agent' shortcut
-  rimba open my-task -w test      # Run a named shortcut
-  rimba open my-task npm start    # Run an inline command
-
 Shortcuts are configured in .rimba/settings.toml:
   [open]
   ide = "code ."
   agent = "claude"
   test = "npm test"`,
+	Example: `  rimba open my-task              # print worktree path
+  cd $(rimba open my-task)        # navigate to worktree
+  rimba open my-task --ide        # run the 'ide' shortcut
+  rimba open my-task --agent      # run the 'agent' shortcut
+  rimba open my-task -w test      # run a named shortcut
+  rimba open my-task npm start    # run an inline command`,
 	Args: cobra.MinimumNArgs(1),
 	FParseErrWhitelist: cobra.FParseErrWhitelist{
 		UnknownFlags: true,

--- a/cmd/prefix.go
+++ b/cmd/prefix.go
@@ -15,11 +15,11 @@ type prefixFlag struct {
 // prefixFlags lists the non-default prefix types available as boolean flags.
 // "feature" is the default and does not need a flag.
 var prefixFlags = []prefixFlag{
-	{"bugfix", resolver.PrefixBugfix, "Fixing minor bugs that are part of the normal workflow"},
-	{"hotfix", resolver.PrefixHotfix, "Urgent fixes that need to be patched directly in production"},
-	{"docs", resolver.PrefixDocs, "Changes related to documentation"},
-	{"test", resolver.PrefixTest, "Experiments or new tests that might not be merged"},
-	{"chore", resolver.PrefixChore, "Non-code tasks like dependency updates"},
+	{"bugfix", resolver.PrefixBugfix, "fixing minor bugs that are part of the normal workflow"},
+	{"hotfix", resolver.PrefixHotfix, "urgent fixes that need to be patched directly in production"},
+	{"docs", resolver.PrefixDocs, "changes related to documentation"},
+	{"test", resolver.PrefixTest, "experiments or new tests that might not be merged"},
+	{"chore", resolver.PrefixChore, "non-code tasks like dependency updates"},
 }
 
 // addPrefixFlags registers all prefix boolean flags on cmd and marks them mutually exclusive.

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -87,8 +87,8 @@ var removeCmd = &cobra.Command{
 }
 
 func init() {
-	removeCmd.Flags().BoolP(flagKeepBranch, "k", false, "Keep the local branch after removing the worktree")
-	removeCmd.Flags().BoolP(flagForce, "f", false, "Force removal even if worktree is dirty")
-	removeCmd.Flags().Bool(flagDryRun, false, "Preview what would be removed without making changes")
+	removeCmd.Flags().BoolP(flagKeepBranch, "k", false, "keep the local branch after removing the worktree")
+	removeCmd.Flags().BoolP(flagForce, "f", false, "force removal even if worktree is dirty")
+	removeCmd.Flags().Bool(flagDryRun, false, "preview what would be removed without making changes")
 	rootCmd.AddCommand(removeCmd)
 }

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -93,8 +93,8 @@ var renameCmd = &cobra.Command{
 }
 
 func init() {
-	renameCmd.Flags().BoolP(flagForce, "f", false, "Force rename even if worktree is locked")
-	renameCmd.Flags().Bool(flagSkipDeps, false, "Skip dependency refresh after rename")
-	renameCmd.Flags().Bool(flagSkipHooks, false, "Skip post-rename hooks")
+	renameCmd.Flags().BoolP(flagForce, "f", false, "force rename even if worktree is locked")
+	renameCmd.Flags().Bool(flagSkipDeps, false, "skip dependency refresh after rename")
+	renameCmd.Flags().Bool(flagSkipHooks, false, "skip post-rename hooks")
 	rootCmd.AddCommand(renameCmd)
 }

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -16,8 +16,16 @@ import (
 var restoreCmd = &cobra.Command{
 	Use:   "restore <task>",
 	Short: "Restore an archived worktree from its preserved branch",
-	Long:  "Recreates a worktree from a branch that was previously archived with `rimba archive`.",
-	Args:  cobra.ExactArgs(1),
+	Long: `Recreates a worktree from a branch that was previously archived with
+rimba archive. The local branch must still exist — restore does not
+fetch from a remote.
+
+If no archived branch is found for the task, restore fails with
+"no archived branch found for task <name>". Use 'rimba list --archived'
+to see available archived branches.`,
+	Example: `  rimba restore auth
+  rimba restore auth --skip-hooks`,
+	Args: cobra.ExactArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
@@ -103,7 +111,7 @@ var restoreCmd = &cobra.Command{
 }
 
 func init() {
-	restoreCmd.Flags().Bool(flagSkipDeps, false, "Skip dependency detection and installation")
-	restoreCmd.Flags().Bool(flagSkipHooks, false, "Skip post-create hooks")
+	restoreCmd.Flags().Bool(flagSkipDeps, false, "skip dependency detection and installation")
+	restoreCmd.Flags().Bool(flagSkipHooks, false, "skip post-create hooks")
 	rootCmd.AddCommand(restoreCmd)
 }

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -17,7 +17,7 @@ var restoreCmd = &cobra.Command{
 	Use:   "restore <task>",
 	Short: "Restore an archived worktree from its preserved branch",
 	Long: `Recreates a worktree from a branch that was previously archived with
-rimba archive. The local branch must still exist — restore does not
+rimba archive. The archived branch must still exist locally — restore does not
 fetch from a remote.
 
 If no archived branch is found for the task, restore fails with

--- a/cmd/restore_test.go
+++ b/cmd/restore_test.go
@@ -8,6 +8,15 @@ import (
 	"github.com/lugassawan/rimba/internal/config"
 )
 
+func TestRestoreLongDescribesArchivePrereq(t *testing.T) {
+	if !strings.Contains(restoreCmd.Long, "rimba archive") {
+		t.Error("restoreCmd.Long must mention 'rimba archive' prerequisite")
+	}
+	if !strings.Contains(restoreCmd.Long, "no archived branch found") {
+		t.Error("restoreCmd.Long must mention 'no archived branch found' failure case")
+	}
+}
+
 func TestRestoreSuccess(t *testing.T) {
 	restore := overrideNewRunner(&mockRunner{
 		run: func(args ...string) (string, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,7 +100,7 @@ func init() {
 
 	rootCmd.PersistentFlags().Bool(flagJSON, false, "output in JSON format")
 	rootCmd.PersistentFlags().Bool(flagNoColor, false, "disable colored output")
-	rootCmd.PersistentFlags().Bool(flagDebug, false, "Log git commands and timings to stderr")
+	rootCmd.PersistentFlags().Bool(flagDebug, false, "log git commands and timings to stderr")
 
 	originalHelp := rootCmd.HelpFunc()
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -23,11 +23,10 @@ plus per-worktree age information.
 
 Use --detail to add SIZE and 7D columns and a disk-footprint summary line. SIZE is the
 on-disk footprint of the worktree directory; 7D is the number of commits on the branch
-in the last 7 days. With --detail, rows are sorted largest-first.
-
-  rimba status
-  rimba status --detail          # Add SIZE/7D columns and disk summary
-  rimba status --stale-days 7    # Consider worktrees stale after 7 days`,
+in the last 7 days. With --detail, rows are sorted largest-first.`,
+	Example: `  rimba status
+  rimba status --detail          # add SIZE/7D columns and disk summary
+  rimba status --stale-days 7    # consider worktrees stale after 7 days`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
@@ -71,8 +70,8 @@ in the last 7 days. With --detail, rows are sorted largest-first.
 }
 
 func init() {
-	statusCmd.Flags().Int(flagStaleDays, defaultStaleDays, "Number of days after which a worktree is considered stale")
-	statusCmd.Flags().Bool(flagDetail, false, "Show per-worktree disk size and 7-day commit velocity")
+	statusCmd.Flags().Int(flagStaleDays, defaultStaleDays, "number of days after which a worktree is considered stale")
+	statusCmd.Flags().Bool(flagDetail, false, "show per-worktree disk size and 7-day commit velocity")
 	rootCmd.AddCommand(statusCmd)
 }
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -118,11 +118,11 @@ var syncCmd = &cobra.Command{
 }
 
 func init() {
-	syncCmd.Flags().Bool(flagAll, false, "Sync all eligible worktrees")
-	syncCmd.Flags().Bool(flagSyncMerge, false, "Use merge instead of rebase")
-	syncCmd.Flags().Bool(flagIncludeInherited, false, "Include inherited/duplicate worktrees when using --all")
-	syncCmd.Flags().Bool(flagNoPush, false, "Skip pushing after sync")
-	syncCmd.Flags().Bool(flagDryRun, false, "Preview what would be synced without making changes")
+	syncCmd.Flags().Bool(flagAll, false, "sync all eligible worktrees")
+	syncCmd.Flags().Bool(flagSyncMerge, false, "use merge instead of rebase")
+	syncCmd.Flags().Bool(flagIncludeInherited, false, "include inherited/duplicate worktrees when using --all")
+	syncCmd.Flags().Bool(flagNoPush, false, "skip pushing after sync")
+	syncCmd.Flags().Bool(flagDryRun, false, "preview what would be synced without making changes")
 
 	rootCmd.AddCommand(syncCmd)
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -18,6 +18,8 @@ const retryUpdateHint = "retry: rimba update"
 var updateCmd = &cobra.Command{
 	Use:   "update",
 	Short: "Update rimba to the latest version",
+	Example: `  rimba update
+  rimba update --force`,
 	Long: `Check for the latest release on GitHub and update the binary in place.
 
 If the current binary cannot be replaced due to file permissions, rimba installs the

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,7 @@ var (
 var versionCmd = &cobra.Command{
 	Use:         "version",
 	Short:       "Print the version information",
+	Example:     "  rimba version",
 	Annotations: map[string]string{"skipConfig": "true"},
 	Run: func(cmd *cobra.Command, args []string) {
 		w := cmd.OutOrStdout()
@@ -24,6 +25,7 @@ var versionCmd = &cobra.Command{
 		fmt.Fprintf(w, "built:  %s\n", date)
 		fmt.Fprintf(w, "os:     %s\n", runtime.GOOS)
 		fmt.Fprintf(w, "arch:   %s\n", runtime.GOARCH)
+		fmt.Fprintf(w, "go:     %s\n", runtime.Version())
 	},
 }
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -19,13 +19,13 @@ func TestVersionCmd(t *testing.T) {
 	versionCmd.Run(cmd, nil)
 
 	out := buf.String()
-	for _, want := range []string{"rimba", version, "commit:", "built:", "os:", "arch:"} {
+	for _, want := range []string{"rimba", version, "commit:", "built:", "os:", "arch:", "go:"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("version output %q does not contain %q", out, want)
 		}
 	}
 	lines := strings.Split(strings.TrimSpace(out), "\n")
-	if len(lines) != 5 {
-		t.Errorf("expected 5 lines, got %d: %q", len(lines), out)
+	if len(lines) < 6 {
+		t.Errorf("expected at least 6 lines, got %d: %q", len(lines), out)
 	}
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -25,7 +25,7 @@ func TestVersionCmd(t *testing.T) {
 		}
 	}
 	lines := strings.Split(strings.TrimSpace(out), "\n")
-	if len(lines) < 6 {
-		t.Errorf("expected at least 6 lines, got %d: %q", len(lines), out)
+	if len(lines) != 6 {
+		t.Errorf("expected 6 lines, got %d: %q", len(lines), out)
 	}
 }

--- a/tests/e2e/version_test.go
+++ b/tests/e2e/version_test.go
@@ -16,6 +16,7 @@ func TestVersionPrintsInfo(t *testing.T) {
 	assertContains(t, r.Stdout, "built:")
 	assertContains(t, r.Stdout, "os:")
 	assertContains(t, r.Stdout, "arch:")
+	assertContains(t, r.Stdout, "go:")
 }
 
 func TestVersionWorksOutsideRepo(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `go:` line (`runtime.Version()`) to `rimba version` output — matches de-facto Go CLI convention
- Expand `rimba restore --help` to document the `rimba archive` prerequisite and the `"no archived branch found for task <name>"` failure case
- Lowercase all flag `Usage` strings across `cmd/` to match Go stdlib `flag` convention
- Add `Example:` field to every runnable cobra command; extract examples from `Long:` where they were embedded (`add`, `list`, `open`, `status`, `completion`)
- Add `TestFlagUsageIsLowercase` and `TestExamplePresent` metatests to guard against future drift

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)
- [x] `bin/rimba version` includes a `go:` line
- [x] `bin/rimba help restore` mentions `rimba archive` and the missing-branch case
- [x] `bin/rimba help <cmd>` shows an Examples section for every command

## Issue

Closes #173