### PR TITLE
[test] resolver edge-case coverage + SplitServiceInput leading-slash fix

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -21,11 +21,12 @@ func FullBranchName(service, prefix, task string) string {
 }
 
 // SplitServiceInput splits input on the first "/" and returns the candidate
-// service name and the rest. Returns ("", input) if no "/" is found.
+// service name (the part before the first "/") and the rest (the part after).
+// A leading "/" yields an empty candidate. Returns ("", input) when there is no "/".
 // The caller is responsible for validating whether candidate is a real service.
 func SplitServiceInput(input string) (candidate, rest string) {
-	if i := strings.Index(input, "/"); i > 0 {
-		return input[:i], input[i+1:]
+	if before, after, ok := strings.Cut(input, "/"); ok {
+		return before, after
 	}
 	return "", input
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -197,6 +197,10 @@ func TestSplitServiceInput(t *testing.T) {
 		{"feature/my-task", "feature", "my-task"},
 		{"my-task", "", "my-task"},
 		{"", "", ""},
+		{"/", "", ""},                       // separator-only: leading "/" splits to two empty parts
+		{"/foo", "", "foo"},                 // leading slash: empty candidate
+		{"auth/v2/beta", "auth", "v2/beta"}, // multiple separators: only the first splits
+		{" auth/task ", " auth", "task "},   // whitespace is NOT trimmed
 	}
 	for _, tt := range tests {
 		candidate, rest := resolver.SplitServiceInput(tt.input)
@@ -224,26 +228,41 @@ func TestSanitizeTask(t *testing.T) {
 }
 
 func TestServiceFromBranch(t *testing.T) {
-	prefixes := resolver.AllPrefixes()
+	defaultPrefixes := resolver.AllPrefixes()
 
 	tests := []struct {
 		branch     string
+		prefixes   []string // nil → defaultPrefixes (AllPrefixes)
 		wantSvc    string
 		wantTask   string
 		wantPrefix string
 	}{
-		{"feature/my-task", "", "my-task", featurePrefix},
-		{"bugfix/login-fix", "", "login-fix", bugfixPrefix},
-		{"auth-api/feature/my-task", "auth-api", "my-task", featurePrefix},
-		{"auth-api/bugfix/crash", "auth-api", "crash", bugfixPrefix},
-		{"bare-branch", "", "bare-branch", ""},
-		{"unknown/prefix", "", "unknown/prefix", ""},
+		// existing happy-path rows
+		{branch: "feature/my-task", wantTask: "my-task", wantPrefix: featurePrefix},
+		{branch: "bugfix/login-fix", wantTask: "login-fix", wantPrefix: bugfixPrefix},
+		{branch: "auth-api/feature/my-task", wantSvc: "auth-api", wantTask: "my-task", wantPrefix: featurePrefix},
+		{branch: "auth-api/bugfix/crash", wantSvc: "auth-api", wantTask: "crash", wantPrefix: bugfixPrefix},
+		{branch: "bare-branch", wantTask: "bare-branch"},
+		{branch: "unknown/prefix", wantTask: "unknown/prefix"},
+		// G3 edge cases
+		{branch: "", wantTask: ""},                                                                  // empty branch, no prefix → clean
+		{branch: "feature/", wantTask: "", wantPrefix: featurePrefix},                               // prefix matches, empty task
+		{branch: "auth-api/feature/", wantSvc: "auth-api", wantTask: "", wantPrefix: featurePrefix}, // monorepo, empty task
+		// prefix-ordering sensitivity: ServiceFromBranch returns the FIRST matching
+		// prefix in slice order, not the longest. Synthetic overlapping prefixes
+		// (real AllPrefixes never overlap) demonstrate the contract.
+		{branch: "a/b/task", prefixes: []string{"a/", "a/b/"}, wantTask: "b/task", wantPrefix: "a/"},
+		{branch: "a/b/task", prefixes: []string{"a/b/", "a/"}, wantTask: "task", wantPrefix: "a/b/"},
 	}
 	for _, tt := range tests {
+		prefixes := tt.prefixes
+		if prefixes == nil {
+			prefixes = defaultPrefixes
+		}
 		svc, task, prefix := resolver.ServiceFromBranch(tt.branch, prefixes)
 		if svc != tt.wantSvc || task != tt.wantTask || prefix != tt.wantPrefix {
-			t.Errorf("ServiceFromBranch(%q) = (%q, %q, %q), want (%q, %q, %q)",
-				tt.branch, svc, task, prefix, tt.wantSvc, tt.wantTask, tt.wantPrefix)
+			t.Errorf("ServiceFromBranch(%q, %v) = (%q, %q, %q), want (%q, %q, %q)",
+				tt.branch, prefixes, svc, task, prefix, tt.wantSvc, tt.wantTask, tt.wantPrefix)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fix `SplitServiceInput("/")` returning `("", "/")` instead of `("", "")` — guard was `i > 0` (excluded `i == 0`), now replaced with `strings.Cut` which handles position-0 correctly and satisfies the `modernize` linter
- Add G2 edge-case rows to `TestSplitServiceInput`: `/`, `/foo`, `auth/v2/beta`, whitespace (not trimmed)
- Restructure `TestServiceFromBranch` to named-field struct with optional per-row `prefixes` slice; add G3 rows: empty branch, prefix-only (`feature/`), monorepo prefix-only (`auth-api/feature/`), prefix-ordering sensitivity ×2

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

## Issue
Closes #176