### PR TITLE
[feat] Prune stale remote-tracking refs during rimba clean

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -93,11 +93,13 @@ func cleanPrune(cmd *cobra.Command, r git.Runner) error {
 // cleanRemotePrune prunes stale origin remote-tracking refs, skipping gracefully
 // when there is no origin remote.
 func cleanRemotePrune(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, dryRun bool) error {
+	s.Start("Pruning remote-tracking refs...")
 	if !git.RemoteExists(r, "origin") {
+		s.Stop()
 		fmt.Fprintln(cmd.OutOrStdout(), "No 'origin' remote; skipped remote-ref prune.")
 		return nil
 	}
-	s.Start("Pruning remote-tracking refs...")
+	s.Update("Pruning remote-tracking refs...")
 	refs, err := git.RemotePrune(r, "origin", dryRun)
 	if err != nil {
 		return err

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -26,8 +26,9 @@ const (
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "Prune stale worktree references or remove merged worktrees",
-	Long:  "Runs git worktree prune to clean up stale references. Use --merged to detect and remove worktrees whose branches have been merged into main.",
+	Long:  "Runs git worktree prune to clean up stale references and prunes stale remote-tracking refs from origin. Use --merged to detect and remove worktrees whose branches have been merged into main.",
 	Example: `  rimba clean
+  rimba clean --dry-run
   rimba clean --merged
   rimba clean --stale --stale-days 7`,
 	Annotations: map[string]string{"skipConfig": "true"},
@@ -86,6 +87,31 @@ func cleanPrune(cmd *cobra.Command, r git.Runner) error {
 		fmt.Fprintln(cmd.OutOrStdout(), "Pruned stale worktree references.")
 	}
 
+	return cleanRemotePrune(cmd, r, s, dryRun)
+}
+
+// cleanRemotePrune prunes stale origin remote-tracking refs, skipping gracefully
+// when there is no origin remote.
+func cleanRemotePrune(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, dryRun bool) error {
+	if !git.RemoteExists(r, "origin") {
+		fmt.Fprintln(cmd.OutOrStdout(), "No 'origin' remote; skipped remote-ref prune.")
+		return nil
+	}
+	s.Start("Pruning remote-tracking refs...")
+	refs, err := git.RemotePrune(r, "origin", dryRun)
+	if err != nil {
+		return err
+	}
+	s.Stop()
+
+	switch {
+	case len(refs) == 0:
+		fmt.Fprintln(cmd.OutOrStdout(), "No stale remote-tracking refs to prune.")
+	case dryRun:
+		fmt.Fprintf(cmd.OutOrStdout(), "Would prune remote-tracking refs: %s\n", strings.Join(refs, ", "))
+	default:
+		fmt.Fprintf(cmd.OutOrStdout(), "Pruned remote-tracking refs: %s\n", strings.Join(refs, ", "))
+	}
 	return nil
 }
 

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -1,13 +1,51 @@
 package git
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lugassawan/rimba/internal/errhint"
+)
+
 // RemoteExists reports whether a remote with the given name is configured.
 func RemoteExists(r Runner, name string) bool {
 	_, err := r.Run("remote", "get-url", name)
 	return err == nil
 }
 
+// RemotePrune runs `git remote prune <remote>`, deleting stale remote-tracking
+// refs, and returns the names of the refs that were (or would be) pruned.
+func RemotePrune(r Runner, remote string, dryRun bool) ([]string, error) {
+	args := []string{"remote", "prune"}
+	if dryRun {
+		args = append(args, "--dry-run")
+	}
+	args = append(args, remote)
+	out, err := r.Run(args...)
+	if err != nil {
+		return nil, errhint.WithFix(
+			fmt.Errorf("remote prune: %w", err),
+			"check remote access, then run: git remote -v",
+		)
+	}
+	return parsePrunedRefs(out), nil
+}
+
 // AddRemote adds a new remote with the given name and URL.
 func AddRemote(r Runner, name, url string) error {
 	_, err := r.Run("remote", "add", name, url)
 	return err
+}
+
+// parsePrunedRefs extracts ref names from `git remote prune` output lines like
+// ` * [pruned] origin/x` (live) and ` * [would prune] origin/x` (dry-run).
+func parsePrunedRefs(out string) []string {
+	refs := []string{}
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.Contains(line, "[pruned]") || strings.Contains(line, "[would prune]") {
+			fields := strings.Fields(line)
+			refs = append(refs, fields[len(fields)-1])
+		}
+	}
+	return refs
 }

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -43,8 +43,9 @@ func parsePrunedRefs(out string) []string {
 	refs := []string{}
 	for line := range strings.SplitSeq(out, "\n") {
 		if strings.Contains(line, "[pruned]") || strings.Contains(line, "[would prune]") {
-			fields := strings.Fields(line)
-			refs = append(refs, fields[len(fields)-1])
+			if fields := strings.Fields(line); len(fields) >= 2 {
+				refs = append(refs, fields[len(fields)-1])
+			}
 		}
 	}
 	return refs

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -2,6 +2,8 @@ package git
 
 import (
 	"errors"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -57,5 +59,121 @@ func TestAddRemoteError(t *testing.T) {
 	}
 	if err := AddRemote(r, "origin", "https://github.com/x/y.git"); err == nil {
 		t.Fatal("expected error from AddRemote")
+	}
+}
+
+func TestRemotePruneNormal(t *testing.T) {
+	var captured []string
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			captured = args
+			return "", nil
+		},
+	}
+	if _, err := RemotePrune(r, "origin", false); err != nil {
+		t.Fatalf("RemotePrune: %v", err)
+	}
+	want := []string{"remote", "prune", "origin"}
+	if len(captured) != len(want) {
+		t.Fatalf("args = %v, want %v", captured, want)
+	}
+	for i, w := range want {
+		if captured[i] != w {
+			t.Errorf("args[%d] = %q, want %q", i, captured[i], w)
+		}
+	}
+	if slices.Contains(captured, flagDryRun) {
+		t.Error("--dry-run should not be present when dryRun=false")
+	}
+}
+
+func TestRemotePruneDryRun(t *testing.T) {
+	var captured []string
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			captured = args
+			return "", nil
+		},
+	}
+	if _, err := RemotePrune(r, "origin", true); err != nil {
+		t.Fatalf("RemotePrune dry-run: %v", err)
+	}
+	want := []string{"remote", "prune", "--dry-run", "origin"}
+	if len(captured) != len(want) {
+		t.Fatalf("args = %v, want %v", captured, want)
+	}
+	for i, w := range want {
+		if captured[i] != w {
+			t.Errorf("args[%d] = %q, want %q", i, captured[i], w)
+		}
+	}
+}
+
+func TestRemotePruneParsesRefs(t *testing.T) {
+	output := "Pruning origin\nURL: https://github.com/owner/repo.git\n * [pruned] origin/old\n * [pruned] origin/hotfix\n"
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return output, nil
+		},
+	}
+	refs, err := RemotePrune(r, "origin", false)
+	if err != nil {
+		t.Fatalf("RemotePrune: %v", err)
+	}
+	want := []string{"origin/old", "origin/hotfix"}
+	if len(refs) != len(want) {
+		t.Fatalf("refs = %v, want %v", refs, want)
+	}
+	for i, w := range want {
+		if refs[i] != w {
+			t.Errorf("refs[%d] = %q, want %q", i, refs[i], w)
+		}
+	}
+}
+
+func TestRemotePruneDryRunParsesRefs(t *testing.T) {
+	output := "Pruning origin\nURL: https://github.com/owner/repo.git\n * [would prune] origin/gone\n"
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return output, nil
+		},
+	}
+	refs, err := RemotePrune(r, "origin", true)
+	if err != nil {
+		t.Fatalf("RemotePrune dry-run: %v", err)
+	}
+	if len(refs) != 1 || refs[0] != "origin/gone" {
+		t.Errorf("refs = %v, want [origin/gone]", refs)
+	}
+}
+
+func TestRemotePruneNoRefs(t *testing.T) {
+	output := "Pruning origin\nURL: https://github.com/owner/repo.git\n"
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return output, nil
+		},
+	}
+	refs, err := RemotePrune(r, "origin", false)
+	if err != nil {
+		t.Fatalf("RemotePrune: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("expected empty refs, got %v", refs)
+	}
+}
+
+func TestRemotePruneErrorWrapping(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("connection refused")
+		},
+	}
+	_, err := RemotePrune(r, "origin", false)
+	if err == nil {
+		t.Fatal("expected error from RemotePrune")
+	}
+	if !strings.Contains(err.Error(), "remote prune:") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "remote prune:")
 	}
 }

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -59,11 +59,20 @@ func mcpCleanPrune(r git.Runner, dryRun bool) (*mcp.CallToolResult, error) {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	var remotePruned []string
+	if git.RemoteExists(r, "origin") {
+		remotePruned, err = git.RemotePrune(r, "origin", dryRun)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+	}
+
 	return marshalResult(cleanResult{
-		Mode:    "prune",
-		DryRun:  dryRun,
-		Removed: make([]cleanedItem, 0),
-		Output:  output,
+		Mode:         "prune",
+		DryRun:       dryRun,
+		Removed:      make([]cleanedItem, 0),
+		Output:       output,
+		RemotePruned: remotePruned,
 	})
 }
 

--- a/internal/mcp/tool_clean_test.go
+++ b/internal/mcp/tool_clean_test.go
@@ -591,3 +591,70 @@ func TestCleanToolStaleResolveMainBranchError(t *testing.T) {
 		t.Error("expected error when main branch can't be resolved")
 	}
 }
+
+func TestCleanToolPruneRemoteRefs(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			key := mockCmdKey(args)
+			switch key {
+			case "remote get-url":
+				return "https://github.com/owner/repo.git", nil
+			case "remote prune":
+				return " * [pruned] origin/x\n", nil
+			}
+			return "", nil
+		},
+	}
+	hctx := testContext(r)
+	handler := handleClean(hctx)
+
+	result := callTool(t, handler, map[string]any{"mode": modePrune})
+	data := unmarshalJSON[cleanResult](t, result)
+	if len(data.RemotePruned) != 1 || data.RemotePruned[0] != "origin/x" {
+		t.Errorf("RemotePruned = %v, want [origin/x]", data.RemotePruned)
+	}
+}
+
+func TestCleanToolPruneNoOrigin(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == "remote" && args[1] == "get-url" {
+				return "", errors.New("no such remote 'origin'")
+			}
+			return "", nil
+		},
+	}
+	hctx := testContext(r)
+	handler := handleClean(hctx)
+
+	result := callTool(t, handler, map[string]any{"mode": modePrune})
+	data := unmarshalJSON[cleanResult](t, result)
+	if data.Mode != modePrune {
+		t.Errorf("mode = %q, want %q", data.Mode, modePrune)
+	}
+	if len(data.RemotePruned) != 0 {
+		t.Errorf("expected RemotePruned empty when no origin, got %v", data.RemotePruned)
+	}
+}
+
+func TestCleanToolPruneRemoteError(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			key := mockCmdKey(args)
+			switch key {
+			case "remote get-url":
+				return "https://github.com/owner/repo.git", nil
+			case "remote prune":
+				return "", errors.New("connection refused")
+			}
+			return "", nil
+		},
+	}
+	hctx := testContext(r)
+	handler := handleClean(hctx)
+
+	result := callTool(t, handler, map[string]any{"mode": modePrune})
+	if !result.IsError {
+		t.Error("expected error result when remote prune fails")
+	}
+}

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -85,11 +85,12 @@ type syncWorktreeResult struct {
 
 // cleanResult holds the outcome of a clean operation.
 type cleanResult struct {
-	Mode     string        `json:"mode"`
-	DryRun   bool          `json:"dry_run"`
-	Removed  []cleanedItem `json:"removed"`
-	Output   string        `json:"output,omitempty"`
-	Warnings []string      `json:"warnings,omitempty"`
+	Mode         string        `json:"mode"`
+	DryRun       bool          `json:"dry_run"`
+	Removed      []cleanedItem `json:"removed"`
+	Output       string        `json:"output,omitempty"`
+	Warnings     []string      `json:"warnings,omitempty"`
+	RemotePruned []string      `json:"remote_pruned,omitempty"`
 }
 
 // cleanedItem represents a single cleaned branch/worktree.

--- a/tests/e2e/clean_test.go
+++ b/tests/e2e/clean_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -387,4 +388,105 @@ func TestCleanFetchWarningOnStderr(t *testing.T) {
 	r := rimbaSuccess(t, repo, "clean", flagMergedE2E)
 	assertContains(t, r.Stderr, "Warning: fetch failed")
 	assertNotContains(t, r.Stdout, "Warning: fetch failed")
+}
+
+// setupRepoWithBareOrigin creates a bare repo, clones it, runs rimba init,
+// commits, and pushes. Returns (localRepo, bareDir).
+func setupRepoWithBareOrigin(t *testing.T) (string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	bareDir := filepath.Join(dir, "origin.git")
+	if err := os.MkdirAll(bareDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitBare(t, bareDir, "init", "--bare", "-b", "main")
+
+	repo := filepath.Join(dir, "repo")
+	cmd := exec.Command("git", "clone", bareDir, repo)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clone: %s: %v", out, err)
+	}
+	testutil.GitCmd(t, repo, "config", "user.email", "test@test.com")
+	testutil.GitCmd(t, repo, "config", "user.name", "Test")
+
+	testutil.CreateFile(t, repo, "README.md", "# Test\n")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "initial commit")
+	testutil.GitCmd(t, repo, "push", "-u", "origin", "main")
+
+	rimbaSuccess(t, repo, "init")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "rimba init")
+	testutil.GitCmd(t, repo, "push")
+
+	return repo, bareDir
+}
+
+func TestCleanPrunesRemoteRefs(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, bareDir := setupRepoWithBareOrigin(t)
+
+	// Create and push a branch, then delete it from the bare repo so it's stale.
+	testutil.GitCmd(t, repo, "checkout", "-b", "gone")
+	testutil.GitCmd(t, repo, "push", "-u", "origin", "gone")
+	testutil.GitCmd(t, repo, "checkout", "main")
+	gitBare(t, bareDir, "branch", "-D", "gone")
+
+	r := rimbaSuccess(t, repo, "clean")
+	assertContains(t, r.Stdout, "Pruned remote-tracking refs: origin/gone")
+
+	// Verify origin/gone is no longer listed.
+	out := testutil.GitCmd(t, repo, "branch", "-r")
+	if strings.Contains(out, "origin/gone") {
+		t.Error("expected origin/gone to be pruned from remote-tracking refs")
+	}
+}
+
+func TestCleanRemotePruneDryRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, bareDir := setupRepoWithBareOrigin(t)
+
+	testutil.GitCmd(t, repo, "checkout", "-b", "gone")
+	testutil.GitCmd(t, repo, "push", "-u", "origin", "gone")
+	testutil.GitCmd(t, repo, "checkout", "main")
+	gitBare(t, bareDir, "branch", "-D", "gone")
+
+	r := rimbaSuccess(t, repo, "clean", flagDryRunE2E)
+	assertContains(t, r.Stdout, "Would prune remote-tracking refs: origin/gone")
+
+	// Dry run: origin/gone should still be listed.
+	out := testutil.GitCmd(t, repo, "branch", "-r")
+	if !strings.Contains(out, "origin/gone") {
+		t.Error("expected origin/gone to still exist after dry run")
+	}
+}
+
+func TestCleanRemotePruneNothingStale(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, _ := setupRepoWithBareOrigin(t)
+
+	r := rimbaSuccess(t, repo, "clean")
+	assertContains(t, r.Stdout, "No stale remote-tracking refs to prune.")
+}
+
+func TestCleanNoOriginSkipsRemotePrune(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+
+	r := rimbaSuccess(t, repo, "clean")
+	assertContains(t, r.Stdout, "No 'origin' remote; skipped remote-ref prune.")
 }

--- a/tests/e2e/clean_test.go
+++ b/tests/e2e/clean_test.go
@@ -44,6 +44,7 @@ func TestCleanDryRun(t *testing.T) {
 
 	r := rimbaSuccess(t, repo, "clean", flagDryRunE2E)
 	assertContains(t, r.Stdout, "Nothing to prune")
+	assertContains(t, r.Stdout, "skipped remote-ref prune")
 }
 
 func TestCleanNothingToPrune(t *testing.T) {
@@ -55,6 +56,7 @@ func TestCleanNothingToPrune(t *testing.T) {
 
 	r := rimbaSuccess(t, repo, "clean")
 	assertContains(t, r.Stdout, "Pruned stale worktree references")
+	assertContains(t, r.Stdout, "skipped remote-ref prune")
 }
 
 func TestCleanWorksWithoutInit(t *testing.T) {


### PR DESCRIPTION
## Summary
- `rimba clean` (default mode) now runs `git remote prune origin` after worktree prune, removing stale `refs/remotes/origin/*` tracking refs that linger after PR branches are deleted on the remote
- `--dry-run` previews remote-ref pruning without deleting; output clearly distinguishes worktree-ref pruning from remote-ref pruning (two separate lines)
- No `origin` remote → skipped gracefully with a non-fatal notice (`No 'origin' remote; skipped remote-ref prune.`), not an error
- MCP `clean` tool (mode=prune) gains a `remote_pruned []string` field (omitempty) in its JSON result, keeping parity with the CLI default

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

## Issue

Closes #211