### PR TITLE
[docs] Sync README and command reference with current CLI behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@
 
 🌿 **Core Workflow**
 
-- **Automatic branch naming** — configurable prefix (e.g. `feat/`, `fix/`) applied to task names
-- **File & directory copying** — auto-copies `.env`, `.envrc`, `.tool-versions`, `.vscode/` and other files or directories into new worktrees
+- **Automatic branch naming** — fixed prefix types (`feature/`, `bugfix/`, `hotfix/`, `docs/`, `test/`, `chore/`) selected per task via flags
+- **File & directory copying** — auto-copies `.env`, `.env.local`, `.envrc`, `.tool-versions` and other files or directories (e.g. `.vscode/`) into new worktrees
 - **Duplicate worktrees** — copy an existing worktree with auto-suffixed or custom name
 - **Local merge** — merge worktree branches into main or other worktrees with auto-cleanup
 - **Sync worktrees** — rebase or merge onto the latest main branch, with bulk sync support
@@ -95,7 +95,7 @@ rimba remove my-feature
 
 | Command | Description |
 |---------|-------------|
-| `rimba init` | Initialize rimba in the current repo; with `--agents` / `-g` also installs agent files at the chosen tier (`--user`/`--team`/`--local`) and registers the MCP server |
+| `rimba init` | Initialize rimba in the current repo; with `--agents` also installs team agent files, `--agents --local` for personal agent files, `-g`/`--global` for user-level installation, all registering the MCP server |
 | `rimba add <task>` | Create a new worktree with auto-prefixed branch (`service/task` for monorepos), or `pr:<num>` to create one from a GitHub PR |
 | `rimba remove <task>` | Remove a worktree and delete its branch |
 | `rimba rename <old> <new>` | Rename a worktree's task, branch, and directory |
@@ -118,7 +118,7 @@ rimba remove my-feature
 | `rimba deps install <task>` | Detect and install dependencies for a worktree |
 | `rimba clean` | Prune stale references or remove merged/stale worktrees |
 | `rimba update` | Check for updates and replace the binary in place; reminds you to refresh agent files after a successful update |
-| `rimba version` | Print version, commit, and build date |
+| `rimba version` | Print version, commit, build date, and platform info (os/arch/go) |
 | `rimba mcp` | Start MCP server for AI tool integration |
 | `rimba completion` | Generate shell completion scripts (bash, zsh, fish, powershell) |
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -21,7 +21,7 @@ func validateTypeFilter(typeFilter string) error {
 	}
 	return errhint.WithFix(
 		fmt.Errorf("invalid type %q; valid types: %s", typeFilter, strings.Join(valid, ", ")),
-		"use a prefix defined in .rimba/settings.toml [prefixes] section",
+		"choose one of the built-in prefix types: "+strings.Join(valid, ", "),
 	)
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -78,7 +78,7 @@ rimba add branch:feature/my-feature  # Promote current branch to its own worktre
 
 > **PR mode:** `pr:<num>` requires `gh` to be installed and authenticated. For cross-fork PRs, rimba adds a `gh-fork-<owner>` remote automatically. Without `--task`, the task name is derived as `review/<num>-<slug>`.
 
-> **Branch mode:** `branch:<branch>` requires that `<branch>` is the currently checked-out branch in the main repo and is not the default branch. Any uncommitted changes are transferred to the new worktree via `git stash`. `--source` is not valid in `branch:` mode.
+> **Branch mode:** `branch:<branch>` requires that `<branch>` is the currently checked-out branch in the main repo and is not the default branch. Any uncommitted changes are transferred to the new worktree via `git stash`. `--source` is not valid in `branch:` mode. `--skip-deps` and `--skip-hooks` are accepted by the parser but have no effect in `branch:` mode; promote does not run dependency installation or post-create hooks.
 
 | Flag | Description |
 |------|-------------|
@@ -610,7 +610,7 @@ commit: <sha>
 built:  <iso8601>
 os:     <linux|darwin|windows>
 arch:   <amd64|arm64>
-go:     go<X.Y.Z>
+go:     go<version>
 ```
 
 ---

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -61,7 +61,7 @@ rimba init --agents --uninstall   # Remove project-team agent files and MCP regi
 
 ### rimba add
 
-Create a new worktree with a branch named `<prefix><task>` and copy dotfiles from the repo root. In monorepos, prefix the task with a service directory name to create service-scoped branches. Use `pr:<num>` to create a worktree from a GitHub PR's head branch.
+Create a new worktree with a branch named `<prefix><task>` and copy dotfiles from the repo root. In monorepos, prefix the task with a service directory name to create service-scoped branches. Use `pr:<num>` to create a worktree from a GitHub PR's head branch. Use `branch:<branch>` to promote the currently checked-out branch into its own worktree.
 
 ```sh
 rimba add my-feature
@@ -71,11 +71,14 @@ rimba add auth-api/my-feature        # Monorepo: branch auth-api/feature/my-feat
 rimba add auth-api/my-feature --bugfix  # Monorepo: branch auth-api/bugfix/my-feature
 rimba add pr:123                     # Create worktree from PR #123's head branch
 rimba add pr:123 --task review/auth-tweak  # Override auto-derived task name
+rimba add branch:feature/my-feature  # Promote current branch to its own worktree
 ```
 
 > **Monorepo:** If the first segment before `/` matches a directory in the repo root, rimba treats it as a service scope. The branch uses a 3-segment pattern: `<service>/<prefix>/<task>`. No configuration needed — detection is automatic.
 
 > **PR mode:** `pr:<num>` requires `gh` to be installed and authenticated. For cross-fork PRs, rimba adds a `gh-fork-<owner>` remote automatically. Without `--task`, the task name is derived as `review/<num>-<slug>`.
+
+> **Branch mode:** `branch:<branch>` requires that `<branch>` is the currently checked-out branch in the main repo and is not the default branch. Any uncommitted changes are transferred to the new worktree via `git stash`. `--source` is not valid in `branch:` mode.
 
 | Flag | Description |
 |------|-------------|
@@ -103,6 +106,7 @@ rimba remove my-feature -f           # Force removal even if dirty
 |------|-------------|
 | `-k`, `--keep-branch` | Keep the local branch after removing the worktree |
 | `-f`, `--force` | Force removal even if the worktree is dirty |
+| `--dry-run` | Preview what would be removed without making changes |
 
 ### rimba rename
 
@@ -116,6 +120,8 @@ rimba rename old-task new-task -f  # Force rename even if locked
 | Flag | Description |
 |------|-------------|
 | `-f`, `--force` | Force rename even if the worktree is locked |
+| `--skip-deps` | Skip dependency refresh after rename |
+| `--skip-hooks` | Skip post-rename hooks |
 
 ### rimba duplicate
 
@@ -131,6 +137,7 @@ rimba duplicate auth --as auth-v2 # Creates feature/auth-v2 from feature/auth
 | `--as` | Custom name for the duplicate worktree (instead of auto-suffix) |
 | `--skip-deps` | Skip dependency detection and installation |
 | `--skip-hooks` | Skip post-create hooks |
+| `--dry-run` | Preview what would be duplicated without making changes |
 
 ### rimba archive
 
@@ -144,6 +151,7 @@ rimba archive my-feature -f      # Force archival even if dirty
 | Flag | Description |
 |------|-------------|
 | `-f`, `--force` | Force archival even if the worktree has uncommitted changes |
+| `--dry-run` | Preview what would be archived without making changes |
 
 > **Note:** The branch is preserved locally. Use [`rimba restore`](#rimba-restore) to recreate the worktree from the archived branch.
 
@@ -316,6 +324,7 @@ rimba merge auth --keep                    # Merge into main, keep source
 rimba merge auth --into dashboard          # Merge into worktree, keep source
 rimba merge auth --into dashboard --delete # Merge into worktree, delete source
 rimba merge auth --no-ff                   # Force merge commit
+rimba merge auth --dry-run                 # Preview merge without making changes
 ```
 
 | Flag | Description |
@@ -324,6 +333,7 @@ rimba merge auth --no-ff                   # Force merge commit
 | `--no-ff` | Force a merge commit (no fast-forward) |
 | `--keep` | Keep source worktree after merging into main |
 | `--delete` | Delete source worktree after merging into another worktree |
+| `--dry-run` | Preview what would be merged/cleaned up without making changes |
 
 > **Note:** `--keep` and `--delete` are mutually exclusive. Merging to main deletes the source by default; merging to another worktree keeps it by default.
 
@@ -345,6 +355,7 @@ rimba sync --all --include-inherited # Include duplicate worktrees
 | `--merge` | Use merge instead of rebase |
 | `--include-inherited` | Include inherited/duplicate worktrees when using `--all` |
 | `--no-push` | Skip pushing after sync (useful for local-only rebase/merge) |
+| `--dry-run` | Preview what would be synced without making changes |
 
 > **Note:** Dirty worktrees are skipped with a warning. On conflict, the rebase is automatically aborted and a recovery hint is printed. After a successful sync, the branch is pushed to origin by default.
 
@@ -587,11 +598,19 @@ rimba update --force     # Also works on dev builds
 
 ### rimba version
 
-Print version, commit, and build date.
+Print version, commit, build date, and platform info.
 
 ```sh
 rimba version
-# rimba v<X.Y.Z> (commit: <sha>, built: <iso8601>)
+```
+
+```
+rimba v<X.Y.Z>
+commit: <sha>
+built:  <iso8601>
+os:     <linux|darwin|windows>
+arch:   <amd64|arm64>
+go:     go<X.Y.Z>
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Fix stale prefix wording: "configurable prefix (e.g. `feat/`, `fix/`)" → fixed set of 6 (`feature/`, `bugfix/`, `hotfix/`, `docs/`, `test/`, `chore/`) selected via flags
- Correct `copy_files` defaults: add `.env.local`, demote `.vscode/` from default to illustrative example
- Fix `rimba init` tier flags: `--user`/`--team`/`--local` → `--agents`, `--agents --local`, `-g`/`--global`
- Document `rimba add branch:<branch>` promote mode with constraints (must be checked-out branch, not default; stash transfers dirty state; `--source` invalid)
- Add `--dry-run` to flag tables for `remove`, `duplicate`, `archive`, `merge`, `sync`
- Add `--skip-deps` and `--skip-hooks` to `rimba rename` flag table
- Replace single-line version example with real 6-line output format (`rimba v<X>` / `commit:` / `built:` / `os:` / `arch:` / `go:`)
- Reword `cmd/flags.go` error hint away from nonexistent `.rimba/settings.toml [prefixes]` config section

## Test Plan

- [x] Linter passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Every documented flag verified against live `--help` output for all six affected commands
- [x] `./bin/rimba version` output matches the new docs example exactly
- [x] Error hint (`rimba list --type bogus`) no longer references `[prefixes]` config section
- [x] `git grep` confirms no stale strings remain (`prefixes] section`, `--user\`/\`--team`, `feat/\`, \`fix/`)

## Issue

Issue: N/A