### PR TITLE
[chore] Extract update orchestration into internal/updater.Runner

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/lugassawan/rimba/internal/config"
@@ -130,5 +133,7 @@ func CommandName() string {
 }
 
 func Execute() error {
-	return rootCmd.Execute()
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return rootCmd.ExecuteContext(ctx)
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,18 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 
-	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/lugassawan/rimba/internal/updater"
 	"github.com/spf13/cobra"
 )
-
-const retryUpdateHint = "retry: rimba update"
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
@@ -38,134 +31,18 @@ refresh). Set RIMBA_QUIET=1 to suppress the tip.`,
 			return nil
 		}
 
-		u := updater.New(version)
-
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
 
-		s.Start("Checking for updates...")
-		result, err := u.Check()
-		if err != nil {
-			return errhint.WithFix(
-				fmt.Errorf("checking for updates: %w", err),
-				"check network connectivity, or set GITHUB_TOKEN if rate limited",
-			)
+		r := updater.NewRunner(version)
+		r.Out = cmd.OutOrStdout()
+		r.Spinner = s
+		r.OnSuccess = func() {
+			home, repoRoot := resolvePostUpdateTipPaths()
+			printAgentRefreshTips(cmd, home, repoRoot)
 		}
 
-		if result.UpToDate {
-			s.Stop()
-			fmt.Fprintf(cmd.OutOrStdout(), "Already up to date (%s).\n", result.CurrentVersion)
-			return nil
-		}
-
-		s.Stop()
-		fmt.Fprintf(cmd.OutOrStdout(), "New version available: %s → %s\n", result.CurrentVersion, result.LatestVersion)
-
-		s.Start("Downloading...")
-		newBinary, err := u.Download(result.DownloadURL)
-		if err != nil {
-			return errhint.WithFix(
-				fmt.Errorf("downloading update: %w", err),
-				"check network connectivity and retry: rimba update",
-			)
-		}
-		defer updater.CleanupTempDir(newBinary)
-
-		if err := updater.PrepareBinary(newBinary); err != nil {
-			return errhint.WithFix(fmt.Errorf("preparing binary: %w", err), retryUpdateHint)
-		}
-
-		currentBinary, err := os.Executable()
-		if err != nil {
-			return errhint.WithFix(
-				fmt.Errorf("locating current binary: %w", err),
-				"reinstall rimba: https://github.com/lugassawan/rimba#installation",
-			)
-		}
-		currentBinary, err = filepath.EvalSymlinks(currentBinary)
-		if err != nil {
-			return errhint.WithFix(
-				fmt.Errorf("resolving binary path: %w", err),
-				"reinstall rimba: https://github.com/lugassawan/rimba#installation",
-			)
-		}
-
-		s.Update("Installing...")
-		installedBinary := currentBinary
-		if err := updater.Replace(currentBinary, newBinary); err != nil {
-			if !updater.IsPermissionError(err) {
-				return errhint.WithFix(fmt.Errorf("replacing binary: %w", err), retryUpdateHint)
-			}
-
-			// Install to user-writable directory instead
-			s.Stop()
-			userDir, dirErr := updater.UserInstallDir()
-			if dirErr != nil {
-				return errhint.WithFix(
-					fmt.Errorf("getting user install dir: %w", dirErr),
-					"set HOME to your user home directory and retry: rimba update",
-				)
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Cannot write to %s. Installing to %s instead.\n",
-				filepath.Dir(currentBinary), userDir)
-
-			if mkErr := os.MkdirAll(userDir, 0750); mkErr != nil {
-				return errhint.WithFix(
-					fmt.Errorf("creating install dir: %w", mkErr),
-					"check write permissions for ~/.local/bin and retry: rimba update",
-				)
-			}
-
-			installedBinary = filepath.Join(userDir, "rimba")
-			s.Start("Installing...")
-			if _, statErr := os.Stat(installedBinary); os.IsNotExist(statErr) {
-				// First install to this directory — write directly
-				src, readErr := os.ReadFile(newBinary)
-				if readErr != nil {
-					return errhint.WithFix(fmt.Errorf("reading new binary: %w", readErr), retryUpdateHint)
-				}
-				if writeErr := os.WriteFile(installedBinary, src, 0755); writeErr != nil { //nolint:gosec // executable binary
-					return errhint.WithFix(
-						fmt.Errorf("writing binary: %w", writeErr),
-						fmt.Sprintf("check write permissions for %s and retry: rimba update", userDir),
-					)
-				}
-			} else if err := updater.Replace(installedBinary, newBinary); err != nil {
-				return errhint.WithFix(
-					fmt.Errorf("replacing binary: %w", err),
-					fmt.Sprintf("check write permissions for %s and retry: rimba update", userDir),
-				)
-			}
-
-			if pathErr := updater.EnsurePath(userDir); pathErr != nil {
-				return errhint.WithFix(
-					fmt.Errorf("updating PATH: %w", pathErr),
-					fmt.Sprintf("add %s to PATH manually: export PATH=\"%s:$PATH\"", userDir, userDir),
-				)
-			}
-		}
-
-		s.Stop()
-
-		// Verify the new binary works
-		out, err := exec.Command(filepath.Clean(installedBinary), "version").Output() //nolint:gosec // path comes from os.Executable
-		if err != nil {
-			return errhint.WithFix(
-				fmt.Errorf("verifying new binary: %w", err),
-				fmt.Sprintf("the new binary at %s may be corrupt — retry: rimba update", installedBinary),
-			)
-		}
-
-		fmt.Fprintf(cmd.OutOrStdout(), "Updated successfully: %s\n", strings.TrimSpace(string(out)))
-
-		home, repoRoot := resolvePostUpdateTipPaths()
-		printAgentRefreshTips(cmd, home, repoRoot)
-
-		// Print migration guidance if installed to a different location
-		if installedBinary != currentBinary {
-			fmt.Fprintf(cmd.OutOrStdout(), "\nTo complete migration, remove the old binary:\n  sudo rm %s\n", currentBinary)
-		}
-		return nil
+		return r.Run(cmd.Context())
 	},
 }
 

--- a/internal/updater/runner.go
+++ b/internal/updater/runner.go
@@ -1,0 +1,244 @@
+package updater
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/lugassawan/rimba/internal/errhint"
+	"github.com/lugassawan/rimba/internal/spinner"
+)
+
+const (
+	retryUpdateHint = "retry: rimba update"
+	reinstallHint   = "reinstall rimba: https://github.com/lugassawan/rimba#installation"
+)
+
+// Runner orchestrates the self-update flow with injectable seams for testability.
+// Each unexported field maps to one stage of the update pipeline; NewRunner wires
+// production defaults. ctx is checked once before the destructive install stage —
+// os.Rename in Replace is atomic so a check inside Replace is pointless.
+// Post-Replace pre-verify crash: a SIGINT/crash after Replace but before verify
+// leaves a working new binary; recovery is `rimba version`.
+type Runner struct {
+	Version   string
+	Out       io.Writer
+	Spinner   *spinner.Spinner
+	OnSuccess func()
+
+	check          func() (*CheckResult, error)
+	download       func(url string) (string, error)
+	prepareBinary  func(path string) error
+	executable     func() (string, error)
+	evalSymlinks   func(path string) (string, error)
+	replace        func(currentBinary, newBinary string) error
+	userInstallDir func() (string, error)
+	mkdirAll       func(path string, perm os.FileMode) error
+	stat           func(path string) (os.FileInfo, error)
+	readFile       func(path string) ([]byte, error)
+	writeFile      func(path string, data []byte, perm os.FileMode) error
+	ensurePath     func(dir string) error
+	execCommand    func(ctx context.Context, name string, args ...string) ([]byte, error)
+	cleanupTempDir func(binaryPath string)
+}
+
+// NewRunner creates a Runner with production defaults wired.
+func NewRunner(version string) *Runner {
+	u := New(version)
+	r := &Runner{
+		Version: version,
+		Out:     os.Stdout,
+		Spinner: spinner.New(spinner.Options{Writer: io.Discard}),
+	}
+	r.check = u.Check
+	r.download = u.Download
+	r.prepareBinary = PrepareBinary
+	r.executable = os.Executable
+	r.evalSymlinks = filepath.EvalSymlinks
+	r.replace = Replace
+	r.userInstallDir = UserInstallDir
+	r.mkdirAll = os.MkdirAll
+	r.stat = os.Stat
+	r.readFile = os.ReadFile
+	r.writeFile = os.WriteFile
+	r.ensurePath = EnsurePath
+	r.execCommand = defaultExecCommand
+	r.cleanupTempDir = CleanupTempDir
+	return r
+}
+
+func defaultExecCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, filepath.Clean(name), args...).Output() //nolint:gosec // path comes from os.Executable
+}
+
+// Run executes the full update pipeline: check → download → prepare → locate →
+// install → verify. ctx is checked before the destructive install stage.
+func (r *Runner) Run(ctx context.Context) error {
+	r.Spinner.Start("Checking for updates...")
+	result, err := r.check()
+	if err != nil {
+		return errhint.WithFix(
+			fmt.Errorf("checking for updates: %w", err),
+			"check network connectivity, or set GITHUB_TOKEN if rate limited",
+		)
+	}
+
+	if result.UpToDate {
+		r.Spinner.Stop()
+		fmt.Fprintf(r.Out, "Already up to date (%s).\n", result.CurrentVersion)
+		return nil
+	}
+
+	r.Spinner.Stop()
+	fmt.Fprintf(r.Out, "New version available: %s → %s\n", result.CurrentVersion, result.LatestVersion)
+
+	r.Spinner.Start("Downloading...")
+	newBinary, err := r.download(result.DownloadURL)
+	if err != nil {
+		return errhint.WithFix(
+			fmt.Errorf("downloading update: %w", err),
+			"check network connectivity and retry: rimba update",
+		)
+	}
+	defer r.cleanupTempDir(newBinary)
+
+	if err := r.prepareBinary(newBinary); err != nil {
+		return errhint.WithFix(fmt.Errorf("preparing binary: %w", err), retryUpdateHint)
+	}
+
+	currentBinary, err := r.locateCurrentBinary()
+	if err != nil {
+		return err
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	r.Spinner.Update("Installing...")
+	installedBinary, err := r.install(currentBinary, newBinary)
+	if err != nil {
+		return err
+	}
+
+	r.Spinner.Stop()
+
+	versionStr, err := r.verify(ctx, installedBinary)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(r.Out, "Updated successfully: %s\n", versionStr)
+
+	if r.OnSuccess != nil {
+		r.OnSuccess()
+	}
+
+	if installedBinary != currentBinary {
+		fmt.Fprintf(r.Out, "\nTo complete migration, remove the old binary:\n  sudo rm %s\n", currentBinary)
+	}
+
+	return nil
+}
+
+func (r *Runner) locateCurrentBinary() (string, error) {
+	current, err := r.executable()
+	if err != nil {
+		return "", errhint.WithFix(
+			fmt.Errorf("locating current binary: %w", err),
+			reinstallHint,
+		)
+	}
+	resolved, err := r.evalSymlinks(current)
+	if err != nil {
+		return "", errhint.WithFix(
+			fmt.Errorf("resolving binary path: %w", err),
+			reinstallHint,
+		)
+	}
+	return resolved, nil
+}
+
+func (r *Runner) install(currentBinary, newBinary string) (string, error) {
+	if err := r.replace(currentBinary, newBinary); err != nil {
+		if !IsPermissionError(err) {
+			return "", errhint.WithFix(fmt.Errorf("replacing binary: %w", err), retryUpdateHint)
+		}
+		return r.installToUserDir(currentBinary, newBinary)
+	}
+	return currentBinary, nil
+}
+
+func (r *Runner) installToUserDir(currentBinary, newBinary string) (string, error) {
+	r.Spinner.Stop()
+	userDir, err := r.userInstallDir()
+	if err != nil {
+		return "", errhint.WithFix(
+			fmt.Errorf("getting user install dir: %w", err),
+			"set HOME to your user home directory and retry: rimba update",
+		)
+	}
+	fmt.Fprintf(r.Out, "Cannot write to %s. Installing to %s instead.\n",
+		filepath.Dir(currentBinary), userDir)
+
+	if err := r.mkdirAll(userDir, 0750); err != nil {
+		return "", errhint.WithFix(
+			fmt.Errorf("creating install dir: %w", err),
+			"check write permissions for ~/.local/bin and retry: rimba update",
+		)
+	}
+
+	installedBinary := filepath.Join(userDir, "rimba")
+	r.Spinner.Start("Installing...")
+
+	if err := r.installBinaryAt(installedBinary, newBinary, userDir); err != nil {
+		return "", err
+	}
+
+	if err := r.ensurePath(userDir); err != nil {
+		return "", errhint.WithFix(
+			fmt.Errorf("updating PATH: %w", err),
+			fmt.Sprintf("add %s to PATH manually: export PATH=\"%s:$PATH\"", userDir, userDir),
+		)
+	}
+
+	return installedBinary, nil
+}
+
+func (r *Runner) installBinaryAt(installedBinary, newBinary, userDir string) error {
+	if _, err := r.stat(installedBinary); os.IsNotExist(err) {
+		src, readErr := r.readFile(newBinary)
+		if readErr != nil {
+			return errhint.WithFix(fmt.Errorf("reading new binary: %w", readErr), retryUpdateHint)
+		}
+		if writeErr := r.writeFile(installedBinary, src, 0755); writeErr != nil { //nolint:gosec // executable binary
+			return errhint.WithFix(
+				fmt.Errorf("writing binary: %w", writeErr),
+				fmt.Sprintf("check write permissions for %s and retry: rimba update", userDir),
+			)
+		}
+		return nil
+	}
+	if err := r.replace(installedBinary, newBinary); err != nil {
+		return errhint.WithFix(
+			fmt.Errorf("replacing binary: %w", err),
+			fmt.Sprintf("check write permissions for %s and retry: rimba update", userDir),
+		)
+	}
+	return nil
+}
+
+func (r *Runner) verify(ctx context.Context, installedBinary string) (string, error) {
+	out, err := r.execCommand(ctx, installedBinary, "version")
+	if err != nil {
+		return "", errhint.WithFix(
+			fmt.Errorf("verifying new binary: %w", err),
+			fmt.Sprintf("the new binary at %s may be corrupt — retry: rimba update", installedBinary),
+		)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/updater/runner.go
+++ b/internal/updater/runner.go
@@ -30,8 +30,8 @@ type Runner struct {
 	Spinner   *spinner.Spinner
 	OnSuccess func()
 
-	check          func() (*CheckResult, error)
-	download       func(url string) (string, error)
+	check          func(ctx context.Context) (*CheckResult, error)
+	download       func(ctx context.Context, url string) (string, error)
 	prepareBinary  func(path string) error
 	executable     func() (string, error)
 	evalSymlinks   func(path string) (string, error)
@@ -54,8 +54,8 @@ func NewRunner(version string) *Runner {
 		Out:     os.Stdout,
 		Spinner: spinner.New(spinner.Options{Writer: io.Discard}),
 	}
-	r.check = u.Check
-	r.download = u.Download
+	r.check = func(_ context.Context) (*CheckResult, error) { return u.Check() }
+	r.download = func(_ context.Context, url string) (string, error) { return u.Download(url) }
 	r.prepareBinary = PrepareBinary
 	r.executable = os.Executable
 	r.evalSymlinks = filepath.EvalSymlinks
@@ -72,14 +72,20 @@ func NewRunner(version string) *Runner {
 }
 
 func defaultExecCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
-	return exec.CommandContext(ctx, filepath.Clean(name), args...).Output() //nolint:gosec // path comes from os.Executable
+	return exec.CommandContext(ctx, filepath.Clean(name), args...).Output() //nolint:gosec // G204: name is installedBinary, written by this process
 }
 
 // Run executes the full update pipeline: check → download → prepare → locate →
 // install → verify. ctx is checked before the destructive install stage.
 func (r *Runner) Run(ctx context.Context) error {
+	if r.Spinner == nil {
+		r.Spinner = spinner.New(spinner.Options{Writer: io.Discard})
+	}
+	if r.Out == nil {
+		r.Out = io.Discard
+	}
 	r.Spinner.Start("Checking for updates...")
-	result, err := r.check()
+	result, err := r.check(ctx)
 	if err != nil {
 		return errhint.WithFix(
 			fmt.Errorf("checking for updates: %w", err),
@@ -97,7 +103,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	fmt.Fprintf(r.Out, "New version available: %s → %s\n", result.CurrentVersion, result.LatestVersion)
 
 	r.Spinner.Start("Downloading...")
-	newBinary, err := r.download(result.DownloadURL)
+	newBinary, err := r.download(ctx, result.DownloadURL)
 	if err != nil {
 		return errhint.WithFix(
 			fmt.Errorf("downloading update: %w", err),
@@ -115,8 +121,8 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	if ctx.Err() != nil {
-		return ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return errhint.WithFix(err, retryUpdateHint)
 	}
 
 	r.Spinner.Update("Installing...")
@@ -174,7 +180,6 @@ func (r *Runner) install(currentBinary, newBinary string) (string, error) {
 }
 
 func (r *Runner) installToUserDir(currentBinary, newBinary string) (string, error) {
-	r.Spinner.Stop()
 	userDir, err := r.userInstallDir()
 	if err != nil {
 		return "", errhint.WithFix(

--- a/internal/updater/runner_test.go
+++ b/internal/updater/runner_test.go
@@ -1,0 +1,334 @@
+package updater
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+const (
+	testUserDir       = "/home/user/.local/bin"
+	testCurrentBinary = "/usr/local/bin/rimba"
+)
+
+// newTestRunner returns a Runner wired with fake seams that all succeed, plus a
+// buffer capturing stdout. Tests override individual seams to exercise one failure path.
+func newTestRunner(t *testing.T) (*Runner, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	r := NewRunner("1.0.0")
+	r.Out = &buf
+	r.check = func() (*CheckResult, error) {
+		return &CheckResult{
+			CurrentVersion: "1.0.0",
+			LatestVersion:  "v1.1.0",
+			DownloadURL:    "http://fake/download",
+		}, nil
+	}
+	r.download = func(url string) (string, error) { return "/tmp/rimba-test/rimba", nil }
+	r.prepareBinary = func(path string) error { return nil }
+	r.executable = func() (string, error) { return testCurrentBinary, nil }
+	r.evalSymlinks = func(path string) (string, error) { return path, nil }
+	r.replace = func(_, _ string) error { return nil }
+	r.userInstallDir = func() (string, error) { return testUserDir, nil }
+	r.mkdirAll = func(path string, perm os.FileMode) error { return nil }
+	r.stat = func(path string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+	r.readFile = func(path string) ([]byte, error) { return []byte("fake"), nil }
+	r.writeFile = func(path string, data []byte, perm os.FileMode) error { return nil }
+	r.ensurePath = func(dir string) error { return nil }
+	r.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return []byte("rimba version 1.1.0"), nil
+	}
+	r.cleanupTempDir = func(binaryPath string) {}
+	return r, &buf
+}
+
+// requireErrContains fails if err is nil or does not contain every fragment.
+func requireErrContains(t *testing.T, err error, fragments ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	got := err.Error()
+	for _, frag := range fragments {
+		if !strings.Contains(got, frag) {
+			t.Errorf("error = %q, want to contain %q", got, frag)
+		}
+	}
+}
+
+// testPermErr returns a wrapped os.ErrPermission to route the replace fallback path.
+func testPermErr() error {
+	return fmt.Errorf("writing to /system/bin: %w", os.ErrPermission)
+}
+
+// statExists returns a stat func that reports the path as existing (takes the replace branch).
+func statExists(t *testing.T) func(string) (os.FileInfo, error) {
+	t.Helper()
+	info, err := os.Stat(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return func(path string) (os.FileInfo, error) { return info, nil }
+}
+
+// TestHintSurfaces verifies all 13 errhint.WithFix surfaces in Runner.Run.
+// Each test case starts from a fully-mocked-success runner and overrides exactly
+// one seam to fail, then asserts the wrapped error prefix and hint fragment.
+func TestHintSurfaces(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupFn    func(*testing.T, *Runner)
+		wantPrefix string
+		wantHint   string
+	}{
+		{
+			name: "check fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.check = func() (*CheckResult, error) {
+					return nil, errors.New("network error")
+				}
+			},
+			wantPrefix: "checking for updates:",
+			wantHint:   "check network connectivity, or set GITHUB_TOKEN if rate limited",
+		},
+		{
+			name: "download fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.download = func(url string) (string, error) {
+					return "", errors.New("connection refused")
+				}
+			},
+			wantPrefix: "downloading update:",
+			wantHint:   "check network connectivity and retry: rimba update",
+		},
+		{
+			name: "prepareBinary fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.prepareBinary = func(path string) error { return errors.New("codesign failed") }
+			},
+			wantPrefix: "preparing binary:",
+			wantHint:   retryUpdateHint,
+		},
+		{
+			name: "executable fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.executable = func() (string, error) { return "", errors.New("no executable") }
+			},
+			wantPrefix: "locating current binary:",
+			wantHint:   reinstallHint,
+		},
+		{
+			name: "evalSymlinks fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.evalSymlinks = func(path string) (string, error) {
+					return "", errors.New("dangling symlink")
+				}
+			},
+			wantPrefix: "resolving binary path:",
+			wantHint:   reinstallHint,
+		},
+		{
+			name: "replace fails non-permission",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.replace = func(_, _ string) error { return errors.New("disk full") }
+			},
+			wantPrefix: "replacing binary:",
+			wantHint:   retryUpdateHint,
+		},
+		{
+			name: "replace perm: userInstallDir fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.replace = func(_, _ string) error { return testPermErr() }
+				r.userInstallDir = func() (string, error) { return "", errors.New("no home dir") }
+			},
+			wantPrefix: "getting user install dir:",
+			wantHint:   "set HOME to your user home directory and retry: rimba update",
+		},
+		{
+			name: "replace perm: mkdirAll fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.replace = func(_, _ string) error { return testPermErr() }
+				r.mkdirAll = func(path string, perm os.FileMode) error {
+					return errors.New("permission denied")
+				}
+			},
+			wantPrefix: "creating install dir:",
+			wantHint:   "check write permissions for ~/.local/bin and retry: rimba update",
+		},
+		{
+			name: "replace perm: stat NotExist, readFile fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.replace = func(_, _ string) error { return testPermErr() }
+				r.readFile = func(path string) ([]byte, error) { return nil, errors.New("read error") }
+			},
+			wantPrefix: "reading new binary:",
+			wantHint:   retryUpdateHint,
+		},
+		{
+			name: "replace perm: stat NotExist, writeFile fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.replace = func(_, _ string) error { return testPermErr() }
+				r.writeFile = func(path string, data []byte, perm os.FileMode) error {
+					return errors.New("write error")
+				}
+			},
+			wantPrefix: "writing binary:",
+			wantHint:   "check write permissions for " + testUserDir + " and retry: rimba update",
+		},
+		{
+			name: "replace perm: stat exists, second replace fails",
+			setupFn: func(t *testing.T, r *Runner) {
+				t.Helper()
+				n := 0
+				r.replace = func(_, _ string) error {
+					n++
+					if n == 1 {
+						return testPermErr()
+					}
+					return errors.New("replace failed")
+				}
+				r.stat = statExists(t)
+			},
+			wantPrefix: "replacing binary:",
+			wantHint:   "check write permissions for " + testUserDir + " and retry: rimba update",
+		},
+		{
+			name: "replace perm: ensurePath fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.replace = func(_, _ string) error { return testPermErr() }
+				r.ensurePath = func(dir string) error { return errors.New("cannot write rc file") }
+			},
+			wantPrefix: "updating PATH:",
+			wantHint:   `add ` + testUserDir + ` to PATH manually: export PATH="` + testUserDir + `:$PATH"`,
+		},
+		{
+			name: "execCommand fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.execCommand = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+					return nil, errors.New("exec failed")
+				}
+			},
+			wantPrefix: "verifying new binary:",
+			wantHint: "the new binary at " + testCurrentBinary +
+				" may be corrupt — retry: rimba update",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := newTestRunner(t)
+			tt.setupFn(t, r)
+			err := r.Run(context.Background())
+			requireErrContains(t, err, "To fix:", tt.wantPrefix, tt.wantHint)
+		})
+	}
+}
+
+func TestRunHappyPath(t *testing.T) {
+	r, out := newTestRunner(t)
+	onSuccessCalled := false
+	r.OnSuccess = func() { onSuccessCalled = true }
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "Updated successfully:") {
+		t.Errorf("output = %q, want 'Updated successfully:'", got)
+	}
+	if !onSuccessCalled {
+		t.Error("OnSuccess should have been called")
+	}
+	if strings.Contains(got, "To complete migration") {
+		t.Errorf("output = %q, migration hint should not appear when installed == current", got)
+	}
+}
+
+func TestRunUpToDate(t *testing.T) {
+	r, out := newTestRunner(t)
+	r.check = func() (*CheckResult, error) {
+		return &CheckResult{CurrentVersion: "1.0.0", UpToDate: true}, nil
+	}
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "Already up to date") {
+		t.Errorf("output = %q, want 'Already up to date'", out.String())
+	}
+}
+
+func TestRunPermFallbackFreshInstall(t *testing.T) {
+	r, out := newTestRunner(t)
+	r.replace = func(_, _ string) error { return testPermErr() }
+	onSuccessCalled := false
+	r.OnSuccess = func() { onSuccessCalled = true }
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "Cannot write to") {
+		t.Errorf("output = %q, want 'Cannot write to'", got)
+	}
+	if !strings.Contains(got, "To complete migration") {
+		t.Errorf("output = %q, want migration hint when installed != current", got)
+	}
+	if !onSuccessCalled {
+		t.Error("OnSuccess should have been called on fallback success path")
+	}
+}
+
+func TestRunPermFallbackExistingFile(t *testing.T) {
+	r, out := newTestRunner(t)
+	n := 0
+	r.replace = func(_, _ string) error {
+		n++
+		if n == 1 {
+			return testPermErr()
+		}
+		return nil
+	}
+	r.stat = statExists(t)
+	onSuccessCalled := false
+	r.OnSuccess = func() { onSuccessCalled = true }
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "Updated successfully:") {
+		t.Errorf("output = %q, want 'Updated successfully:'", out.String())
+	}
+	if !onSuccessCalled {
+		t.Error("OnSuccess should have been called on fallback success path")
+	}
+}
+
+func TestRunCtxCancelledBeforeInstall(t *testing.T) {
+	r, _ := newTestRunner(t)
+	replaceCalled := false
+	r.replace = func(_, _ string) error {
+		replaceCalled = true
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := r.Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if replaceCalled {
+		t.Error("replace should not be called after ctx cancellation")
+	}
+}

--- a/internal/updater/runner_test.go
+++ b/internal/updater/runner_test.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/lugassawan/rimba/internal/spinner"
 )
 
 const (
@@ -20,16 +23,19 @@ const (
 func newTestRunner(t *testing.T) (*Runner, *bytes.Buffer) {
 	t.Helper()
 	var buf bytes.Buffer
-	r := NewRunner("1.0.0")
-	r.Out = &buf
-	r.check = func() (*CheckResult, error) {
+	r := &Runner{
+		Version: "1.0.0",
+		Out:     &buf,
+		Spinner: spinner.New(spinner.Options{Writer: io.Discard}),
+	}
+	r.check = func(_ context.Context) (*CheckResult, error) {
 		return &CheckResult{
 			CurrentVersion: "1.0.0",
 			LatestVersion:  "v1.1.0",
 			DownloadURL:    "http://fake/download",
 		}, nil
 	}
-	r.download = func(url string) (string, error) { return "/tmp/rimba-test/rimba", nil }
+	r.download = func(_ context.Context, url string) (string, error) { return "/tmp/rimba-test/rimba", nil }
 	r.prepareBinary = func(path string) error { return nil }
 	r.executable = func() (string, error) { return testCurrentBinary, nil }
 	r.evalSymlinks = func(path string) (string, error) { return path, nil }
@@ -89,7 +95,7 @@ func TestHintSurfaces(t *testing.T) {
 		{
 			name: "check fails",
 			setupFn: func(_ *testing.T, r *Runner) {
-				r.check = func() (*CheckResult, error) {
+				r.check = func(_ context.Context) (*CheckResult, error) {
 					return nil, errors.New("network error")
 				}
 			},
@@ -99,7 +105,7 @@ func TestHintSurfaces(t *testing.T) {
 		{
 			name: "download fails",
 			setupFn: func(_ *testing.T, r *Runner) {
-				r.download = func(url string) (string, error) {
+				r.download = func(_ context.Context, url string) (string, error) {
 					return "", errors.New("connection refused")
 				}
 			},
@@ -252,7 +258,7 @@ func TestRunHappyPath(t *testing.T) {
 
 func TestRunUpToDate(t *testing.T) {
 	r, out := newTestRunner(t)
-	r.check = func() (*CheckResult, error) {
+	r.check = func(_ context.Context) (*CheckResult, error) {
 		return &CheckResult{CurrentVersion: "1.0.0", UpToDate: true}, nil
 	}
 
@@ -330,5 +336,38 @@ func TestRunCtxCancelledBeforeInstall(t *testing.T) {
 	}
 	if replaceCalled {
 		t.Error("replace should not be called after ctx cancellation")
+	}
+}
+
+func TestRunVerifyFailsAfterFallbackInstall(t *testing.T) {
+	r, _ := newTestRunner(t)
+	r.replace = func(_, _ string) error { return testPermErr() }
+	r.execCommand = func(_ context.Context, name string, args ...string) ([]byte, error) {
+		return nil, errors.New("exec failed")
+	}
+
+	err := r.Run(context.Background())
+	requireErrContains(t, err, "To fix:", "verifying new binary:", testUserDir+"/rimba")
+}
+
+func TestNewRunner(t *testing.T) {
+	r := NewRunner("1.2.3")
+	if r.Version != "1.2.3" {
+		t.Errorf("Version = %q, want %q", r.Version, "1.2.3")
+	}
+	if r.Out == nil {
+		t.Error("Out should not be nil")
+	}
+	if r.Spinner == nil {
+		t.Error("Spinner should not be nil")
+	}
+}
+
+func TestRunNilDefaults(t *testing.T) {
+	r, _ := newTestRunner(t)
+	r.Spinner = nil
+	r.Out = nil
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error with nil Spinner/Out: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Move the ~138-line `cmd/update.go` `RunE` closure into `internal/updater.Runner` with function-valued struct fields as injectable seams
- Each of the 13 `errhint.WithFix` error surfaces now has a focused unit test that injects a fake at exactly one stage — previously untestable because CI can't trigger a real update
- `cmd/update.go` `RunE` shrinks from ~138 to ~17 LOC (thin wrapper: dev-build guard + spinner + `NewRunner` + `Run`)
- `cmd/root.go` `Execute()` gains `signal.NotifyContext` so Ctrl-C cancels a mid-update
- All hint strings preserved verbatim (including em-dash U+2014 and escaped PATH export quotes)

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

## Issue

Closes #195