### PR TITLE
[fix] promote flow: surface stash apply/drop errors instead of masking them

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -698,7 +698,7 @@ func conflictRunInDirStash(stashDropped *bool, args []string) (string, error, bo
 	case len(args) >= 2 && args[0] == cmdSwitch:
 		return "", nil, true
 	case len(args) >= 3 && args[0] == cmdStash && args[1] == gitSubcmdStashAppl:
-		return "", errGitFailed, true // simulate conflict
+		return "", errors.New("CONFLICT: merge conflict in file.txt"), true
 	case len(args) >= 3 && args[0] == cmdStash && args[1] == gitSubcmdStashDrop:
 		*stashDropped = true
 		return "", nil, true

--- a/internal/operations/add_branch.go
+++ b/internal/operations/add_branch.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
@@ -121,15 +122,29 @@ func restoreStash(r git.Runner, dir, sha string) error {
 	return nil
 }
 
-// applyStashToWorktree applies a stash to the worktree. On conflict, the stash entry
-// is preserved so the user can resolve manually.
+// applyStashToWorktree applies a stash to the worktree and drops it on success.
+// Any failure preserves the stash so the user can recover: real conflicts get a
+// resolve-then-cleanup hint, other apply errors surface their true cause, and a
+// failed drop after a clean apply is reported rather than swallowed.
 func applyStashToWorktree(r git.Runner, wtPath, sha string) error {
 	if err := git.StashApply(r, wtPath, sha); err != nil {
-		return errhint.WithFix(
-			errors.New("stash apply had conflicts"),
-			fmt.Sprintf("resolve conflicts in %s (stash SHA: %s), then: git stash list (find 'rimba: promote ...' entry) && git stash drop stash@{N}", wtPath, sha),
-		)
+		if stashApplyConflicted(err) {
+			return errhint.WithFix(
+				errors.New("stash apply had conflicts"),
+				fmt.Sprintf("resolve conflicts in %s (stash SHA: %s), then: git stash list (find 'rimba: promote ...' entry) && git stash drop stash@{N}", wtPath, sha),
+			)
+		}
+		return fmt.Errorf("stash apply failed; your changes are preserved in stash %s — recover them with: cd %s && git stash list (look for 'rimba: promote ...') then git stash apply stash@{N}: %w", sha, wtPath, err)
 	}
-	_ = git.StashDrop(r, wtPath, sha)
+	if dropErr := git.StashDrop(r, wtPath, sha); dropErr != nil {
+		return fmt.Errorf("stash applied but could not drop entry %s (clean up manually: git stash list, then git stash drop stash@{N}): %w", sha, dropErr)
+	}
 	return nil
+}
+
+// stashApplyConflicted reports whether a failed git stash apply was due to merge
+// conflicts. git prints CONFLICT markers and StashApply wraps that output, so the
+// marker surfaces in the error text (see git.StashApply / git.RunInDir).
+func stashApplyConflicted(err error) bool {
+	return strings.Contains(err.Error(), "CONFLICT")
 }

--- a/internal/operations/add_branch_test.go
+++ b/internal/operations/add_branch_test.go
@@ -393,17 +393,25 @@ func conflictRunFn(porcelain, wtDir string) func(args ...string) (string, error)
 	}
 }
 
-// stashOutcomeDispatch handles stash-operation args for promote mocks, injecting
-// the given apply/drop errors. Extracted so its cyclomatic complexity does not
-// count toward the closure in stashOutcomeRunInDirFn.
-func stashOutcomeDispatch(stashDropped *bool, applyErr, dropErr error, args []string) (string, error, bool) {
+// stashOutcomeDispatchA handles push / rev-parse / switch for promote mocks.
+func stashOutcomeDispatchA(args []string) (string, bool) {
 	switch {
 	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdPush:
-		return "", nil, true
+		return "", true
 	case len(args) >= 2 && args[0] == cmdRevParse && args[1] == "stash@{0}":
-		return stashSHATest, nil, true
+		return stashSHATest, true
 	case len(args) >= 2 && args[0] == gitCmdSwitch:
-		return "", nil, true
+		return "", true
+	}
+	return "", false
+}
+
+// stashOutcomeDispatchB handles list / apply / drop for promote mocks, injecting
+// the given apply/drop errors. Split from stashOutcomeDispatchA to stay under gocyclo=15.
+func stashOutcomeDispatchB(stashDropped *bool, applyErr, dropErr error, args []string) (string, error, bool) {
+	switch {
+	case len(args) >= 3 && args[0] == gitCmdStash && args[1] == gitSubcmdList:
+		return stashListLine, nil, true
 	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdApply:
 		return "", applyErr, true
 	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdDrop:
@@ -411,6 +419,15 @@ func stashOutcomeDispatch(stashDropped *bool, applyErr, dropErr error, args []st
 		return "", dropErr, true
 	}
 	return "", nil, false
+}
+
+// stashOutcomeDispatch drives promote mocks to the apply/drop step, injecting the
+// given apply/drop errors so tests can exercise each applyStashToWorktree branch.
+func stashOutcomeDispatch(stashDropped *bool, applyErr, dropErr error, args []string) (string, error, bool) {
+	if out, ok := stashOutcomeDispatchA(args); ok {
+		return out, nil, true
+	}
+	return stashOutcomeDispatchB(stashDropped, applyErr, dropErr, args)
 }
 
 // stashOutcomeRunInDirFn drives promote to the apply/drop step, injecting the given
@@ -501,5 +518,8 @@ func TestPromoteBranchStashDropFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), stashSHATest) {
 		t.Errorf("error %q should contain the stash SHA for recovery", err)
+	}
+	if !stashDropped {
+		t.Error("drop should have been attempted (stashDropped should be true)")
 	}
 }

--- a/internal/operations/add_branch_test.go
+++ b/internal/operations/add_branch_test.go
@@ -393,8 +393,10 @@ func conflictRunFn(porcelain, wtDir string) func(args ...string) (string, error)
 	}
 }
 
-// conflictStash handles stash ops with apply-conflict simulation; returns (out, err, matched).
-func conflictStash(stashDropped *bool, args []string) (string, error, bool) {
+// stashOutcomeDispatch handles stash-operation args for promote mocks, injecting
+// the given apply/drop errors. Extracted so its cyclomatic complexity does not
+// count toward the closure in stashOutcomeRunInDirFn.
+func stashOutcomeDispatch(stashDropped *bool, applyErr, dropErr error, args []string) (string, error, bool) {
 	switch {
 	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdPush:
 		return "", nil, true
@@ -403,21 +405,22 @@ func conflictStash(stashDropped *bool, args []string) (string, error, bool) {
 	case len(args) >= 2 && args[0] == gitCmdSwitch:
 		return "", nil, true
 	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdApply:
-		return "", errors.New("CONFLICT: merge conflict"), true
+		return "", applyErr, true
 	case len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdDrop:
 		*stashDropped = true
-		return "", nil, true
+		return "", dropErr, true
 	}
 	return "", nil, false
 }
 
-// conflictRunInDirFn is the RunInDir closure for TestPromoteBranchStashApplyConflict.
-func conflictRunInDirFn(stashDropped *bool) func(dir string, args ...string) (string, error) {
+// stashOutcomeRunInDirFn drives promote to the apply/drop step, injecting the given
+// apply/drop errors so tests can exercise each applyStashToWorktree branch.
+func stashOutcomeRunInDirFn(stashDropped *bool, applyErr, dropErr error) func(string, ...string) (string, error) {
 	return func(_ string, args ...string) (string, error) {
 		if out, ok := promoteRunInDirIdentity(true, args); ok {
 			return out, nil
 		}
-		out, err, _ := conflictStash(stashDropped, args)
+		out, err, _ := stashOutcomeDispatch(stashDropped, applyErr, dropErr, args)
 		return out, err
 	}
 }
@@ -430,7 +433,7 @@ func TestPromoteBranchStashApplyConflict(t *testing.T) {
 
 	r := &mockRunner{
 		run:      conflictRunFn(porcelain, wtDir),
-		runInDir: conflictRunInDirFn(&stashDropped),
+		runInDir: stashOutcomeRunInDirFn(&stashDropped, errors.New("CONFLICT: merge conflict"), nil),
 	}
 
 	_, err := PromoteBranch(context.Background(), wtDir, r, repoRoot, branchFeatureX)
@@ -445,5 +448,58 @@ func TestPromoteBranchStashApplyConflict(t *testing.T) {
 	}
 	if stashDropped {
 		t.Error("stash should NOT be dropped on conflict")
+	}
+}
+
+func TestPromoteBranchStashApplyNonConflictFails(t *testing.T) {
+	repoRoot := t.TempDir()
+	wtDir := t.TempDir()
+	porcelain := "worktree " + repoRoot + "\nHEAD abc\nbranch refs/heads/main\n"
+	stashDropped := false
+
+	applyErr := errors.New("error: Your local changes would be overwritten by merge")
+	r := &mockRunner{
+		run:      conflictRunFn(porcelain, wtDir),
+		runInDir: stashOutcomeRunInDirFn(&stashDropped, applyErr, nil),
+	}
+
+	_, err := PromoteBranch(context.Background(), wtDir, r, repoRoot, branchFeatureX)
+	if err == nil {
+		t.Fatal("expected error from non-conflict stash apply failure")
+	}
+	if !strings.Contains(err.Error(), "preserved") {
+		t.Errorf("error %q should say stash is 'preserved'", err)
+	}
+	if !strings.Contains(err.Error(), stashSHATest) {
+		t.Errorf("error %q should contain the stash SHA for recovery", err)
+	}
+	if strings.Contains(err.Error(), "had conflicts") {
+		t.Errorf("error %q should NOT mention 'had conflicts' for a non-conflict failure", err)
+	}
+	if stashDropped {
+		t.Error("stash should NOT be dropped on apply failure")
+	}
+}
+
+func TestPromoteBranchStashDropFails(t *testing.T) {
+	repoRoot := t.TempDir()
+	wtDir := t.TempDir()
+	porcelain := "worktree " + repoRoot + "\nHEAD abc\nbranch refs/heads/main\n"
+	stashDropped := false
+
+	r := &mockRunner{
+		run:      conflictRunFn(porcelain, wtDir),
+		runInDir: stashOutcomeRunInDirFn(&stashDropped, nil, errGitFailed),
+	}
+
+	_, err := PromoteBranch(context.Background(), wtDir, r, repoRoot, branchFeatureX)
+	if err == nil {
+		t.Fatal("expected error from stash drop failure")
+	}
+	if !strings.Contains(err.Error(), "could not drop") {
+		t.Errorf("error %q should mention 'could not drop'", err)
+	}
+	if !strings.Contains(err.Error(), stashSHATest) {
+		t.Errorf("error %q should contain the stash SHA for recovery", err)
 	}
 }


### PR DESCRIPTION
## Summary
- `applyStashToWorktree` previously labelled every `StashApply` failure as a conflict, masking the real cause (e.g. "local changes would be overwritten")
- Drop errors after a successful apply were silently discarded with `_ = git.StashDrop(...)`, leaving orphaned stash entries with no warning
- Fix: distinguish real `CONFLICT` failures (conflict-specific hint + SHA) from other apply failures (surface true cause, preserve stash), and surface drop errors rather than swallowing them

## Test Plan
- [x] Unit tests pass (`make test`) — including 2 new tests: `TestPromoteBranchStashApplyNonConflictFails`, `TestPromoteBranchStashDropFails`
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2E tests pass (`make test-e2e`)
- [x] Coverage ≥ 97% (`make test-coverage`) — 97.5%

## Issue

Closes #207