### PR TITLE
[ci] run e2e suite and race detector in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,28 @@ jobs:
           cache: true
       - run: make build
 
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          cache: true
+      - run: make test-e2e
+
+  race:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          cache: true
+      - run: make test-race
+
   vuln:
     runs-on: ubuntu-latest
     # TODO: remove continue-on-error once go.mod toolchain is bumped to ≥go1.26.1

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS  = -s -w \
 	-X github.com/lugassawan/rimba/cmd.commit=$(COMMIT) \
 	-X github.com/lugassawan/rimba/cmd.date=$(DATE)
 
-.PHONY: build test test-short test-e2e test-coverage clean fmt lint bench hooks
+.PHONY: build test test-short test-e2e test-coverage test-race clean fmt lint bench hooks
 
 build:
 	go build -ldflags '$(LDFLAGS)' -o bin/rimba .
@@ -25,6 +25,9 @@ fmt:
 
 test-e2e:
 	go test ./tests/e2e/ -v -count=1 -timeout 120s
+
+test-race:
+	go test -race ./... -count=1
 
 test-coverage:
 	go test ./... -coverprofile=coverage.out -count=1

--- a/cmd/update_hint.go
+++ b/cmd/update_hint.go
@@ -24,8 +24,11 @@ func checkUpdateHint(version string, timeout time.Duration) <-chan *updater.Chec
 		return ch
 	}
 
+	// Read newUpdater before spawning the goroutine: goroutine launch
+	// establishes a happens-before edge, preventing a data race with
+	// test overrides that restore the variable via t.Cleanup.
+	u := newUpdater(version)
 	go func() {
-		u := newUpdater(version)
 		result, err := u.Check(context.Background())
 		if err != nil || result.UpToDate {
 			close(ch)


### PR DESCRIPTION
## Summary

- Add `e2e` CI job running `make test-e2e` (the full `tests/e2e/` subprocess suite) on push to `main` and PRs
- Add `race` CI job running `make test-race` (`go test -race ./... -count=1`) on push to `main` and PRs
- Add `test-race` Makefile target to support the new CI job
- Fix pre-existing data race in `checkUpdateHint`: `newUpdater(version)` was called inside a goroutine, racing against `t.Cleanup` restoring the package-level `newUpdater` variable; hoisting the call before `go func()` establishes a happens-before edge and eliminates the race

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)
- [x] Race detector passes (`make test-race`) — was failing before the race fix
- [x] CI YAML validated (`actionlint .github/workflows/ci.yml`)

## Issue

Closes #210