### PR TITLE
[chore] gitignore: ignore macOS .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ local.properties
 # Claude Code runtime files
 .claude/scheduled_tasks.lock
 .claude/worktrees/
+
+# macOS
+.DS_Store


### PR DESCRIPTION
## Summary

- Adds `.DS_Store` under a new `# macOS` section in `.gitignore`
- Prevents macOS Finder metadata files from appearing as untracked in contributors' working trees

## Motivation

Re-releasing v1.9.3 requires a clean commit at `main` HEAD — one whose message contains no CI-skip keywords. This minimal, genuinely useful change provides that commit.

N/A

## Test plan

- [ ] CI passes (`lint`, `coverage`, `build`, `validate-pr`, `e2e`, `race`)
- [ ] Squash-merge commit body contains no `[no ci]`, `[skip ci]`, `[ci skip]`, `[skip actions]`, or `[actions skip]` keywords