### PR TITLE
[fix] rimba clean prunes all remotes, not just origin

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -26,7 +26,7 @@ const (
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "Prune stale worktree references or remove merged worktrees",
-	Long:  "Runs git worktree prune to clean up stale references and prunes stale remote-tracking refs from origin. Use --merged to detect and remove worktrees whose branches have been merged into main.",
+	Long:  "Runs git worktree prune to clean up stale references and prunes stale remote-tracking refs across all remotes. Use --merged to detect and remove worktrees whose branches have been merged into main.",
 	Example: `  rimba clean
   rimba clean --dry-run
   rimba clean --merged
@@ -90,29 +90,32 @@ func cleanPrune(cmd *cobra.Command, r git.Runner) error {
 	return cleanRemotePrune(cmd, r, s, dryRun)
 }
 
-// cleanRemotePrune prunes stale origin remote-tracking refs, skipping gracefully
-// when there is no origin remote.
+// cleanRemotePrune prunes stale remote-tracking refs across all configured remotes.
+// Skips gracefully when there are no remotes; warns and continues on per-remote failure.
 func cleanRemotePrune(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, dryRun bool) error {
 	s.Start("Pruning remote-tracking refs...")
-	if !git.RemoteExists(r, "origin") {
-		s.Stop()
-		fmt.Fprintln(cmd.OutOrStdout(), "No 'origin' remote; skipped remote-ref prune.")
-		return nil
-	}
-	s.Update("Pruning remote-tracking refs...")
-	refs, err := git.RemotePrune(r, "origin", dryRun)
+	remotes, err := git.ListRemotes(r)
 	if err != nil {
+		s.Stop()
 		return err
 	}
+	if len(remotes) == 0 {
+		s.Stop()
+		fmt.Fprintln(cmd.OutOrStdout(), "No remotes; skipped remote-ref prune.")
+		return nil
+	}
+	pruned, failures := git.PruneRemotes(r, remotes, dryRun)
 	s.Stop()
-
+	for _, f := range failures {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to prune %s: %v\n", f.Remote, f.Err)
+	}
 	switch {
-	case len(refs) == 0:
+	case len(pruned) == 0:
 		fmt.Fprintln(cmd.OutOrStdout(), "No stale remote-tracking refs to prune.")
 	case dryRun:
-		fmt.Fprintf(cmd.OutOrStdout(), "Would prune remote-tracking refs: %s\n", strings.Join(refs, ", "))
+		fmt.Fprintf(cmd.OutOrStdout(), "Would prune remote-tracking refs: %s\n", strings.Join(pruned, ", "))
 	default:
-		fmt.Fprintf(cmd.OutOrStdout(), "Pruned remote-tracking refs: %s\n", strings.Join(refs, ", "))
+		fmt.Fprintf(cmd.OutOrStdout(), "Pruned remote-tracking refs: %s\n", strings.Join(pruned, ", "))
 	}
 	return nil
 }

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -106,10 +106,14 @@ func cleanRemotePrune(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, dryR
 	}
 	pruned, failures := git.PruneRemotes(r, remotes, dryRun)
 	s.Stop()
-	for _, f := range failures {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to prune %s: %v\n", f.Remote, f.Err)
+	failureMsgs := make([]string, len(failures))
+	for i, f := range failures {
+		failureMsgs[i] = fmt.Sprintf("failed to prune %s: %v", f.Remote, f.Err)
 	}
+	printWarnings(cmd, failureMsgs)
 	switch {
+	case len(pruned) == 0 && len(failures) > 0:
+		// All remotes failed; warnings already emitted above.
 	case len(pruned) == 0:
 		fmt.Fprintln(cmd.OutOrStdout(), "No stale remote-tracking refs to prune.")
 	case dryRun:

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -22,9 +22,9 @@ func TestCleanRemotePruneMultiRemote(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			if len(args) == 1 && args[0] == cmdRemote {
-				return "origin\nupstream\n", nil
+				return twoRemotesList, nil
 			}
-			if len(args) >= 3 && args[0] == cmdRemote && args[1] == "prune" {
+			if len(args) >= 3 && args[0] == cmdRemote && args[1] == cmdPrune {
 				remote := args[len(args)-1]
 				calls = append(calls, remote)
 				return " * [pruned] " + remote + "/gone\n", nil
@@ -55,9 +55,9 @@ func TestCleanRemotePrunePartialFailure(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			if len(args) == 1 && args[0] == cmdRemote {
-				return "origin\nupstream\n", nil
+				return twoRemotesList, nil
 			}
-			if len(args) >= 3 && args[0] == cmdRemote && args[1] == "prune" {
+			if len(args) >= 3 && args[0] == cmdRemote && args[1] == cmdPrune {
 				remote := args[len(args)-1]
 				if remote == "upstream" {
 					return "", errors.New("connection refused")
@@ -77,6 +77,37 @@ func TestCleanRemotePrunePartialFailure(t *testing.T) {
 	}
 	if !strings.Contains(errBuf.String(), "Warning: failed to prune upstream:") {
 		t.Errorf("stderr = %q, want 'Warning: failed to prune upstream:'", errBuf.String())
+	}
+}
+
+func TestCleanRemotePruneAllFail(t *testing.T) {
+	cmd, buf := newCleanPruneCmd()
+	var errBuf bytes.Buffer
+	cmd.SetErr(&errBuf)
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) == 1 && args[0] == cmdRemote {
+				return twoRemotesList, nil
+			}
+			if len(args) >= 3 && args[0] == cmdRemote && args[1] == cmdPrune {
+				return "", errors.New("connection refused")
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	if err := cleanPrune(cmd, r); err != nil {
+		t.Fatalf("cleanPrune should return nil on all-remote failure, got: %v", err)
+	}
+	// stdout must NOT contain the false-positive "No stale" message
+	if strings.Contains(buf.String(), "No stale remote-tracking refs to prune.") {
+		t.Errorf("stdout = %q: false-positive 'No stale' message when all remotes failed", buf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Warning: failed to prune origin:") {
+		t.Errorf("stderr = %q, want warning for origin failure", errBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Warning: failed to prune upstream:") {
+		t.Errorf("stderr = %q, want warning for upstream failure", errBuf.String())
 	}
 }
 

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -16,6 +16,89 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func TestCleanRemotePruneMultiRemote(t *testing.T) {
+	cmd, buf := newCleanPruneCmd()
+	var calls []string
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) == 1 && args[0] == cmdRemote {
+				return "origin\nupstream\n", nil
+			}
+			if len(args) >= 3 && args[0] == cmdRemote && args[1] == "prune" {
+				remote := args[len(args)-1]
+				calls = append(calls, remote)
+				return " * [pruned] " + remote + "/gone\n", nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	if err := cleanPrune(cmd, r); err != nil {
+		t.Fatalf("cleanPrune: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 prune calls, got %d: %v", len(calls), calls)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "origin/gone") {
+		t.Errorf("output = %q, want origin/gone", out)
+	}
+	if !strings.Contains(out, "upstream/gone") {
+		t.Errorf("output = %q, want upstream/gone", out)
+	}
+}
+
+func TestCleanRemotePrunePartialFailure(t *testing.T) {
+	cmd, buf := newCleanPruneCmd()
+	var errBuf bytes.Buffer
+	cmd.SetErr(&errBuf)
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) == 1 && args[0] == cmdRemote {
+				return "origin\nupstream\n", nil
+			}
+			if len(args) >= 3 && args[0] == cmdRemote && args[1] == "prune" {
+				remote := args[len(args)-1]
+				if remote == "upstream" {
+					return "", errors.New("connection refused")
+				}
+				return " * [pruned] origin/gone\n", nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	err := cleanPrune(cmd, r)
+	if err != nil {
+		t.Fatalf("cleanPrune should return nil on partial failure, got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "origin/gone") {
+		t.Errorf("stdout = %q, want origin/gone", buf.String())
+	}
+	if !strings.Contains(errBuf.String(), "Warning: failed to prune upstream:") {
+		t.Errorf("stderr = %q, want 'Warning: failed to prune upstream:'", errBuf.String())
+	}
+}
+
+func TestCleanRemotePruneNoRemotes(t *testing.T) {
+	cmd, buf := newCleanPruneCmd()
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) == 1 && args[0] == cmdRemote {
+				return "", nil // no remotes
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+	if err := cleanPrune(cmd, r); err != nil {
+		t.Fatalf("cleanPrune: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No remotes; skipped remote-ref prune.") {
+		t.Errorf("output = %q, want 'No remotes; skipped remote-ref prune.'", buf.String())
+	}
+}
+
 func TestCleanMergedFetchFails(t *testing.T) {
 	worktreeOut := cleanMergedWorktreeOut()
 	cmd, outBuf := newCleanMergedCmd()

--- a/cmd/mock_runner_test.go
+++ b/cmd/mock_runner_test.go
@@ -45,11 +45,14 @@ const (
 	cmdRevList                = "rev-list"
 
 	// Shared git command and value constants
-	cmdList               = "list"
-	cmdDiff               = "diff"
-	cmdFetch              = "fetch"
-	cmdRemote             = "remote"
-	cmdRemove             = "remove"
+	cmdList   = "list"
+	cmdDiff   = "diff"
+	cmdFetch  = "fetch"
+	cmdPrune  = "prune"
+	cmdRemote = "remote"
+	cmdRemove = "remove"
+
+	twoRemotesList        = "origin\nupstream\n"
 	gitSubcmdWorktreeAdd  = "add"
 	cmdSymbolicRef        = "symbolic-ref"
 	cmdStatus             = "status"

--- a/cmd/mock_runner_test.go
+++ b/cmd/mock_runner_test.go
@@ -48,6 +48,7 @@ const (
 	cmdList               = "list"
 	cmdDiff               = "diff"
 	cmdFetch              = "fetch"
+	cmdRemote             = "remote"
 	cmdRemove             = "remove"
 	gitSubcmdWorktreeAdd  = "add"
 	cmdSymbolicRef        = "symbolic-ref"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -573,7 +573,7 @@ rimba clean --stale --dry-run            # Show stale worktrees without removing
 | `--stale-days` | Number of days to consider a worktree stale (default: 14, used with `--stale`) |
 | `--force` | Skip confirmation prompt when used with `--merged` or `--stale` |
 
-> **Note:** `--merged` and `--stale` are mutually exclusive. `--merged` works with or without `rimba init`. Without a config file, it falls back to auto-detecting the default branch.
+> **Note:** `--merged` and `--stale` are mutually exclusive. `--merged` works with or without `rimba init`. Without a config file, it falls back to auto-detecting the default branch. By default, `rimba clean` prunes stale remote-tracking refs across all configured remotes (not just `origin`).
 
 ---
 

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -7,6 +7,12 @@ import (
 	"github.com/lugassawan/rimba/internal/errhint"
 )
 
+// RemoteFailure records a prune error for a single remote.
+type RemoteFailure struct {
+	Remote string
+	Err    error
+}
+
 // RemoteExists reports whether a remote with the given name is configured.
 func RemoteExists(r Runner, name string) bool {
 	_, err := r.Run("remote", "get-url", name)
@@ -54,12 +60,6 @@ func ListRemotes(r Runner) ([]string, error) {
 		}
 	}
 	return remotes, nil
-}
-
-// RemoteFailure records a prune error for a single remote.
-type RemoteFailure struct {
-	Remote string
-	Err    error
 }
 
 // PruneRemotes calls RemotePrune for each remote in order. Pruned refs from all

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -37,6 +37,49 @@ func AddRemote(r Runner, name, url string) error {
 	return err
 }
 
+// ListRemotes returns the names of all configured remotes by running `git remote`.
+// It returns an empty (non-nil) slice when there are no remotes configured.
+func ListRemotes(r Runner) ([]string, error) {
+	out, err := r.Run("remote")
+	if err != nil {
+		return nil, errhint.WithFix(
+			fmt.Errorf("list remotes: %w", err),
+			"check the repository, then run: git remote -v",
+		)
+	}
+	remotes := []string{}
+	for line := range strings.SplitSeq(out, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			remotes = append(remotes, line)
+		}
+	}
+	return remotes, nil
+}
+
+// RemoteFailure records a prune error for a single remote.
+type RemoteFailure struct {
+	Remote string
+	Err    error
+}
+
+// PruneRemotes calls RemotePrune for each remote in order. Pruned refs from all
+// successful remotes are collected and returned. Any remote that fails is
+// recorded in the failures slice; iteration continues regardless of errors.
+// Both return values are initialized as non-nil empty slices.
+func PruneRemotes(r Runner, remotes []string, dryRun bool) ([]string, []RemoteFailure) {
+	pruned := []string{}
+	failures := []RemoteFailure{}
+	for _, remote := range remotes {
+		refs, err := RemotePrune(r, remote, dryRun)
+		if err != nil {
+			failures = append(failures, RemoteFailure{Remote: remote, Err: err})
+			continue
+		}
+		pruned = append(pruned, refs...)
+	}
+	return pruned, failures
+}
+
 // parsePrunedRefs extracts ref names from `git remote prune` output lines like
 // ` * [pruned] origin/x` (live) and ` * [would prune] origin/x` (dry-run).
 func parsePrunedRefs(out string) []string {

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -177,3 +177,130 @@ func TestRemotePruneErrorWrapping(t *testing.T) {
 		t.Errorf("error = %q, want it to contain %q", err.Error(), "remote prune:")
 	}
 }
+
+func TestListRemotesTwoRemotes(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "origin\nupstream\n", nil
+		},
+	}
+	remotes, err := ListRemotes(r)
+	if err != nil {
+		t.Fatalf("ListRemotes: %v", err)
+	}
+	want := []string{"origin", "upstream"}
+	if len(remotes) != len(want) {
+		t.Fatalf("remotes = %v, want %v", remotes, want)
+	}
+	for i, w := range want {
+		if remotes[i] != w {
+			t.Errorf("remotes[%d] = %q, want %q", i, remotes[i], w)
+		}
+	}
+}
+
+func TestListRemotesEmpty(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", nil
+		},
+	}
+	remotes, err := ListRemotes(r)
+	if err != nil {
+		t.Fatalf("ListRemotes: %v", err)
+	}
+	if remotes == nil {
+		t.Fatal("expected non-nil slice, got nil")
+	}
+	if len(remotes) != 0 {
+		t.Errorf("expected empty slice, got %v", remotes)
+	}
+}
+
+func TestListRemotesRunnerError(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("not a git repository")
+		},
+	}
+	_, err := ListRemotes(r)
+	if err == nil {
+		t.Fatal("expected error from ListRemotes")
+	}
+	if !strings.Contains(err.Error(), "list remotes:") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "list remotes:")
+	}
+}
+
+func TestPruneRemotesBothSucceed(t *testing.T) {
+	calls := map[string]string{
+		"origin":   " * [pruned] origin/old\n",
+		"upstream": " * [pruned] upstream/gone\n",
+	}
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			remote := args[len(args)-1]
+			return calls[remote], nil
+		},
+	}
+	pruned, failures := PruneRemotes(r, []string{"origin", "upstream"}, false)
+	if len(failures) != 0 {
+		t.Fatalf("expected no failures, got %v", failures)
+	}
+	want := []string{"origin/old", "upstream/gone"}
+	if len(pruned) != len(want) {
+		t.Fatalf("pruned = %v, want %v", pruned, want)
+	}
+	for i, w := range want {
+		if pruned[i] != w {
+			t.Errorf("pruned[%d] = %q, want %q", i, pruned[i], w)
+		}
+	}
+}
+
+func TestPruneRemotesPartialFailure(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			remote := args[len(args)-1]
+			if remote == "upstream" {
+				return "", errors.New("could not read from remote")
+			}
+			return " * [pruned] origin/old\n", nil
+		},
+	}
+	pruned, failures := PruneRemotes(r, []string{"origin", "upstream"}, false)
+	if len(failures) != 1 {
+		t.Fatalf("expected 1 failure, got %d: %v", len(failures), failures)
+	}
+	if failures[0].Remote != "upstream" {
+		t.Errorf("failures[0].Remote = %q, want %q", failures[0].Remote, "upstream")
+	}
+	if failures[0].Err == nil {
+		t.Error("failures[0].Err should not be nil")
+	}
+	if len(pruned) != 1 || pruned[0] != "origin/old" {
+		t.Errorf("pruned = %v, want [origin/old]", pruned)
+	}
+}
+
+func TestPruneRemotesEmptyInput(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			t.Error("runner should not be called for empty input")
+			return "", nil
+		},
+	}
+	pruned, failures := PruneRemotes(r, []string{}, false)
+	if pruned == nil {
+		t.Error("expected non-nil pruned slice")
+	}
+	if failures == nil {
+		t.Error("expected non-nil failures slice")
+	}
+	if len(pruned) != 0 {
+		t.Errorf("expected empty pruned, got %v", pruned)
+	}
+	if len(failures) != 0 {
+		t.Errorf("expected empty failures, got %v", failures)
+	}
+}

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -60,10 +60,15 @@ func mcpCleanPrune(r git.Runner, dryRun bool) (*mcp.CallToolResult, error) {
 	}
 
 	var remotePruned []string
-	if git.RemoteExists(r, "origin") {
-		remotePruned, err = git.RemotePrune(r, "origin", dryRun)
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+	var warnings []string
+	remotes, err := git.ListRemotes(r)
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf("failed to list remotes: %v", err))
+	} else {
+		var failures []git.RemoteFailure
+		remotePruned, failures = git.PruneRemotes(r, remotes, dryRun)
+		for _, f := range failures {
+			warnings = append(warnings, fmt.Sprintf("failed to prune %s: %v", f.Remote, f.Err))
 		}
 	}
 
@@ -73,6 +78,7 @@ func mcpCleanPrune(r git.Runner, dryRun bool) (*mcp.CallToolResult, error) {
 		Removed:      make([]cleanedItem, 0),
 		Output:       output,
 		RemotePruned: remotePruned,
+		Warnings:     warnings,
 	})
 }
 

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -60,7 +60,7 @@ func mcpCleanPrune(r git.Runner, dryRun bool) (*mcp.CallToolResult, error) {
 	}
 
 	var remotePruned []string
-	var warnings []string
+	warnings := []string{}
 	remotes, err := git.ListRemotes(r)
 	if err != nil {
 		warnings = append(warnings, fmt.Sprintf("failed to list remotes: %v", err))

--- a/internal/mcp/tool_clean_test.go
+++ b/internal/mcp/tool_clean_test.go
@@ -669,6 +669,43 @@ func TestCleanToolPruneRemoteError(t *testing.T) {
 	}
 }
 
+func TestMcpCleanPruneListRemotesError(t *testing.T) {
+	// When git.ListRemotes itself fails, mcpCleanPrune records a warning
+	// and returns a success result with empty RemotePruned — not a tool error.
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if mockCmdKey(args) == gitRemote {
+				return "", errors.New("not a git repository")
+			}
+			return "", nil
+		},
+	}
+	hctx := testContext(r)
+	handler := handleClean(hctx)
+
+	result := callTool(t, handler, map[string]any{"mode": modePrune})
+	if result.IsError {
+		t.Error("expected success result when ListRemotes fails; got error result")
+	}
+	data := unmarshalJSON[cleanResult](t, result)
+	if len(data.RemotePruned) != 0 {
+		t.Errorf("RemotePruned = %v, want empty when ListRemotes fails", data.RemotePruned)
+	}
+	if len(data.Warnings) == 0 {
+		t.Error("expected Warnings to be populated when ListRemotes fails")
+	}
+	found := false
+	for _, w := range data.Warnings {
+		if strings.Contains(w, "list remotes") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Warnings = %v, want an entry mentioning 'list remotes'", data.Warnings)
+	}
+}
+
 func TestMcpCleanPruneMultiRemote(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {

--- a/internal/mcp/tool_clean_test.go
+++ b/internal/mcp/tool_clean_test.go
@@ -10,11 +10,13 @@ import (
 
 // Constants for repeated string literals in clean tests.
 const (
-	gitFetch  = "fetch"
-	gitBranch = "branch"
-	gitLog    = "log"
-	gitRemove = "remove"
-	gitMerged = "--merged"
+	gitFetch       = "fetch"
+	gitBranch      = "branch"
+	gitLog         = "log"
+	gitRemote      = "remote"
+	gitRemotePrune = "remote prune"
+	gitRemove      = "remove"
+	gitMerged      = "--merged"
 
 	modeStale  = "stale"
 	modeMerged = "merged"
@@ -28,6 +30,8 @@ const (
 
 // mockCmdKey builds a dispatch key from git arguments.
 // Two-arg commands like "worktree list" use "arg0 arg1"; single-arg commands use "arg0".
+// Note: unmatched keys silently return ("", nil) — callers are responsible for handling
+// only the args they declare and letting the remainder fall through harmlessly.
 func mockCmdKey(args []string) string {
 	if len(args) >= 2 {
 		return args[0] + " " + args[1]
@@ -597,9 +601,9 @@ func TestCleanToolPruneRemoteRefs(t *testing.T) {
 		run: func(args ...string) (string, error) {
 			key := mockCmdKey(args)
 			switch key {
-			case "remote get-url":
-				return "https://github.com/owner/repo.git", nil
-			case "remote prune":
+			case gitRemote:
+				return "origin\n", nil
+			case gitRemotePrune:
 				return " * [pruned] origin/x\n", nil
 			}
 			return "", nil
@@ -618,8 +622,8 @@ func TestCleanToolPruneRemoteRefs(t *testing.T) {
 func TestCleanToolPruneNoOrigin(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
-			if len(args) >= 2 && args[0] == "remote" && args[1] == "get-url" {
-				return "", errors.New("no such remote 'origin'")
+			if len(args) == 1 && args[0] == gitRemote {
+				return "", nil // no remotes configured
 			}
 			return "", nil
 		},
@@ -633,18 +637,20 @@ func TestCleanToolPruneNoOrigin(t *testing.T) {
 		t.Errorf("mode = %q, want %q", data.Mode, modePrune)
 	}
 	if len(data.RemotePruned) != 0 {
-		t.Errorf("expected RemotePruned empty when no origin, got %v", data.RemotePruned)
+		t.Errorf("expected RemotePruned empty when no remotes, got %v", data.RemotePruned)
 	}
 }
 
 func TestCleanToolPruneRemoteError(t *testing.T) {
+	// When a remote prune fails, mcpCleanPrune records it as a warning (partial failure),
+	// not as a tool error — the result should be successful with warnings populated.
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			key := mockCmdKey(args)
 			switch key {
-			case "remote get-url":
-				return "https://github.com/owner/repo.git", nil
-			case "remote prune":
+			case gitRemote:
+				return "origin\n", nil
+			case gitRemotePrune:
 				return "", errors.New("connection refused")
 			}
 			return "", nil
@@ -654,7 +660,88 @@ func TestCleanToolPruneRemoteError(t *testing.T) {
 	handler := handleClean(hctx)
 
 	result := callTool(t, handler, map[string]any{"mode": modePrune})
-	if !result.IsError {
-		t.Error("expected error result when remote prune fails")
+	if result.IsError {
+		t.Error("expected success result (warning) when remote prune fails; got error result")
+	}
+	data := unmarshalJSON[cleanResult](t, result)
+	if len(data.Warnings) == 0 {
+		t.Error("expected Warnings to be populated on partial failure")
+	}
+}
+
+func TestMcpCleanPruneMultiRemote(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			key := mockCmdKey(args)
+			switch key {
+			case gitRemote:
+				return "origin\nupstream\n", nil
+			case gitRemotePrune:
+				remote := args[len(args)-1]
+				return " * [pruned] " + remote + "/gone\n", nil
+			}
+			return "", nil
+		},
+	}
+	hctx := testContext(r)
+	handler := handleClean(hctx)
+
+	result := callTool(t, handler, map[string]any{"mode": modePrune})
+	data := unmarshalJSON[cleanResult](t, result)
+	if data.Mode != modePrune {
+		t.Errorf("mode = %q, want %q", data.Mode, modePrune)
+	}
+	pruned := make(map[string]bool)
+	for _, ref := range data.RemotePruned {
+		pruned[ref] = true
+	}
+	if !pruned["origin/gone"] {
+		t.Errorf("RemotePruned = %v, want origin/gone included", data.RemotePruned)
+	}
+	if !pruned["upstream/gone"] {
+		t.Errorf("RemotePruned = %v, want upstream/gone included", data.RemotePruned)
+	}
+}
+
+func TestMcpCleanPrunePartialFailure(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			key := mockCmdKey(args)
+			switch key {
+			case gitRemote:
+				return "origin\nupstream\n", nil
+			case gitRemotePrune:
+				remote := args[len(args)-1]
+				if remote == "upstream" {
+					return "", errors.New("connection refused")
+				}
+				return " * [pruned] origin/gone\n", nil
+			}
+			return "", nil
+		},
+	}
+	hctx := testContext(r)
+	handler := handleClean(hctx)
+
+	result := callTool(t, handler, map[string]any{"mode": modePrune})
+	if result.IsError {
+		t.Error("expected success result on partial failure; got error result")
+	}
+	data := unmarshalJSON[cleanResult](t, result)
+	if len(data.RemotePruned) != 1 || data.RemotePruned[0] != "origin/gone" {
+		t.Errorf("RemotePruned = %v, want [origin/gone]", data.RemotePruned)
+	}
+	if len(data.Warnings) == 0 {
+		t.Error("expected Warnings to be populated for upstream failure")
+	}
+	found := false
+	for _, w := range data.Warnings {
+		if strings.Contains(w, "upstream") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Warnings = %v, want an entry mentioning 'upstream'", data.Warnings)
 	}
 }

--- a/tests/e2e/clean_test.go
+++ b/tests/e2e/clean_test.go
@@ -490,5 +490,89 @@ func TestCleanNoOriginSkipsRemotePrune(t *testing.T) {
 	repo := setupInitializedRepo(t)
 
 	r := rimbaSuccess(t, repo, "clean")
-	assertContains(t, r.Stdout, "No 'origin' remote; skipped remote-ref prune.")
+	assertContains(t, r.Stdout, "No remotes; skipped remote-ref prune.")
+}
+
+func TestCleanPrunesNonOriginRemote(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	dir := t.TempDir()
+
+	bareDir := filepath.Join(dir, "upstream.git")
+	if err := os.MkdirAll(bareDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitBare(t, bareDir, "init", "--bare", "-b", "main")
+
+	repo := filepath.Join(dir, "repo")
+	cmd := exec.Command("git", "clone", bareDir, repo)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clone: %s: %v", out, err)
+	}
+
+	testutil.GitCmd(t, repo, "config", "user.email", "test@test.com")
+	testutil.GitCmd(t, repo, "config", "user.name", "Test")
+
+	// Rename the remote from "origin" to "upstream"
+	testutil.GitCmd(t, repo, "remote", "rename", "origin", "upstream")
+
+	testutil.CreateFile(t, repo, "README.md", "# Test\n")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "initial commit")
+	testutil.GitCmd(t, repo, "push", "-u", "upstream", "main")
+
+	rimbaSuccess(t, repo, "init")
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "rimba init")
+	testutil.GitCmd(t, repo, "push", "upstream", "main")
+
+	// Create a branch, push to upstream, then delete from bare so it's stale.
+	testutil.GitCmd(t, repo, "checkout", "-b", "gone")
+	testutil.GitCmd(t, repo, "push", "-u", "upstream", "gone")
+	testutil.GitCmd(t, repo, "checkout", "main")
+	gitBare(t, bareDir, "branch", "-D", "gone")
+
+	r := rimbaSuccess(t, repo, "clean")
+	assertContains(t, r.Stdout, "Pruned remote-tracking refs: upstream/gone")
+
+	// Verify a subsequent fetch --prune emits no "[deleted]" line.
+	fetchCmd := exec.Command("git", "-C", repo, "fetch", "--prune", "upstream")
+	fetchOut, _ := fetchCmd.CombinedOutput()
+	if strings.Contains(string(fetchOut), "[deleted]") {
+		t.Errorf("expected no [deleted] after rimba clean, got: %s", fetchOut)
+	}
+}
+
+func TestCleanPrunesCustomRefspec(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, bareDir := setupRepoWithBareOrigin(t)
+
+	// Add a custom fetch refspec mapping refs/heads/custom/* → refs/remotes/origin/custom/*.
+	testutil.GitCmd(t, repo, "config", "--add", "remote.origin.fetch", "+refs/heads/custom/*:refs/remotes/origin/custom/*")
+
+	// Create and push a branch matching the custom refspec namespace.
+	testutil.GitCmd(t, repo, "checkout", "-b", "custom/feature")
+	testutil.GitCmd(t, repo, "push", "-u", "origin", "custom/feature")
+	testutil.GitCmd(t, repo, "checkout", "main")
+
+	// Fetch so the tracking ref exists under refs/remotes/origin/custom/feature.
+	testutil.GitCmd(t, repo, "fetch", "origin")
+
+	// Delete the branch from the bare remote so the tracking ref becomes stale.
+	gitBare(t, bareDir, "branch", "-D", "custom/feature")
+
+	r := rimbaSuccess(t, repo, "clean")
+	assertContains(t, r.Stdout, "origin/custom/feature")
+
+	// Verify a subsequent fetch --prune emits no "[deleted]" line.
+	fetchCmd := exec.Command("git", "-C", repo, "fetch", "--prune")
+	fetchOut, _ := fetchCmd.CombinedOutput()
+	if strings.Contains(string(fetchOut), "[deleted]") {
+		t.Errorf("expected no [deleted] after rimba clean, got: %s", fetchOut)
+	}
 }


### PR DESCRIPTION
## Summary

- `cleanRemotePrune` and `mcpCleanPrune` now enumerate **all configured remotes** via `git.ListRemotes` instead of hardcoding `"origin"`.
- Per-remote prune failures warn to stderr and continue; the overall command still exits 0.
- New git-layer primitives: `ListRemotes`, `RemoteFailure`, `PruneRemotes` (typed, independently testable).
- `RemoteExists` is unchanged — still used by `add_pr_worktree.go`.
- `Long` description and `docs/commands.md` updated to reflect the broadened scope.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

### Type-tailored checks (fix)

- [x] Reproduced original bug: repo with `upstream` remote silently skipped prune — now pruned correctly.
- [x] `TestCleanPrunesNonOriginRemote` (e2e): rename `origin` → `upstream`, push/delete branch, `rimba clean` → `Pruned remote-tracking refs: upstream/<branch>`.
- [x] `TestCleanPrunesCustomRefspec` (e2e): custom `remote.origin.fetch` refspec; stale ref pruned; subsequent `git fetch --prune` reports nothing deleted.
- [x] `TestCleanRemotePrunePartialFailure` (unit): one remote fails → warning on stderr, surviving refs reported, exit 0.
- [x] `TestCleanRemotePruneNoRemotes` (unit): no remotes → `"No remotes; skipped remote-ref prune."`.
- [x] `TestMcpCleanPruneMultiRemote` / `TestMcpCleanPrunePartialFailure` (unit): MCP path has full parity.
- [x] Coverage ≥ 97% (`make test-coverage` → 97.3%).

## Issue

Closes #219
