### PR TITLE
[chore] pin go1.26.3 toolchain, harden vuln gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - uses: actions/cache@v5
         with:
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - name: Run tests with coverage
         run: make test-coverage
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - run: make build
 
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - run: make test-e2e
 
@@ -71,20 +71,17 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - run: make test-race
 
   vuln:
     runs-on: ubuntu-latest
-    # TODO: remove continue-on-error once go.mod toolchain is bumped to ≥go1.26.1
-    # to resolve stdlib CVEs (GO-2026-4599 etc.) and gate is confirmed clean.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
       - uses: goreleaser/goreleaser-action@v7
         with:
           args: release --clean

--- a/cmd/status_detail_test.go
+++ b/cmd/status_detail_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
 	"github.com/lugassawan/rimba/internal/termcolor"
-	"github.com/lugassawan/rimba/testutil"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +42,7 @@ func TestFormatSizeCell(t *testing.T) {
 	if got := formatSizeCell(operations.StatusEntry{SizeBytes: nil}, p); got != "?" {
 		t.Errorf("nil sizeBytes cell = %q, want '?'", got)
 	}
-	if got := formatSizeCell(operations.StatusEntry{SizeBytes: testutil.Ptr(int64(2048))}, p); got != "2.0KB" {
+	if got := formatSizeCell(operations.StatusEntry{SizeBytes: new(int64(2048))}, p); got != "2.0KB" {
 		t.Errorf("2048-byte cell = %q, want '2.0KB'", got)
 	}
 }
@@ -54,7 +53,7 @@ func TestFormatRecentCell(t *testing.T) {
 	if got := formatRecentCell(operations.StatusEntry{Recent7D: nil}, p); got != "?" {
 		t.Errorf("nil recent7D cell = %q, want '?'", got)
 	}
-	if got := formatRecentCell(operations.StatusEntry{Recent7D: testutil.Ptr(42)}, p); got != "42" {
+	if got := formatRecentCell(operations.StatusEntry{Recent7D: new(42)}, p); got != "42" {
 		t.Errorf("recent7D=42 cell = %q, want '42'", got)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/mark3labs/mcp-go v0.54.0
 	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 )
 
 require (
@@ -15,7 +16,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/text v0.14.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lugassawan/rimba
 
-go 1.25.7
+go 1.26.3
 
 require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/internal/operations/footprint_test.go
+++ b/internal/operations/footprint_test.go
@@ -5,11 +5,10 @@ import (
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/operations"
-	"github.com/lugassawan/rimba/testutil"
 )
 
 func TestBuildDiskFootprint(t *testing.T) {
-	sizes := []*int64{testutil.Ptr(int64(1000)), testutil.Ptr(int64(500)), nil}
+	sizes := []*int64{new(int64(1000)), new(int64(500)), nil}
 	fp := operations.BuildDiskFootprint(sizes, 10_000, nil)
 
 	if fp.MainBytes != 10_000 || fp.WorktreesBytes != 1500 || fp.TotalBytes != 11_500 {
@@ -22,7 +21,7 @@ func TestBuildDiskFootprint(t *testing.T) {
 
 func TestBuildDiskFootprintMainError(t *testing.T) {
 	want := errors.New("permission denied")
-	fp := operations.BuildDiskFootprint([]*int64{testutil.Ptr(int64(200))}, 0, want)
+	fp := operations.BuildDiskFootprint([]*int64{new(int64(200))}, 0, want)
 
 	if fp.MainBytes != 0 {
 		t.Errorf("MainBytes = %d, want 0 when MainErr != nil", fp.MainBytes)

--- a/testutil/ptr.go
+++ b/testutil/ptr.go
@@ -1,6 +1,8 @@
 package testutil
 
 // Ptr returns a pointer to v — useful in tests for constructing *T literals inline.
+// Uses Go 1.26 new(expr) form (module minimum ≥ 1.26.3); //go:fix inline lets
+// tooling rewrite call-sites automatically.
 //
 //go:fix inline
 func Ptr[T any](v T) *T { return new(v) }

--- a/testutil/ptr.go
+++ b/testutil/ptr.go
@@ -1,4 +1,6 @@
 package testutil
 
 // Ptr returns a pointer to v — useful in tests for constructing *T literals inline.
-func Ptr[T any](v T) *T { return &v }
+//
+//go:fix inline
+func Ptr[T any](v T) *T { return new(v) }


### PR DESCRIPTION
## Summary

- Bump `go.mod` from `go 1.25.7` → `go 1.26.3` to fix four stdlib CVEs reachable through the auto-updater's TLS/cert path: GO-2026-4599, GO-2026-4600, GO-2026-4601, GO-2026-4870
- Replace `go-version: stable` with `go-version-file: go.mod` in all 7 `setup-go` steps (6 in `ci.yml`, 1 in `release.yml`) — `go.mod` becomes the single source of truth for the toolchain version
- Remove `continue-on-error: true` and its TODO comment from the `vuln` job — govulncheck is now a true blocking gate (`No vulnerabilities found` confirmed locally)
- Apply Go 1.26 `modernize/newexpr` lint fixes: `testutil.Ptr` marked `//go:fix inline`, callsites inlined to `new(v)`, unused imports removed

## Test Plan

- [x] Unit tests pass (`make test`) — 1843 tests, 26 packages
- [x] Linter passes (`make lint`) — 0 issues under go1.26.3
- [x] E2E tests pass (`make test-e2e`)
- [x] `govulncheck ./...` — `No vulnerabilities found`
- [x] `go build ./...` — clean under go1.26.3 (auto-fetched via GOTOOLCHAIN=auto)

### Type-tailored checks ([chore])

- [ ] No application behaviour changed — only toolchain, CI config, and test-utility cosmetics
- [ ] `go.sum` unchanged — no new third-party dependencies introduced
- [ ] Release workflow unchanged in behaviour — only `go-version` key renamed

## Issue

Closes #221
