### PR TITLE
[chore] Audit hardening: security + reliability fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
 
   vuln:
     runs-on: ubuntu-latest
+    # TODO: remove continue-on-error once go.mod toolchain is bumped to ≥go1.26.1
+    # to resolve stdlib CVEs (GO-2026-4599 etc.) and gate is confirmed clean.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -62,7 +65,4 @@ jobs:
           go-version: stable
           cache: true
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
-        # TODO: remove || true once the local toolchain (go1.26.0) is updated to ≥1.26.1
-        # and all stdlib CVEs (GO-2026-4599 etc.) are confirmed resolved.
-        # Tracked: upgrade go directive in go.mod and CI toolchain, then make this gate blocking.
-      - run: govulncheck ./... || true
+      - run: govulncheck ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,17 @@ jobs:
           go-version: stable
           cache: true
       - run: make build
+
+  vuln:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          cache: true
+      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        # TODO: remove || true once the local toolchain (go1.26.0) is updated to ≥1.26.1
+        # and all stdlib CVEs (GO-2026-4599 etc.) are confirmed resolved.
+        # Tracked: upgrade go directive in go.mod and CI toolchain, then make this gate blocking.
+      - run: govulncheck ./... || true

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -33,9 +33,13 @@ in the last 7 days. With --detail, rows are sorted largest-first.`,
 		staleDays, _ := cmd.Flags().GetInt(flagStaleDays)
 		detail, _ := cmd.Flags().GetBool(flagDetail)
 
+		ctx := cmd.Context()
+		if ctx == nil {
+			ctx = context.Background()
+		}
 		s := spinner.New(spinnerOpts(cmd))
 		s.Start("Collecting worktree status...")
-		res, err := operations.StatusDashboard(context.Background(), r, operations.StatusDashboardRequest{Detail: detail})
+		res, err := operations.StatusDashboard(ctx, r, operations.StatusDashboardRequest{Detail: detail})
 		s.Stop()
 		if err != nil {
 			return err

--- a/cmd/update_hint.go
+++ b/cmd/update_hint.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -25,7 +26,7 @@ func checkUpdateHint(version string, timeout time.Duration) <-chan *updater.Chec
 
 	go func() {
 		u := newUpdater(version)
-		result, err := u.Check()
+		result, err := u.Check(context.Background())
 		if err != nil || result.UpToDate {
 			close(ch)
 			return

--- a/internal/deps/clone.go
+++ b/internal/deps/clone.go
@@ -63,7 +63,7 @@ func cloneRecursive(srcWT, dstWT string, mod Module) error {
 	_ = filepath.WalkDir(searchRoot, walkCloneFunc(srcWT, dstWT, baseName, &cloneErrs))
 
 	if err := cloneExtraDirs(srcWT, dstWT, mod.ExtraDirs); err != nil {
-		return err
+		cloneErrs = append(cloneErrs, err)
 	}
 
 	return errors.Join(cloneErrs...)

--- a/internal/deps/clone.go
+++ b/internal/deps/clone.go
@@ -1,6 +1,8 @@
 package deps
 
 import (
+	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -56,20 +58,24 @@ func cloneRecursive(srcWT, dstWT string, mod Module) error {
 		searchRoot = filepath.Join(srcWT, mod.WorkDir)
 	}
 
+	var cloneErrs []error
 	baseName := filepath.Base(mod.Dir)
-	err := filepath.WalkDir(searchRoot, walkCloneFunc(srcWT, dstWT, baseName))
-	if err != nil {
+	_ = filepath.WalkDir(searchRoot, walkCloneFunc(srcWT, dstWT, baseName, &cloneErrs))
+
+	if err := cloneExtraDirs(srcWT, dstWT, mod.ExtraDirs); err != nil {
 		return err
 	}
 
-	return cloneExtraDirs(srcWT, dstWT, mod.ExtraDirs)
+	return errors.Join(cloneErrs...)
 }
 
 // walkCloneFunc returns a WalkDirFunc that clones directories matching baseName.
-func walkCloneFunc(srcWT, dstWT, baseName string) fs.WalkDirFunc {
+// Clone failures are appended to errs; walking continues regardless.
+func walkCloneFunc(srcWT, dstWT, baseName string, errs *[]error) fs.WalkDirFunc {
 	return func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return nil //nolint:nilerr // WalkDir: skip errors and continue walking
+			*errs = append(*errs, err)
+			return nil // keep walking
 		}
 		if !d.IsDir() {
 			return nil
@@ -80,20 +86,22 @@ func walkCloneFunc(srcWT, dstWT, baseName string) fs.WalkDirFunc {
 		}
 
 		relPath, _ := filepath.Rel(srcWT, path)
-		return cloneIfParentExists(path, dstWT, relPath)
+		return cloneIfParentExists(path, dstWT, relPath, errs)
 	}
 }
 
 // cloneIfParentExists clones srcPath to dstWT/relPath if the parent dir exists in dstWT.
-func cloneIfParentExists(srcPath, dstWT, relPath string) error {
+// Clone failures are appended to errs and the directory is skipped.
+func cloneIfParentExists(srcPath, dstWT, relPath string, errs *[]error) error {
 	dstParent := filepath.Join(dstWT, filepath.Dir(relPath))
 	if _, err := os.Stat(dstParent); os.IsNotExist(err) {
 		return filepath.SkipDir
 	}
 
 	dst := filepath.Join(dstWT, relPath)
-	if err := CloneDir(srcPath, dst); err != nil { //nolint:nilerr // best-effort clone; continue walking
-		return filepath.SkipDir
+	if err := CloneDir(srcPath, dst); err != nil {
+		*errs = append(*errs, fmt.Errorf("clone %s: %w", relPath, err))
+		return filepath.SkipDir // continue walking other dirs
 	}
 	return filepath.SkipDir // don't descend into cloned dir
 }

--- a/internal/deps/clone_test.go
+++ b/internal/deps/clone_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -262,9 +263,13 @@ func TestCloneIfParentExistsNoParent(t *testing.T) {
 	// dstWT does NOT have packages/foo — parent is missing
 	relPath := filepath.Join("packages", "foo", "node_modules")
 
-	err := cloneIfParentExists(srcPath, dstWT, relPath)
+	var errs []error
+	err := cloneIfParentExists(srcPath, dstWT, relPath, &errs)
 	if !errors.Is(err, filepath.SkipDir) {
 		t.Errorf("expected filepath.SkipDir, got: %v", err)
+	}
+	if len(errs) != 0 {
+		t.Errorf("expected no collected errors for missing-parent skip, got: %v", errs)
 	}
 
 	// Verify node_modules was NOT cloned
@@ -358,12 +363,16 @@ func TestWalkCloneFuncSkipsErrors(t *testing.T) {
 	srcWT := t.TempDir()
 	dstWT := t.TempDir()
 
-	fn := walkCloneFunc(srcWT, dstWT, DirNodeModules)
+	var errs []error
+	fn := walkCloneFunc(srcWT, dstWT, DirNodeModules, &errs)
 
-	// Call the returned WalkDirFunc with a non-nil error — should return nil (skip)
+	// Call the returned WalkDirFunc with a non-nil error — should return nil (keep walking)
 	err := fn("/some/path", nil, os.ErrPermission)
 	if err != nil {
 		t.Errorf("expected nil when err is non-nil, got: %v", err)
+	}
+	if len(errs) != 1 || !errors.Is(errs[0], os.ErrPermission) {
+		t.Errorf("expected traversal error to be collected, got: %v", errs)
 	}
 }
 
@@ -393,7 +402,8 @@ func TestWalkCloneFuncSkipsFiles(t *testing.T) {
 		t.Fatal("could not find file entry")
 	}
 
-	fn := walkCloneFunc(srcWT, dstWT, DirNodeModules)
+	var errs []error
+	fn := walkCloneFunc(srcWT, dstWT, DirNodeModules, &errs)
 
 	result := fn(filePath, fileEntry, nil)
 	if result != nil {
@@ -414,9 +424,13 @@ func TestCloneIfParentExistsCloneFails(t *testing.T) {
 	srcPath := filepath.Join(t.TempDir(), "nonexistent", "node_modules")
 	relPath := filepath.Join("packages", "foo", "node_modules")
 
-	err := cloneIfParentExists(srcPath, dstWT, relPath)
+	var errs []error
+	err := cloneIfParentExists(srcPath, dstWT, relPath, &errs)
 	if !errors.Is(err, filepath.SkipDir) {
 		t.Errorf("expected filepath.SkipDir on clone failure, got: %v", err)
+	}
+	if len(errs) == 0 {
+		t.Error("expected clone failure to be collected in errs")
 	}
 }
 
@@ -513,4 +527,83 @@ func TestCloneRecursiveWithExtraDirs(t *testing.T) {
 
 	// Verify extra dir (.yarn/cache) was cloned
 	assertFileContent(t, filepath.Join(dstWT, ".yarn", "cache", testDepZip), "cached")
+}
+
+func TestCloneModuleRecursiveSearchRootNotFound(t *testing.T) {
+	srcWT := t.TempDir()
+	dstWT := t.TempDir()
+
+	// WorkDir points to a non-existent directory — WalkDir fails on Lstat
+	mod := Module{Dir: DirNodeModules, Recursive: true, WorkDir: "nonexistent"}
+	err := CloneModule(srcWT, dstWT, mod)
+	if err == nil {
+		t.Fatal("expected error when WorkDir does not exist")
+	}
+}
+
+func TestCloneModuleRecursiveExtraDirError(t *testing.T) {
+	srcWT := t.TempDir()
+	dstWT := t.TempDir()
+
+	// Create a node_modules in srcWT root so walk finds it
+	if err := os.MkdirAll(filepath.Join(srcWT, DirNodeModules), 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(srcWT, DirNodeModules), "pkg.json", "{}")
+
+	// Create a valid ExtraDir source
+	extraSrc := filepath.Join(srcWT, ".yarn", "cache")
+	if err := os.MkdirAll(extraSrc, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, extraSrc, testDepZip, "data")
+
+	// Block the ExtraDir dst by placing a regular file where the parent dir would go
+	if err := os.WriteFile(filepath.Join(dstWT, ".yarn"), []byte("block"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mod := Module{Dir: DirNodeModules, Recursive: true, ExtraDirs: []string{DirYarnCache}}
+	err := CloneModule(srcWT, dstWT, mod)
+	if err == nil {
+		t.Fatal("expected error when ExtraDir clone fails in recursive mode")
+	}
+}
+
+func TestCloneModuleRecursiveAggregatesErrors(t *testing.T) {
+	srcWT := t.TempDir()
+	dstWT := t.TempDir()
+
+	// Create two nested node_modules dirs in srcWT
+	for _, app := range []string{"app-a", "app-b"} {
+		if err := os.MkdirAll(filepath.Join(srcWT, app, DirNodeModules), 0755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(srcWT, app, DirNodeModules), "pkg.json", app)
+	}
+
+	// app-a: create the parent dir normally so it clones fine
+	if err := os.MkdirAll(filepath.Join(dstWT, "app-a"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// app-b: place a regular file named "app-b" so MkdirAll(dstWT/app-b) fails
+	// inside CloneDir, causing the clone to fail and be collected in errs.
+	if err := os.WriteFile(filepath.Join(dstWT, "app-b"), []byte("block"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mod := Module{Dir: DirNodeModules, Recursive: true}
+	err := CloneModule(srcWT, dstWT, mod)
+
+	// app-a should have been cloned successfully despite app-b failing
+	assertFileContent(t, filepath.Join(dstWT, "app-a", DirNodeModules, "pkg.json"), "app-a")
+
+	// Error must be returned and mention the failed path
+	if err == nil {
+		t.Fatal("expected aggregated error for partial clone failure")
+	}
+	if !strings.Contains(err.Error(), "app-b") {
+		t.Errorf("error = %q, want it to mention 'app-b'", err.Error())
+	}
 }

--- a/internal/gh/pr_meta.go
+++ b/internal/gh/pr_meta.go
@@ -14,6 +14,10 @@ import (
 // safeNameRe matches strings safe to embed in git remote names and URLs.
 var safeNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
+// branchNameRe matches valid branch names. Allows slashes for namespaced refs
+// (e.g. feature/foo, dependabot/go_modules/x) but excludes shell-special chars.
+var branchNameRe = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
+
 const ghShapeHint = "gh CLI returned an unexpected response shape — update gh: gh --version"
 
 // PRMeta holds the metadata needed to check out a PR's head branch.
@@ -55,6 +59,9 @@ func FetchPRMeta(ctx context.Context, r Runner, num int) (PRMeta, error) {
 	if resp.HeadRefName == "" {
 		return PRMeta{}, errhint.WithFix(fmt.Errorf("PR #%d: missing headRefName in response", num), ghShapeHint)
 	}
+	if err := validateBranchName(num, resp.HeadRefName); err != nil {
+		return PRMeta{}, err
+	}
 	owner := resp.HeadRepositoryOwner.Login
 	repoName := resp.HeadRepository.Name
 	if owner == "" {
@@ -77,6 +84,22 @@ func FetchPRMeta(ctx context.Context, r Runner, num int) (PRMeta, error) {
 		HeadRepoName:      repoName,
 		IsCrossRepository: resp.IsCrossRepository,
 	}, nil
+}
+
+// validateBranchName rejects headRefName values that could inject options or
+// traverse paths when used in git commands.
+func validateBranchName(num int, name string) error {
+	switch {
+	case strings.HasPrefix(name, "-"):
+		return errhint.WithFix(fmt.Errorf("PR #%d: unsafe headRefName %q (leading dash)", num, name), ghShapeHint)
+	case strings.Contains(name, ".."):
+		return errhint.WithFix(fmt.Errorf("PR #%d: unsafe headRefName %q (contains ..)", num, name), ghShapeHint)
+	case strings.HasPrefix(name, "/"):
+		return errhint.WithFix(fmt.Errorf("PR #%d: unsafe headRefName %q (leading slash)", num, name), ghShapeHint)
+	case !branchNameRe.MatchString(name):
+		return errhint.WithFix(fmt.Errorf("PR #%d: unsafe headRefName %q", num, name), ghShapeHint)
+	}
+	return nil
 }
 
 func classifyFetchPRErr(err error) string {

--- a/internal/gh/pr_meta_test.go
+++ b/internal/gh/pr_meta_test.go
@@ -218,3 +218,56 @@ func TestFetchPRMetaArgsIncludeNumber(t *testing.T) {
 		t.Errorf("expected args to include 'view 42', got %v", capturedArgs)
 	}
 }
+
+func TestFetchPRMetaHeadRefNameValidation(t *testing.T) {
+	makeJSON := func(ref string) string {
+		return `{"headRefName":"` + ref + `","headRepository":{"name":"rimba"},"headRepositoryOwner":{"login":"alice"}}`
+	}
+
+	valid := []string{
+		"feature/foo",
+		"dependabot/go_modules/x",
+		"release-1.2",
+		"fix-login-redirect",
+		"main",
+	}
+	for _, ref := range valid {
+		t.Run("accept "+ref, func(t *testing.T) {
+			r := &mockRunner{
+				run: func(_ context.Context, _ ...string) ([]byte, error) {
+					return []byte(makeJSON(ref)), nil
+				},
+			}
+			_, err := FetchPRMeta(context.Background(), r, 1)
+			if err != nil {
+				t.Errorf("expected valid branch %q to be accepted, got error: %v", ref, err)
+			}
+		})
+	}
+
+	invalid := []struct {
+		ref     string
+		wantErr string
+	}{
+		{"-foo", "leading dash"},
+		{"../etc/passwd", "contains .."},
+		{"/abs/path", "leading slash"},
+		{"a;b", "unsafe headRefName"},
+		{"a b", "unsafe headRefName"},
+	}
+	for _, tt := range invalid {
+		t.Run("reject "+tt.ref, func(t *testing.T) {
+			r := &mockRunner{
+				run: func(_ context.Context, _ ...string) ([]byte, error) {
+					return []byte(makeJSON(tt.ref)), nil
+				},
+			}
+			_, err := FetchPRMeta(context.Background(), r, 1)
+			if err == nil {
+				t.Fatalf("expected error for branch %q, got nil", tt.ref)
+			}
+			assertContains(t, err, tt.wantErr)
+			assertContains(t, err, "To fix:")
+		})
+	}
+}

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -2,6 +2,7 @@ package git_test
 
 import (
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -317,5 +318,23 @@ func TestCheckoutError(t *testing.T) {
 
 	if err := git.Checkout(r, repo, "nonexistent-branch"); err == nil {
 		t.Error("expected error for nonexistent branch")
+	}
+}
+
+func TestCurrentBranchDetachedHead(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	// Detach HEAD by checking out the current commit SHA directly.
+	sha := testutil.GitCmd(t, repo, "rev-parse", "HEAD")
+	testutil.GitCmd(t, repo, "checkout", "--detach", strings.TrimSpace(sha))
+
+	_, err := git.CurrentBranch(r, repo)
+	if err == nil {
+		t.Fatal("expected error for detached HEAD")
 	}
 }

--- a/internal/operations/clean_test.go
+++ b/internal/operations/clean_test.go
@@ -364,3 +364,20 @@ func TestFindStaleCandidatesLastCommitError(t *testing.T) {
 		t.Errorf("expected 1 warning, got %d", len(result.Warnings))
 	}
 }
+
+func TestFindMergedCandidatesListWorktreesError(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitCmdBranch {
+				return "", nil // MergedBranches succeeds (empty list)
+			}
+			return "", errors.New("worktree list failed")
+		},
+		runInDir: noopRunInDir,
+	}
+
+	_, err := FindMergedCandidates(r, "origin/main", branchMain)
+	if err == nil {
+		t.Fatal("expected error when ListWorktrees fails")
+	}
+}

--- a/internal/operations/merge_test.go
+++ b/internal/operations/merge_test.go
@@ -12,6 +12,7 @@ const (
 	gitCmdStatus       = "status"
 	gitCmdMerge        = "merge"
 	branchFeatureLogin = "feature/login"
+	statusDirtyOutput  = "M dirty.go"
 )
 
 func mergeWorktreeList() string {
@@ -171,7 +172,7 @@ func TestMergeWorktreeSourceDirty(t *testing.T) {
 		runInDir: func(dir string, args ...string) (string, error) {
 			if len(args) >= 1 && args[0] == gitCmdStatus {
 				if strings.Contains(dir, "login") {
-					return "M dirty.go", nil
+					return statusDirtyOutput, nil
 				}
 				return "", nil
 			}
@@ -201,7 +202,7 @@ func TestMergeWorktreeTargetDirty(t *testing.T) {
 		runInDir: func(dir string, args ...string) (string, error) {
 			if len(args) >= 1 && args[0] == gitCmdStatus {
 				if dir == "/repo" {
-					return "M dirty.go", nil
+					return statusDirtyOutput, nil
 				}
 				return "", nil
 			}
@@ -408,5 +409,36 @@ func TestMergeWorktreeTargetDirtyCheckError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "target status failed") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestMergeWorktreeTargetDirtyToWorktree(t *testing.T) {
+	wt := mergeWorktreeList()
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return wt, nil
+		},
+		runInDir: func(dir string, args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitCmdStatus {
+				if dir == "/wt/feature-dashboard" {
+					return statusDirtyOutput, nil
+				}
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+
+	_, err := MergeWorktree(r, MergeParams{
+		SourceTask: "login",
+		IntoTask:   "dashboard",
+		RepoRoot:   "/repo",
+		MainBranch: branchMain,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error for dirty target worktree")
+	}
+	if !strings.Contains(err.Error(), "uncommitted changes") {
+		t.Errorf("expected 'uncommitted changes', got: %v", err)
 	}
 }

--- a/internal/operations/status_dashboard.go
+++ b/internal/operations/status_dashboard.go
@@ -46,7 +46,10 @@ type StatusDashboardResult struct {
 //
 // Spinner is a UI concern excluded from this layer; callers wrap the call
 // with spinner.Start/Stop as needed.
-func StatusDashboard(_ context.Context, gitR git.Runner, req StatusDashboardRequest) (StatusDashboardResult, error) {
+func StatusDashboard(ctx context.Context, gitR git.Runner, req StatusDashboardRequest) (StatusDashboardResult, error) {
+	if err := ctx.Err(); err != nil {
+		return StatusDashboardResult{}, err
+	}
 	mainBranch, err := ResolveMainBranch(gitR, "")
 	if err != nil {
 		return StatusDashboardResult{}, err

--- a/internal/operations/status_dashboard_test.go
+++ b/internal/operations/status_dashboard_test.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -266,6 +267,34 @@ func TestStatusDashboardLastCommitTimeErrorIsNonFatal(t *testing.T) {
 		if e.Entry.Branch == branchBugfixLogin && e.HasTime {
 			t.Errorf("bugfix/login: expected HasTime=false on commit-time error")
 		}
+	}
+}
+
+func TestStatusDashboardCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled
+
+	r := &mockRunner{
+		run:      func(...string) (string, error) { return "", nil },
+		runInDir: noopRunInDir,
+	}
+	_, err := StatusDashboard(ctx, r, StatusDashboardRequest{})
+	if err == nil {
+		t.Fatal("expected error for pre-cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestStatusDashboardResolveMainBranchError(t *testing.T) {
+	r := &mockRunner{
+		run:      func(...string) (string, error) { return "", errGitFailed },
+		runInDir: noopRunInDir,
+	}
+	_, err := StatusDashboard(context.Background(), r, StatusDashboardRequest{})
+	if err == nil {
+		t.Fatal("expected error when ResolveMainBranch fails")
 	}
 }
 

--- a/internal/updater/runner.go
+++ b/internal/updater/runner.go
@@ -54,8 +54,8 @@ func NewRunner(version string) *Runner {
 		Out:     os.Stdout,
 		Spinner: spinner.New(spinner.Options{Writer: io.Discard}),
 	}
-	r.check = func(_ context.Context) (*CheckResult, error) { return u.Check() }
-	r.download = func(_ context.Context, url string) (string, error) { return u.Download(url) }
+	r.check = u.Check
+	r.download = u.Download
 	r.prepareBinary = PrepareBinary
 	r.executable = os.Executable
 	r.evalSymlinks = filepath.EvalSymlinks

--- a/internal/updater/runner_test.go
+++ b/internal/updater/runner_test.go
@@ -363,6 +363,16 @@ func TestNewRunner(t *testing.T) {
 	}
 }
 
+func TestDefaultExecCommand(t *testing.T) {
+	out, err := defaultExecCommand(context.Background(), "echo", "rimba-test")
+	if err != nil {
+		t.Fatalf("defaultExecCommand: %v", err)
+	}
+	if !strings.Contains(string(out), "rimba-test") {
+		t.Errorf("output = %q, expected to contain 'rimba-test'", string(out))
+	}
+}
+
 func TestRunNilDefaults(t *testing.T) {
 	r, _ := newTestRunner(t)
 	r.Spinner = nil

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bufio"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 const (
@@ -21,6 +23,10 @@ const (
 	binaryName         = "rimba"
 	localBinSubdir     = ".local"
 )
+
+// maxBinarySize is the decompressed size limit for the extracted binary (100 MiB).
+// Tests may override this to exercise the size-limit path.
+var maxBinarySize int64 = 100 << 20
 
 // HTTPClient abstracts HTTP requests for testability.
 type HTTPClient interface {
@@ -62,7 +68,7 @@ func New(currentVersion string) *Updater {
 		CurrentVersion: currentVersion,
 		GOOS:           runtime.GOOS,
 		GOARCH:         runtime.GOARCH,
-		Client:         &http.Client{},
+		Client:         &http.Client{Timeout: 30 * time.Second},
 		APIEndpoint:    defaultAPIEndpoint,
 	}
 }
@@ -73,10 +79,10 @@ func IsDevVersion(v string) bool {
 }
 
 // Check queries the GitHub API for the latest release and compares versions.
-func (u *Updater) Check() (*CheckResult, error) {
+func (u *Updater) Check(ctx context.Context) (*CheckResult, error) {
 	url := u.APIEndpoint + repoPath
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
@@ -124,8 +130,8 @@ func (u *Updater) Check() (*CheckResult, error) {
 
 // Download fetches a tar.gz archive from the given URL and extracts the binary
 // to a temporary directory. Returns the path to the extracted binary.
-func (u *Updater) Download(url string) (string, error) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+func (u *Updater) Download(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", fmt.Errorf("creating download request: %w", err)
 	}
@@ -258,7 +264,8 @@ func EnsurePath(dir string) error {
 	if f, err := os.Open(rcFile); err == nil {
 		scanner := bufio.NewScanner(f)
 		for scanner.Scan() {
-			if strings.Contains(scanner.Text(), dir) && strings.Contains(scanner.Text(), "PATH") {
+			line := scanner.Text()
+			if !strings.HasPrefix(strings.TrimSpace(line), "#") && strings.Contains(line, dir) && strings.Contains(line, "PATH") {
 				_ = f.Close()
 				return nil // already configured
 			}
@@ -302,6 +309,9 @@ func extractBinary(r io.Reader, dstDir string) (string, error) {
 			return "", fmt.Errorf("reading archive: %w", err)
 		}
 
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
 		if hdr.Name == binaryName {
 			return writeBinary(filepath.Join(dstDir, binaryName), tr)
 		}
@@ -311,6 +321,7 @@ func extractBinary(r io.Reader, dstDir string) (string, error) {
 }
 
 // writeBinary writes the tar entry contents to dst with executable permissions.
+// It enforces maxBinarySize to guard against zip-bomb payloads.
 func writeBinary(dst string, r io.Reader) (_ string, retErr error) {
 	f, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0755) //nolint:gosec // executable binary requires 0755
 	if err != nil {
@@ -322,8 +333,13 @@ func writeBinary(dst string, r io.Reader) (_ string, retErr error) {
 		}
 	}()
 
-	if _, err := io.Copy(f, r); err != nil {
+	lr := io.LimitReader(r, maxBinarySize+1)
+	n, err := io.Copy(f, lr)
+	if err != nil {
 		return "", fmt.Errorf("extracting binary: %w", err)
+	}
+	if n > maxBinarySize {
+		return "", fmt.Errorf("binary exceeds max allowed size of %d bytes", maxBinarySize)
 	}
 
 	return dst, nil

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 const (
@@ -79,7 +81,7 @@ func TestCheckUpToDate(t *testing.T) {
 	srv := serveJSON(t, `{"tag_name":"`+testVersion+`","assets":[]}`)
 	u := newTestUpdater(srv)
 
-	result, err := u.Check()
+	result, err := u.Check(context.Background())
 	requireNoError(t, err)
 	if !result.UpToDate {
 		t.Errorf("expected up to date, got not up to date")
@@ -98,7 +100,7 @@ func TestCheckNewVersionAvailable(t *testing.T) {
 	}`)
 	u := newTestUpdater(srv)
 
-	result, err := u.Check()
+	result, err := u.Check(context.Background())
 	requireNoError(t, err)
 	if result.UpToDate {
 		t.Errorf("expected not up to date")
@@ -119,7 +121,7 @@ func TestCheckNoMatchingAsset(t *testing.T) {
 	}`)
 	u := newTestUpdater(srv)
 
-	_, err := u.Check()
+	_, err := u.Check(context.Background())
 	if err == nil {
 		t.Fatal("expected error for missing asset")
 	}
@@ -137,7 +139,7 @@ func TestCheckAPIError(t *testing.T) {
 	t.Cleanup(srv.Close)
 	u := newTestUpdater(srv)
 
-	_, err := u.Check()
+	_, err := u.Check(context.Background())
 	if err == nil {
 		t.Fatal("expected error for API failure")
 	}
@@ -175,7 +177,7 @@ func TestDownloadValidArchive(t *testing.T) {
 
 	u := newTestUpdater(srv)
 
-	binaryPath, err := u.Download(srv.URL + "/rimba_1.0.0_linux_amd64.tar.gz")
+	binaryPath, err := u.Download(context.Background(), srv.URL+"/rimba_1.0.0_linux_amd64.tar.gz")
 	requireNoError(t, err)
 	t.Cleanup(func() { CleanupTempDir(binaryPath) })
 
@@ -264,6 +266,84 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNewClientHasTimeout(t *testing.T) {
+	u := New(testVersion)
+	hc, ok := u.Client.(*http.Client)
+	if !ok {
+		t.Fatal("Client is not *http.Client")
+	}
+	if hc.Timeout != 30*time.Second {
+		t.Errorf("Client.Timeout = %v, want 30s", hc.Timeout)
+	}
+}
+
+// ctxCapturingClient records the context from the most recent request.
+type ctxCapturingClient struct {
+	captured context.Context
+	delegate HTTPClient
+}
+
+func (c *ctxCapturingClient) Do(req *http.Request) (*http.Response, error) {
+	c.captured = req.Context()
+	return c.delegate.Do(req)
+}
+
+// ctxMarkerKey is a package-level context key used to verify ctx propagation.
+type ctxMarkerKey struct{}
+
+func TestCheckContextPropagated(t *testing.T) {
+	srv := serveJSON(t, `{"tag_name":"`+testVersion+`","assets":[]}`)
+	capturing := &ctxCapturingClient{delegate: srv.Client()}
+	u := &Updater{
+		CurrentVersion: testVersion,
+		GOOS:           testOS,
+		GOARCH:         testArch,
+		Client:         capturing,
+		APIEndpoint:    srv.URL,
+	}
+
+	ctx := context.WithValue(context.Background(), ctxMarkerKey{}, "marker")
+	_, err := u.Check(ctx)
+	requireNoError(t, err)
+
+	if capturing.captured == nil || capturing.captured.Value(ctxMarkerKey{}) != "marker" {
+		t.Error("Check did not propagate the provided context to the HTTP request")
+	}
+}
+
+func TestCheckCancelledContext(t *testing.T) {
+	srv := serveJSON(t, `{"tag_name":"`+testVersion+`","assets":[]}`)
+	u := newTestUpdater(srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := u.Check(ctx)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}
+
+func TestDownloadMkdirTempError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("data"))
+	}))
+	t.Cleanup(srv.Close)
+
+	// Point TMPDIR at a non-existent path so os.MkdirTemp fails.
+	t.Setenv("TMPDIR", "/nonexistent/tmp/rimba-test")
+
+	u := newTestUpdater(srv)
+	_, err := u.Download(context.Background(), srv.URL+"/archive.tar.gz")
+	if err == nil {
+		t.Fatal("expected error when MkdirTemp fails")
+	}
+	if !strings.Contains(err.Error(), "creating temp dir") {
+		t.Errorf("error = %q, want to contain 'creating temp dir'", err.Error())
+	}
+}
+
 func TestDownloadHTTPError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
@@ -271,7 +351,7 @@ func TestDownloadHTTPError(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	u := newTestUpdater(srv)
-	_, err := u.Download(srv.URL + "/missing.tar.gz")
+	_, err := u.Download(context.Background(), srv.URL+"/missing.tar.gz")
 	if err == nil {
 		t.Fatal("expected error for 404 response")
 	}
@@ -285,7 +365,7 @@ func TestDownloadInvalidArchive(t *testing.T) {
 	srv := serveOctetStream(t, []byte("not a valid gzip archive"))
 
 	u := newTestUpdater(srv)
-	_, err := u.Download(srv.URL + "/invalid.tar.gz")
+	_, err := u.Download(context.Background(), srv.URL+"/invalid.tar.gz")
 	if err == nil {
 		t.Fatal("expected error for invalid archive")
 	}
@@ -296,7 +376,7 @@ func TestDownloadMissingBinary(t *testing.T) {
 	srv := serveOctetStream(t, archiveData)
 
 	u := newTestUpdater(srv)
-	_, err := u.Download(srv.URL + "/archive.tar.gz")
+	_, err := u.Download(context.Background(), srv.URL+"/archive.tar.gz")
 	if err == nil {
 		t.Fatal("expected error for archive without rimba binary")
 	}
@@ -373,7 +453,7 @@ func TestCheckNetworkError(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	u := newTestUpdater(srv)
-	_, err := u.Check()
+	_, err := u.Check(context.Background())
 	if err == nil {
 		t.Fatal("expected error for network failure")
 	}
@@ -388,7 +468,7 @@ func TestCheckRequestError(t *testing.T) {
 		APIEndpoint:    "\x7f://invalid", // control char causes NewRequest to fail
 	}
 
-	_, err := u.Check()
+	_, err := u.Check(context.Background())
 	if err == nil {
 		t.Fatal("expected error for invalid URL")
 	}
@@ -405,7 +485,7 @@ func TestDownloadRequestError(t *testing.T) {
 		Client:         http.DefaultClient,
 	}
 
-	_, err := u.Download("\x7f://invalid/archive.tar.gz")
+	_, err := u.Download(context.Background(), "\x7f://invalid/archive.tar.gz")
 	if err == nil {
 		t.Fatal("expected error for invalid download URL")
 	}
@@ -428,7 +508,7 @@ func TestDownloadCorruptTarArchive(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	u := newTestUpdater(srv)
-	_, err := u.Download(srv.URL + "/corrupt.tar.gz")
+	_, err := u.Download(context.Background(), srv.URL+"/corrupt.tar.gz")
 	if err == nil {
 		t.Fatal("expected error for corrupt tar archive")
 	}
@@ -453,7 +533,7 @@ func TestDownloadConnectionError(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	u := newTestUpdater(srv)
-	_, err := u.Download(srv.URL + "/archive.tar.gz")
+	_, err := u.Download(context.Background(), srv.URL+"/archive.tar.gz")
 	if err == nil {
 		t.Fatal("expected error for connection failure")
 	}
@@ -504,6 +584,74 @@ func TestWriteBinaryOpenError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "creating binary file") {
 		t.Errorf("error = %q, want to contain 'creating binary file'", err.Error())
+	}
+}
+
+// buildTestArchiveTypeflag creates a tar.gz archive with a single entry of the given typeflag.
+func buildTestArchiveTypeflag(t *testing.T, name, content string, typeflag byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	hdr := &tar.Header{
+		Typeflag: typeflag,
+		Name:     name,
+		Mode:     0755,
+		Size:     int64(len(content)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractBinarySkipsNonRegularFiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeflag byte
+	}{
+		{"dir typeflag", tar.TypeDir},
+		{"symlink typeflag", tar.TypeSymlink},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			archiveData := buildTestArchiveTypeflag(t, binaryName, "", tt.typeflag)
+			tmpDir := t.TempDir()
+			_, err := extractBinary(bytes.NewReader(archiveData), tmpDir)
+			if err == nil {
+				t.Fatal("expected error when rimba entry is not a regular file")
+			}
+			if !strings.Contains(err.Error(), "not found in archive") {
+				t.Errorf("error = %q, want 'not found in archive'", err.Error())
+			}
+		})
+	}
+}
+
+func TestWriteBinaryExceedsMaxSize(t *testing.T) {
+	orig := maxBinarySize
+	maxBinarySize = 5
+	t.Cleanup(func() { maxBinarySize = orig })
+
+	tmpDir := t.TempDir()
+	dst := filepath.Join(tmpDir, "binary")
+
+	r := strings.NewReader("this is more than 5 bytes of content")
+	_, err := writeBinary(dst, r)
+	if err == nil {
+		t.Fatal("expected size-limit error for oversized binary")
+	}
+	if !strings.Contains(err.Error(), "exceeds max") {
+		t.Errorf("error = %q, want to contain 'exceeds max'", err.Error())
 	}
 }
 
@@ -622,7 +770,7 @@ func TestCheckInvalidJSON(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	u := newTestUpdater(srv)
-	_, err := u.Check()
+	_, err := u.Check(context.Background())
 	if err == nil {
 		t.Fatal("expected error for invalid JSON response")
 	}
@@ -810,6 +958,35 @@ func TestEnsurePathIdempotent(t *testing.T) {
 	// Should not have added a duplicate
 	if strings.Count(string(content), dir) != 1 {
 		t.Errorf("expected exactly one PATH entry, got:\n%s", content)
+	}
+}
+
+func TestEnsurePathSkipsCommentLines(t *testing.T) {
+	tmpDir := t.TempDir()
+	rcFile := filepath.Join(tmpDir, testRcZshrc)
+
+	dir := filepath.Join(tmpDir, localBinSubdir, "bin")
+	// A comment that mentions both the dir and "PATH" must not be treated as
+	// an existing export — EnsurePath should still append the real export line.
+	commentOnly := fmt.Sprintf("# %s is not yet in PATH\n", dir)
+	if err := os.WriteFile(rcFile, []byte(commentOnly), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SHELL", testShellZsh)
+	t.Setenv("HOME", tmpDir)
+
+	if err := EnsurePath(dir); err != nil {
+		t.Fatalf("EnsurePath: %v", err)
+	}
+
+	content, err := os.ReadFile(rcFile)
+	if err != nil {
+		t.Fatalf("reading rc file: %v", err)
+	}
+	exportLine := fmt.Sprintf(`export PATH="%s:$PATH"`, dir)
+	if !strings.Contains(string(content), exportLine) {
+		t.Errorf("rc file missing real export line; got:\n%s", content)
 	}
 }
 
@@ -1003,7 +1180,7 @@ func TestDownloadValidArchiveCleanup(t *testing.T) {
 
 	u := newTestUpdater(srv)
 
-	binaryPath, err := u.Download(srv.URL + "/rimba_1.0.0_linux_amd64.tar.gz")
+	binaryPath, err := u.Download(context.Background(), srv.URL+"/rimba_1.0.0_linux_amd64.tar.gz")
 	requireNoError(t, err)
 
 	// Verify the binary exists


### PR DESCRIPTION
## Summary

- **Unit A** — HTTP client 30s timeout + context threading in `Updater.Check`/`Download`; cancellable downloads and rate-limit-aware error hints
- **Unit B** — tar zip-bomb guard in `extractBinary`: skip non-regular-file entries (`TypeReg` check) and cap decompressed output at 100 MiB via `io.LimitReader`
- **Unit C** — `EnsurePath` false-positive fix: skip comment lines (`# ...`) when scanning for existing PATH exports
- **Unit D** — `HeadRefName` (branch name) validation in `FetchPRMeta`: permissive regex (`^[a-zA-Z0-9._/-]+$`), rejects leading `-`/`..`/`/` to prevent option injection
- **Unit E** — Ctrl-C context propagation: `cmd/status.go` uses `cmd.Context()` (signal-aware) instead of `context.Background()`; `StatusDashboard` adds entry-guard `ctx.Err()` check
- **Unit F** — Clone error aggregation in `cloneRecursive`: collects partial failures via `errors.Join` instead of silently discarding them
- **Unit G** — `govulncheck` CI job (informational `|| true` until go toolchain is bumped past current stdlib CVEs — see TODO in ci.yml)

## Test Plan

- [x] Unit tests pass (`make test`) — 97.5% coverage (≥97% gate)
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2E tests pass (`make test-e2e`) — 276/276
- [x] `govulncheck ./...` run locally; findings are go1.26.0 stdlib CVEs fixed in go1.26.1 (CI uses `go-version: stable`)

### Type-tailored checks ([chore]/security)

- [ ] `rimba update` still completes a real self-update end-to-end
- [ ] `rimba status` respects Ctrl-C (sends SIGINT mid-run, confirms clean exit)
- [ ] `rimba add <pr>` with a branch name containing `/` (e.g. `dependabot/...`) is accepted
- [ ] `rimba add <pr>` with a branch name starting with `-` or containing `..` is rejected

## Issue

Closes #206
