### PR TITLE
[fix] unify partial-failure recovery and auto-abort failed merges

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -304,7 +304,7 @@ func printCleanedItems(cmd *cobra.Command, items []operations.CleanedItem) {
 		if item.BranchDeleted {
 			fmt.Fprintf(cmd.OutOrStdout(), "Deleted branch: %s\n", item.Branch)
 		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "Worktree removed but failed to delete branch\nTo delete manually: git branch -D %s\n", item.Branch)
+			fmt.Fprintln(cmd.OutOrStdout(), item.Error)
 		}
 	}
 }

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/spf13/cobra"
@@ -633,7 +634,13 @@ func TestPrintCleanedItemsAllBranches(t *testing.T) {
 		// Success: worktree removed + branch deleted
 		{Branch: "feature/ok", Path: "/wt/ok", WorktreeRemoved: true, BranchDeleted: true},
 		// Partial: worktree removed but branch delete failed
-		{Branch: "feature/partial", Path: "/wt/partial", WorktreeRemoved: true, BranchDeleted: false},
+		{
+			Branch: "feature/partial", Path: "/wt/partial", WorktreeRemoved: true, BranchDeleted: false,
+			Error: errhint.WithFix(
+				errors.New("worktree removed but failed to delete branch: branch in use"),
+				"delete manually: git branch -D feature/partial",
+			),
+		},
 		// Failure: worktree removal failed
 		{Branch: "feature/fail", Path: "/wt/fail", WorktreeRemoved: false, BranchDeleted: false},
 	}

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -102,7 +102,7 @@ var mergeCmd = &cobra.Command{
 			fmt.Fprintf(cmd.OutOrStdout(), "Deleted branch: %s\n", result.SourceBranch)
 		} else if result.WorktreeRemoved {
 			fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree: %s\n", result.SourcePath)
-			fmt.Fprintf(cmd.OutOrStdout(), "Worktree removed but failed to delete branch: %v\nTo delete manually: git branch -D %s\n", result.RemoveError, result.SourceBranch)
+			fmt.Fprintln(cmd.OutOrStdout(), result.RemoveError)
 		} else if result.RemoveError != nil {
 			fmt.Fprintf(cmd.OutOrStdout(), "Merged successfully but failed to remove worktree: %v\nTo remove manually: rimba remove %s\n", result.RemoveError, sourceTask)
 		}

--- a/internal/git/merge.go
+++ b/internal/git/merge.go
@@ -10,3 +10,15 @@ func Merge(r Runner, dir, branch string, noFF bool) error {
 	_, err := r.RunInDir(dir, args...)
 	return err
 }
+
+// MergeInProgress reports whether a merge is in progress in dir (MERGE_HEAD exists).
+func MergeInProgress(r Runner, dir string) bool {
+	_, err := r.RunInDir(dir, "rev-parse", "--verify", "-q", "MERGE_HEAD")
+	return err == nil
+}
+
+// MergeAbort runs `git merge --abort` in dir.
+func MergeAbort(r Runner, dir string) error {
+	_, err := r.RunInDir(dir, "merge", "--abort")
+	return err
+}

--- a/internal/git/merge.go
+++ b/internal/git/merge.go
@@ -1,5 +1,10 @@
 package git
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Merge runs `git merge [--no-ff] <branch>` inside the given directory.
 func Merge(r Runner, dir, branch string, noFF bool) error {
 	args := []string{"merge"}
@@ -12,9 +17,23 @@ func Merge(r Runner, dir, branch string, noFF bool) error {
 }
 
 // MergeInProgress reports whether a merge is in progress in dir (MERGE_HEAD exists).
-func MergeInProgress(r Runner, dir string) bool {
+// Returns (false, nil) when no merge is in progress, (true, nil) when one is,
+// and (false, err) when the check itself fails (infrastructure error).
+func MergeInProgress(r Runner, dir string) (bool, error) {
 	_, err := r.RunInDir(dir, "rev-parse", "--verify", "-q", "MERGE_HEAD")
-	return err == nil
+	if err == nil {
+		return true, nil
+	}
+	// rev-parse exits non-zero when MERGE_HEAD doesn't exist; that is not an error.
+	// Distinguish "ref not found" (exit 128 / message mentions MERGE_HEAD or missing-ref
+	// text) from genuine infrastructure failures by checking the error text.
+	s := err.Error()
+	if strings.Contains(s, "MERGE_HEAD") ||
+		strings.Contains(s, "unknown revision") ||
+		strings.Contains(s, "Needed a single revision") {
+		return false, nil
+	}
+	return false, fmt.Errorf("checking merge state: %w", err)
 }
 
 // MergeAbort runs `git merge --abort` in dir.

--- a/internal/git/merge_test.go
+++ b/internal/git/merge_test.go
@@ -87,7 +87,11 @@ func TestMergeInProgress(t *testing.T) {
 	r := &git.ExecRunner{Dir: repo}
 
 	// Clean repo: no merge in progress
-	if git.MergeInProgress(r, repo) {
+	inProgress, err := git.MergeInProgress(r, repo)
+	if err != nil {
+		t.Fatalf("MergeInProgress on clean repo: %v", err)
+	}
+	if inProgress {
 		t.Error("expected MergeInProgress=false on clean repo")
 	}
 
@@ -111,7 +115,11 @@ func TestMergeInProgress(t *testing.T) {
 	}
 
 	// Now a merge should be in progress.
-	if !git.MergeInProgress(r, repo) {
+	inProgress, err = git.MergeInProgress(r, repo)
+	if err != nil {
+		t.Fatalf("MergeInProgress after conflict: %v", err)
+	}
+	if !inProgress {
 		t.Error("expected MergeInProgress=true after conflicting merge")
 	}
 }
@@ -154,7 +162,11 @@ func TestMergeAbort(t *testing.T) {
 	if dirty {
 		t.Error("expected repo to be clean after MergeAbort")
 	}
-	if git.MergeInProgress(r, repo) {
+	inProgress, err := git.MergeInProgress(r, repo)
+	if err != nil {
+		t.Fatalf("MergeInProgress after abort: %v", err)
+	}
+	if inProgress {
 		t.Error("expected MergeInProgress=false after MergeAbort")
 	}
 }

--- a/internal/git/merge_test.go
+++ b/internal/git/merge_test.go
@@ -77,3 +77,84 @@ func TestMergeError(t *testing.T) {
 		t.Error("expected error merging nonexistent branch")
 	}
 }
+
+func TestMergeInProgress(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	// Clean repo: no merge in progress
+	if git.MergeInProgress(r, repo) {
+		t.Error("expected MergeInProgress=false on clean repo")
+	}
+
+	// Set up a conflicting merge: two branches edit the same file differently.
+	wtPath := filepath.Join(filepath.Dir(repo), "wt-merge-in-progress")
+	if err := git.AddWorktree(r, wtPath, "feat/conflict-source", "main"); err != nil {
+		t.Fatalf(fatalAddWorktree, err)
+	}
+	testutil.CreateFile(t, wtPath, "conflict.txt", "source version")
+	testutil.GitCmd(t, wtPath, "add", ".")
+	testutil.GitCmd(t, wtPath, "commit", "-m", "source change")
+
+	// Also add the file on main with different content so it conflicts.
+	testutil.CreateFile(t, repo, "conflict.txt", "main version")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "main change")
+
+	// Attempt the conflicting merge — it should fail.
+	if err := git.Merge(r, repo, "feat/conflict-source", false); err == nil {
+		t.Fatal("expected conflict error from Merge")
+	}
+
+	// Now a merge should be in progress.
+	if !git.MergeInProgress(r, repo) {
+		t.Error("expected MergeInProgress=true after conflicting merge")
+	}
+}
+
+func TestMergeAbort(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipIntegration)
+	}
+
+	repo := testutil.NewTestRepo(t)
+	r := &git.ExecRunner{Dir: repo}
+
+	// Set up a conflicting merge (same steps as TestMergeInProgress).
+	wtPath := filepath.Join(filepath.Dir(repo), "wt-merge-abort")
+	if err := git.AddWorktree(r, wtPath, "feat/abort-source", "main"); err != nil {
+		t.Fatalf(fatalAddWorktree, err)
+	}
+	testutil.CreateFile(t, wtPath, "conflict.txt", "source version")
+	testutil.GitCmd(t, wtPath, "add", ".")
+	testutil.GitCmd(t, wtPath, "commit", "-m", "source change")
+
+	testutil.CreateFile(t, repo, "conflict.txt", "main version")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "main change")
+
+	if err := git.Merge(r, repo, "feat/abort-source", false); err == nil {
+		t.Fatal("expected conflict error from Merge")
+	}
+
+	// Abort the merge.
+	if err := git.MergeAbort(r, repo); err != nil {
+		t.Fatalf("MergeAbort: %v", err)
+	}
+
+	// Repo should be clean and no merge in progress.
+	dirty, err := git.IsDirty(r, repo)
+	if err != nil {
+		t.Fatalf("IsDirty after abort: %v", err)
+	}
+	if dirty {
+		t.Error("expected repo to be clean after MergeAbort")
+	}
+	if git.MergeInProgress(r, repo) {
+		t.Error("expected MergeInProgress=false after MergeAbort")
+	}
+}

--- a/internal/operations/list_worktrees_test.go
+++ b/internal/operations/list_worktrees_test.go
@@ -66,7 +66,7 @@ func (m *mockGHRunner) Run(_ context.Context, args ...string) ([]byte, error) {
 	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
 		return nil, m.authErr
 	}
-	if len(args) >= 2 && args[0] == "pr" && args[1] == "list" {
+	if len(args) >= 2 && args[0] == "pr" && args[1] == gitSubcmdList {
 		if m.prErr != nil {
 			return nil, m.prErr
 		}

--- a/internal/operations/merge.go
+++ b/internal/operations/merge.go
@@ -121,8 +121,18 @@ func MergeWorktree(r git.Runner, params MergeParams, onProgress progress.Func) (
 // abortFailedMerge attempts to roll back a failed merge in targetDir.
 // It checks MERGE_HEAD first so we only abort when a merge is actually in progress.
 // If the abort also fails, both errors are surfaced with a manual-cleanup hint.
+// If the MERGE_HEAD check itself fails (infrastructure error), a conservative
+// manual-cleanup hint is returned rather than assuming no merge is in progress.
 func abortFailedMerge(r git.Runner, targetDir, targetLabel, sourceBranch string, mergeErr error) error {
-	if git.MergeInProgress(r, targetDir) {
+	inProgress, checkErr := git.MergeInProgress(r, targetDir)
+	if checkErr != nil {
+		// Cannot determine merge state — conservative: tell user to clean up manually.
+		return errhint.WithFix(
+			fmt.Errorf("merge failed: %w", mergeErr),
+			"clean up manually: cd "+targetDir+" && git merge --abort",
+		)
+	}
+	if inProgress {
 		if abortErr := git.MergeAbort(r, targetDir); abortErr != nil {
 			return errhint.WithFix(
 				fmt.Errorf("merge failed and rollback failed: %w (rollback: %w)", mergeErr, abortErr),

--- a/internal/operations/merge.go
+++ b/internal/operations/merge.go
@@ -95,10 +95,7 @@ func MergeWorktree(r git.Runner, params MergeParams, onProgress progress.Func) (
 	if err := plan.Do(mergeDesc, func() error {
 		return git.Merge(r, targetDir, source.Branch, params.NoFF)
 	}); err != nil {
-		return result, errhint.WithFix(
-			fmt.Errorf("merge failed: %w", err),
-			fmt.Sprintf("resolve conflicts in %s, commit, then re-run rimba merge", targetDir),
-		)
+		return result, abortFailedMerge(r, targetDir, targetLabel, source.Branch, err)
 	}
 
 	// Auto-cleanup
@@ -119,6 +116,28 @@ func MergeWorktree(r git.Runner, params MergeParams, onProgress progress.Func) (
 	}
 
 	return result, nil
+}
+
+// abortFailedMerge attempts to roll back a failed merge in targetDir.
+// It checks MERGE_HEAD first so we only abort when a merge is actually in progress.
+// If the abort also fails, both errors are surfaced with a manual-cleanup hint.
+func abortFailedMerge(r git.Runner, targetDir, targetLabel, sourceBranch string, mergeErr error) error {
+	if git.MergeInProgress(r, targetDir) {
+		if abortErr := git.MergeAbort(r, targetDir); abortErr != nil {
+			return errhint.WithFix(
+				fmt.Errorf("merge failed and rollback failed: %w (rollback: %w)", mergeErr, abortErr),
+				"clean up manually: cd "+targetDir+" && git merge --abort",
+			)
+		}
+		return errhint.WithFix(
+			fmt.Errorf("merge failed: %w", mergeErr),
+			fmt.Sprintf("%s restored to pre-merge state; reconcile %s, then re-run rimba merge", targetLabel, sourceBranch),
+		)
+	}
+	return errhint.WithFix(
+		fmt.Errorf("merge failed: %w", mergeErr),
+		fmt.Sprintf("target %s unchanged; reconcile %s, then re-run rimba merge", targetLabel, sourceBranch),
+	)
 }
 
 // checkDirty checks both source and target for uncommitted changes concurrently.

--- a/internal/operations/merge_test.go
+++ b/internal/operations/merge_test.go
@@ -11,6 +11,7 @@ import (
 const (
 	gitCmdStatus       = "status"
 	gitCmdMerge        = "merge"
+	gitCmdAbort        = "--abort"
 	branchFeatureLogin = "feature/login"
 	statusDirtyOutput  = "M dirty.go"
 )
@@ -25,6 +26,7 @@ func mergeWorktreeList() string {
 
 func mergeRunner(mergeErr error) *mockRunner {
 	wt := mergeWorktreeList()
+	mergeInProgress := mergeErr != nil // MERGE_HEAD exists iff a merge failure is expected
 	return &mockRunner{
 		run: func(args ...string) (string, error) {
 			if len(args) >= 2 && args[0] == gitCmdWorktree {
@@ -37,7 +39,16 @@ func mergeRunner(mergeErr error) *mockRunner {
 				return "", nil
 			}
 			if len(args) >= 1 && args[0] == gitCmdMerge {
+				if len(args) >= 2 && args[1] == gitCmdAbort {
+					return "", nil // abort succeeds by default
+				}
 				return "", mergeErr
+			}
+			if len(args) >= 1 && args[0] == cmdRevParse {
+				if !mergeInProgress {
+					return "", errors.New("no MERGE_HEAD")
+				}
+				return "abc1234", nil // MERGE_HEAD exists
 			}
 			return "", nil
 		},
@@ -238,6 +249,9 @@ func TestMergeWorktreeMergeConflict(t *testing.T) {
 	if !strings.Contains(err.Error(), "merge failed") {
 		t.Errorf("expected 'merge failed', got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "restored to pre-merge state") {
+		t.Errorf("expected 'restored to pre-merge state', got: %v", err)
+	}
 }
 
 func TestMergeWorktreeCleanupPartialFailure(t *testing.T) {
@@ -409,6 +423,141 @@ func TestMergeWorktreeTargetDirtyCheckError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "target status failed") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestMergeWorktreeMergeFailsAbortAlsoFails(t *testing.T) {
+	abortErr := errors.New("abort failed")
+	wt := mergeWorktreeList()
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == gitCmdWorktree {
+				return wt, nil
+			}
+			return "", nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitCmdStatus {
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdMerge {
+				if len(args) >= 2 && args[1] == gitCmdAbort {
+					return "", abortErr
+				}
+				return "", errors.New("conflict")
+			}
+			if len(args) >= 1 && args[0] == cmdRevParse {
+				return "abc1234", nil // MERGE_HEAD exists
+			}
+			return "", nil
+		},
+	}
+
+	_, err := MergeWorktree(r, MergeParams{
+		SourceTask: "login",
+		RepoRoot:   "/repo",
+		MainBranch: "main",
+		Keep:       true,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "rollback failed") {
+		t.Errorf("expected 'rollback failed', got: %v", err)
+	}
+}
+
+func TestMergeWorktreeMergeFailsNoMergeInProgress(t *testing.T) {
+	wt := mergeWorktreeList()
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == gitCmdWorktree {
+				return wt, nil
+			}
+			return "", nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitCmdStatus {
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdMerge {
+				return "", errors.New("conflict")
+			}
+			if len(args) >= 1 && args[0] == cmdRevParse {
+				return "", errors.New("no MERGE_HEAD") // merge never started
+			}
+			return "", nil
+		},
+	}
+
+	_, err := MergeWorktree(r, MergeParams{
+		SourceTask: "login",
+		RepoRoot:   "/repo",
+		MainBranch: "main",
+		Keep:       true,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "merge failed") {
+		t.Errorf("expected 'merge failed', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "target") || !strings.Contains(err.Error(), "unchanged") {
+		t.Errorf("expected 'target ... unchanged', got: %v", err)
+	}
+}
+
+// mergeCleanupBranchDeleteFailsRunner returns a runner where merge + worktree
+// removal succeed but branch deletion fails. Extracted to keep
+// TestMergeWorktreeCleanupBranchDeleteFails under the gocyclo limit.
+func mergeCleanupBranchDeleteFailsRunner(wt string) *mockRunner {
+	return &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == gitCmdWorktree && args[1] == gitSubcmdList {
+				return wt, nil
+			}
+			if len(args) >= 2 && args[0] == gitCmdWorktree && args[1] == "remove" {
+				return "", nil
+			}
+			if len(args) >= 2 && args[0] == cmdBranch && args[1] == "-D" {
+				return "", errors.New("branch in use")
+			}
+			return "", nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitCmdStatus {
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdMerge {
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+}
+
+func TestMergeWorktreeCleanupBranchDeleteFails(t *testing.T) {
+	r := mergeCleanupBranchDeleteFailsRunner(mergeWorktreeList())
+
+	result, err := MergeWorktree(r, MergeParams{
+		SourceTask: "login",
+		RepoRoot:   "/repo",
+		MainBranch: "main",
+	}, nil)
+	if err != nil {
+		t.Fatalf("expected no fatal error (branch delete failure is non-fatal), got: %v", err)
+	}
+	if result.SourceRemoved {
+		t.Error("expected SourceRemoved=false when branch delete fails")
+	}
+	if result.RemoveError == nil {
+		t.Fatal("expected RemoveError to be set")
+	}
+	if !strings.Contains(result.RemoveError.Error(), "failed to delete branch") {
+		t.Errorf("expected unified hint in RemoveError, got: %v", result.RemoveError)
+	}
+	if !strings.Contains(result.RemoveError.Error(), "git branch -D "+branchFeatureLogin) {
+		t.Errorf("expected branch name in RemoveError hint, got: %v", result.RemoveError)
 	}
 }
 

--- a/internal/operations/operations.go
+++ b/internal/operations/operations.go
@@ -80,6 +80,15 @@ func FilterByType(worktrees []resolver.WorktreeInfo, prefixes []string, typeStr 
 	return out
 }
 
+// branchDeleteFailedErr builds the unified recovery error for the
+// "worktree removed but branch delete failed" partial-failure case.
+func branchDeleteFailedErr(branch string, cause error) error {
+	return errhint.WithFix(
+		fmt.Errorf("worktree removed but failed to delete branch: %w", cause),
+		"delete manually: git branch -D "+branch,
+	)
+}
+
 // ambiguityError builds a descriptive error when a bare task matches multiple services.
 func ambiguityError(task string, matches []resolver.WorktreeInfo) error {
 	branches := make([]string, len(matches))

--- a/internal/operations/remove.go
+++ b/internal/operations/remove.go
@@ -1,9 +1,6 @@
 package operations
 
 import (
-	"fmt"
-
-	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/progress"
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -36,10 +33,7 @@ func RemoveWorktree(r git.Runner, wt resolver.WorktreeInfo, task string, keepBra
 	if !keepBranch {
 		progress.Notify(onProgress, "Deleting branch...")
 		if err := git.DeleteBranch(r, wt.Branch, true); err != nil {
-			result.BranchError = errhint.WithFix(
-				fmt.Errorf("worktree removed but failed to delete branch: %w", err),
-				"delete manually: git branch -D "+wt.Branch,
-			)
+			result.BranchError = branchDeleteFailedErr(wt.Branch, err)
 			return result, nil
 		}
 		result.BranchDeleted = true
@@ -56,7 +50,7 @@ func removeAndCleanup(r git.Runner, path, branch string) (wtRemoved, brDeleted b
 	}
 
 	if err := git.DeleteBranch(r, branch, true); err != nil {
-		return true, false, err
+		return true, false, branchDeleteFailedErr(branch, err)
 	}
 
 	return true, true, nil

--- a/internal/operations/remove_test.go
+++ b/internal/operations/remove_test.go
@@ -211,4 +211,10 @@ func TestRemoveAndCleanupBranchDeleteFails(t *testing.T) {
 	if brDeleted {
 		t.Error("expected brDeleted to be false")
 	}
+	if !strings.Contains(err.Error(), "failed to delete branch") {
+		t.Errorf("expected unified hint in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "git branch -D feature/test") {
+		t.Errorf("expected 'git branch -D feature/test' hint in error, got: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary

- Unified the "worktree removed but branch delete failed" recovery error across `remove`, `clean`, and `merge` — previously each cmd re-templated its own hint string; now `branchDeleteFailedErr` in `operations.go` is the single source of truth and cmd layer prints the stored error
- Added `MergeInProgress` and `MergeAbort` helpers to `internal/git`
- `MergeWorktree` now auto-aborts a failed merge via `git merge --abort` when `MERGE_HEAD` is present, restoring the target worktree to clean state; if the abort itself fails, both errors are surfaced with a manual-cleanup hint; if no merge was in progress (fast-forward pre-check failure, bad ref), reports "target unchanged" instead of the misleading "restored" message
- Cmd layer (`cmd/clean.go`, `cmd/merge.go`) changed from re-templating to `fmt.Fprintln(cmd.OutOrStdout(), item.Error)` — thin presenter pattern

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)
- [x] Coverage ≥ 97% confirmed (97.5%)

### Type-tailored checks ([fix])

- [x] `TestMergeInProgress` — false on clean repo, true after conflicting merge
- [x] `TestMergeAbort` — abort restores clean state and clears MERGE_HEAD
- [x] `TestMergeWorktreeMergeConflict` — error contains "merge failed" + "restored to pre-merge state"
- [x] `TestMergeWorktreeMergeFailsAbortAlsoFails` — error contains "rollback failed"
- [x] `TestMergeWorktreeMergeFailsNoMergeInProgress` — error contains "target … unchanged"
- [x] `TestMergeWorktreeCleanupBranchDeleteFails` — `result.RemoveError` contains unified hint
- [x] `TestRemoveAndCleanupBranchDeleteFails` — error contains "failed to delete branch" + "git branch -D"
- [x] `TestPrintCleanedItemsAllBranches` — clean cmd prints stored error verbatim

## Issue

Closes #208
