### PR TITLE
[feat] idempotent clean --merged + delete remote branch (#231)

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -21,6 +21,8 @@ const (
 	hintDryRunPrune = "Preview what would be pruned without making changes"
 	hintDryRunClean = "Preview what would be removed without making changes"
 	hintForce       = "Skip confirmation prompt"
+
+	remoteOrigin = "origin"
 )
 
 var cleanCmd = &cobra.Command{
@@ -148,10 +150,11 @@ func cleanResolveAndHint(cmd *cobra.Command, r git.Runner, entries []hintEntry) 
 
 // cleanStrategy describes what differs between the merged and stale clean modes.
 type cleanStrategy struct {
-	label      string
-	spinnerMsg string
-	emptyMsg   string
-	summaryFmt string
+	label        string
+	spinnerMsg   string
+	emptyMsg     string
+	summaryFmt   string
+	deleteRemote bool // true for merged mode: also deletes the remote branch
 	// preFind runs before find and owns the spinner; nil means runClean starts it.
 	preFind func(*cobra.Command, git.Runner, *spinner.Spinner) error
 	find    func(git.Runner) ([]operations.CleanCandidate, []string, error)
@@ -198,7 +201,7 @@ func runClean(cmd *cobra.Command, r git.Runner, s cleanStrategy) error {
 		return nil
 	}
 
-	removed := cleanRemoveCandidates(cmd, r, sp, candidates)
+	removed := cleanRemoveCandidates(cmd, r, sp, candidates, s.deleteRemote)
 	fmt.Fprintf(cmd.OutOrStdout(), s.summaryFmt, removed)
 	return nil
 }
@@ -212,12 +215,14 @@ func cleanMerged(cmd *cobra.Command, r git.Runner) error {
 		return err
 	}
 
+	remotePresent := git.RemoteExists(r, remoteOrigin)
 	var mergeRef string
 	return runClean(cmd, r, cleanStrategy{
-		label:      "merged",
-		spinnerMsg: "Analyzing branches...",
-		emptyMsg:   "No merged worktrees found.",
-		summaryFmt: "Cleaned %d merged worktree(s).\n",
+		label:        "merged",
+		spinnerMsg:   "Analyzing branches...",
+		emptyMsg:     "No merged worktrees found.",
+		summaryFmt:   "Cleaned %d merged worktree(s).\n",
+		deleteRemote: true,
 		preFind: func(c *cobra.Command, rr git.Runner, sp *spinner.Spinner) error {
 			mergeRef = cleanFetchMergeRef(c, rr, sp, mainBranch)
 			return nil
@@ -230,7 +235,7 @@ func cleanMerged(cmd *cobra.Command, r git.Runner) error {
 			return result.Candidates, result.Warnings, nil
 		},
 		printRows: func(candidates []operations.CleanCandidate) {
-			printMergedCandidates(cmd, candidates)
+			printMergedCandidates(cmd, candidates, remotePresent)
 		},
 	})
 }
@@ -248,10 +253,11 @@ func cleanStale(cmd *cobra.Command, r git.Runner) error {
 	staleDays, _ := cmd.Flags().GetInt(flagStaleDays)
 	var staleCandidates []operations.StaleCandidate
 	return runClean(cmd, r, cleanStrategy{
-		label:      "stale",
-		spinnerMsg: "Analyzing worktree activity...",
-		emptyMsg:   "No stale worktrees found.",
-		summaryFmt: "Cleaned %d stale worktree(s).\n",
+		label:        "stale",
+		spinnerMsg:   "Analyzing worktree activity...",
+		emptyMsg:     "No stale worktrees found.",
+		summaryFmt:   "Cleaned %d stale worktree(s).\n",
+		deleteRemote: false,
 		find: func(rr git.Runner) ([]operations.CleanCandidate, []string, error) {
 			result, err := operations.FindStaleCandidates(rr, mainBranch, staleDays)
 			if err != nil {
@@ -270,17 +276,17 @@ func cleanStale(cmd *cobra.Command, r git.Runner) error {
 // Falls back to mainBranch with a warning if fetch fails.
 func cleanFetchMergeRef(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, mainBranch string) string {
 	s.Start("Fetching from origin...")
-	if err := git.Fetch(r, "origin"); err != nil {
+	if err := git.Fetch(r, remoteOrigin); err != nil {
 		s.Stop()
 		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: fetch failed (no remote?): continuing with local state\n")
 		return mainBranch
 	}
-	return "origin/" + mainBranch
+	return remoteOrigin + "/" + mainBranch
 }
 
-func cleanRemoveCandidates(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, candidates []operations.CleanCandidate) int {
+func cleanRemoveCandidates(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, candidates []operations.CleanCandidate, deleteRemote bool) int {
 	s.Start("Removing worktrees...")
-	items := operations.RemoveCandidates(r, candidates, func(msg string) {
+	items := operations.RemoveCandidates(r, candidates, deleteRemote, func(msg string) {
 		s.Update(msg)
 	})
 	s.Stop()
@@ -296,12 +302,15 @@ func flattenStaleCandidates(candidates []operations.StaleCandidate) []operations
 	return out
 }
 
-func printMergedCandidates(cmd *cobra.Command, candidates []operations.CleanCandidate) {
+func printMergedCandidates(cmd *cobra.Command, candidates []operations.CleanCandidate, remotePresent bool) {
 	prefixes := resolver.AllPrefixes()
 	fmt.Fprintln(cmd.OutOrStdout(), "Merged worktrees:")
 	for _, c := range candidates {
 		task, _ := resolver.PureTaskFromBranch(c.Branch, prefixes)
 		fmt.Fprintf(cmd.OutOrStdout(), "  %s (%s)\n", task, c.Branch)
+		if remotePresent {
+			fmt.Fprintf(cmd.OutOrStdout(), "    will delete remote: %s/%s\n", remoteOrigin, c.Branch)
+		}
 	}
 }
 
@@ -340,6 +349,12 @@ func printCleanedItems(cmd *cobra.Command, items []operations.CleanedItem) {
 			fmt.Fprintf(cmd.OutOrStdout(), "Deleted branch: %s\n", item.Branch)
 		} else {
 			fmt.Fprintln(cmd.OutOrStdout(), item.Error)
+		}
+		if item.RemoteDeleted {
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted remote branch: %s/%s\n", remoteOrigin, item.Branch)
+		} else if item.RemoteError != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "Failed to delete remote branch %s/%s\nTo delete remote: git push %s --delete %s\n",
+				remoteOrigin, item.Branch, remoteOrigin, item.Branch)
 		}
 	}
 }

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -148,11 +148,11 @@ func cleanResolveAndHint(cmd *cobra.Command, r git.Runner, entries []hintEntry) 
 
 // cleanStrategy describes what differs between the merged and stale clean modes.
 type cleanStrategy struct {
-	label        string
-	spinnerMsg   string
-	emptyMsg     string
-	summaryFmt   string
-	deleteRemote bool // true for merged mode: also deletes the remote branch
+	label         string
+	spinnerMsg    string
+	emptyMsg      string
+	summaryFmt    string
+	originPresent bool // pre-resolved: origin exists AND remote deletion is wanted
 	// preFind runs before find and owns the spinner; nil means runClean starts it.
 	preFind func(*cobra.Command, git.Runner, *spinner.Spinner) error
 	find    func(git.Runner) ([]operations.CleanCandidate, []string, error)
@@ -199,7 +199,7 @@ func runClean(cmd *cobra.Command, r git.Runner, s cleanStrategy) error {
 		return nil
 	}
 
-	removed := cleanRemoveCandidates(cmd, r, sp, candidates, s.deleteRemote)
+	removed := cleanRemoveCandidates(cmd, r, sp, candidates, s.originPresent)
 	fmt.Fprintf(cmd.OutOrStdout(), s.summaryFmt, removed)
 	return nil
 }
@@ -216,11 +216,11 @@ func cleanMerged(cmd *cobra.Command, r git.Runner) error {
 	remotePresent := git.RemoteExists(r, git.DefaultRemote)
 	var mergeRef string
 	return runClean(cmd, r, cleanStrategy{
-		label:        "merged",
-		spinnerMsg:   "Analyzing branches...",
-		emptyMsg:     "No merged worktrees found.",
-		summaryFmt:   "Cleaned %d merged worktree(s).\n",
-		deleteRemote: true,
+		label:         "merged",
+		spinnerMsg:    "Analyzing branches...",
+		emptyMsg:      "No merged worktrees found.",
+		summaryFmt:    "Cleaned %d merged worktree(s).\n",
+		originPresent: remotePresent, // shared with printMergedCandidates — single probe
 		preFind: func(c *cobra.Command, rr git.Runner, sp *spinner.Spinner) error {
 			mergeRef = cleanFetchMergeRef(c, rr, sp, mainBranch)
 			return nil
@@ -251,11 +251,11 @@ func cleanStale(cmd *cobra.Command, r git.Runner) error {
 	staleDays, _ := cmd.Flags().GetInt(flagStaleDays)
 	var staleCandidates []operations.StaleCandidate
 	return runClean(cmd, r, cleanStrategy{
-		label:        "stale",
-		spinnerMsg:   "Analyzing worktree activity...",
-		emptyMsg:     "No stale worktrees found.",
-		summaryFmt:   "Cleaned %d stale worktree(s).\n",
-		deleteRemote: false,
+		label:         "stale",
+		spinnerMsg:    "Analyzing worktree activity...",
+		emptyMsg:      "No stale worktrees found.",
+		summaryFmt:    "Cleaned %d stale worktree(s).\n",
+		originPresent: false, // stale mode is local-only
 		find: func(rr git.Runner) ([]operations.CleanCandidate, []string, error) {
 			result, err := operations.FindStaleCandidates(rr, mainBranch, staleDays)
 			if err != nil {
@@ -273,7 +273,7 @@ func cleanStale(cmd *cobra.Command, r git.Runner) error {
 // cleanFetchMergeRef fetches from origin and returns the ref to diff against.
 // Falls back to mainBranch with a warning if fetch fails.
 func cleanFetchMergeRef(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, mainBranch string) string {
-	s.Start("Fetching from origin...")
+	s.Start("Fetching from " + git.DefaultRemote + "...")
 	if err := git.Fetch(r, git.DefaultRemote); err != nil {
 		s.Stop()
 		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: fetch failed (no remote?): continuing with local state\n")
@@ -282,9 +282,9 @@ func cleanFetchMergeRef(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, ma
 	return git.DefaultRemote + "/" + mainBranch
 }
 
-func cleanRemoveCandidates(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, candidates []operations.CleanCandidate, deleteRemote bool) int {
+func cleanRemoveCandidates(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, candidates []operations.CleanCandidate, originPresent bool) int {
 	s.Start("Removing worktrees...")
-	items := operations.RemoveCandidates(r, candidates, deleteRemote, func(msg string) {
+	items := operations.RemoveCandidates(r, candidates, originPresent, func(msg string) {
 		s.Update(msg)
 	})
 	s.Stop()

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -21,8 +21,6 @@ const (
 	hintDryRunPrune = "Preview what would be pruned without making changes"
 	hintDryRunClean = "Preview what would be removed without making changes"
 	hintForce       = "Skip confirmation prompt"
-
-	remoteOrigin = "origin"
 )
 
 var cleanCmd = &cobra.Command{
@@ -215,7 +213,7 @@ func cleanMerged(cmd *cobra.Command, r git.Runner) error {
 		return err
 	}
 
-	remotePresent := git.RemoteExists(r, remoteOrigin)
+	remotePresent := git.RemoteExists(r, git.DefaultRemote)
 	var mergeRef string
 	return runClean(cmd, r, cleanStrategy{
 		label:        "merged",
@@ -276,12 +274,12 @@ func cleanStale(cmd *cobra.Command, r git.Runner) error {
 // Falls back to mainBranch with a warning if fetch fails.
 func cleanFetchMergeRef(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, mainBranch string) string {
 	s.Start("Fetching from origin...")
-	if err := git.Fetch(r, remoteOrigin); err != nil {
+	if err := git.Fetch(r, git.DefaultRemote); err != nil {
 		s.Stop()
 		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: fetch failed (no remote?): continuing with local state\n")
 		return mainBranch
 	}
-	return remoteOrigin + "/" + mainBranch
+	return git.DefaultRemote + "/" + mainBranch
 }
 
 func cleanRemoveCandidates(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, candidates []operations.CleanCandidate, deleteRemote bool) int {
@@ -309,7 +307,7 @@ func printMergedCandidates(cmd *cobra.Command, candidates []operations.CleanCand
 		task, _ := resolver.PureTaskFromBranch(c.Branch, prefixes)
 		fmt.Fprintf(cmd.OutOrStdout(), "  %s (%s)\n", task, c.Branch)
 		if remotePresent {
-			fmt.Fprintf(cmd.OutOrStdout(), "    will delete remote: %s/%s\n", remoteOrigin, c.Branch)
+			fmt.Fprintf(cmd.OutOrStdout(), "    will delete remote: %s/%s\n", git.DefaultRemote, c.Branch)
 		}
 	}
 }
@@ -347,14 +345,14 @@ func printCleanedItems(cmd *cobra.Command, items []operations.CleanedItem) {
 		fmt.Fprintf(cmd.OutOrStdout(), "Removed worktree: %s\n", item.Path)
 		if item.BranchDeleted {
 			fmt.Fprintf(cmd.OutOrStdout(), "Deleted branch: %s\n", item.Branch)
-		} else {
+		} else if item.Error != nil {
 			fmt.Fprintln(cmd.OutOrStdout(), item.Error)
 		}
 		if item.RemoteDeleted {
-			fmt.Fprintf(cmd.OutOrStdout(), "Deleted remote branch: %s/%s\n", remoteOrigin, item.Branch)
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted remote branch: %s/%s\n", git.DefaultRemote, item.Branch)
 		} else if item.RemoteError != nil {
 			fmt.Fprintf(cmd.OutOrStdout(), "Failed to delete remote branch %s/%s\nTo delete remote: git push %s --delete %s\n",
-				remoteOrigin, item.Branch, remoteOrigin, item.Branch)
+				git.DefaultRemote, item.Branch, git.DefaultRemote, item.Branch)
 		}
 	}
 }

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -225,7 +225,7 @@ func TestPrintMergedCandidates(t *testing.T) {
 		{Path: pathWtDone, Branch: branchDone},
 		{Path: "/wt/bugfix-old", Branch: "bugfix/old"},
 	}
-	printMergedCandidates(cmd, candidates)
+	printMergedCandidates(cmd, candidates, false)
 
 	out := buf.String()
 	if !strings.Contains(out, "Merged worktrees:") {

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -18,12 +18,16 @@ func BranchExists(r Runner, branch string) bool {
 }
 
 // DeleteBranch deletes a local branch. If force is true, uses -D instead of -d.
+// Already-gone branches are treated as success (idempotent).
 func DeleteBranch(r Runner, branch string, force bool) error {
 	flag := "-d"
 	if force {
 		flag = "-D"
 	}
 	_, err := r.Run("branch", flag, branch)
+	if err != nil && strings.Contains(err.Error(), "branch '") && strings.Contains(err.Error(), "not found") {
+		return nil // already gone — idempotent
+	}
 	return err
 }
 

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -25,6 +25,7 @@ func DeleteBranch(r Runner, branch string, force bool) error {
 		flag = "-D"
 	}
 	_, err := r.Run("branch", flag, branch)
+	// git emits "error: branch 'X' not found." — assumes LC_ALL=C or English git.
 	if err != nil && strings.Contains(err.Error(), "branch '") && strings.Contains(err.Error(), "not found") {
 		return nil // already gone — idempotent
 	}

--- a/internal/git/mock_runner_test.go
+++ b/internal/git/mock_runner_test.go
@@ -182,6 +182,40 @@ func TestDeleteBranchForce(t *testing.T) {
 	}
 }
 
+func TestDeleteBranchNotFoundIsIdempotent(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("error: branch 'gone' not found.")
+		},
+	}
+	if err := DeleteBranch(r, "gone", false); err != nil {
+		t.Fatalf("expected nil for already-gone branch, got: %v", err)
+	}
+}
+
+func TestDeleteBranchOtherErrorPropagates(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("error: Cannot delete branch 'main' checked out at '/repo'")
+		},
+	}
+	if err := DeleteBranch(r, "main", false); err == nil {
+		t.Fatal("expected non-nil error for checked-out branch")
+	}
+}
+
+func TestDeleteBranchNotFoundWithoutBranchKeywordPropagates(t *testing.T) {
+	// "not found" alone (no "branch '") must NOT be swallowed — tight substring match.
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("ref not found")
+		},
+	}
+	if err := DeleteBranch(r, "gone", false); err == nil {
+		t.Fatal("expected non-nil error when 'branch \\'' is absent from the message")
+	}
+}
+
 func TestRenameBranch(t *testing.T) {
 	var captured []string
 	r := &mockRunner{

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -47,6 +47,7 @@ func DeleteRemoteBranch(r Runner, remote, branch string) error {
 	if err == nil {
 		return nil
 	}
+	// git emits "error: remote ref does not exist" — assumes LC_ALL=C or English git.
 	if strings.Contains(err.Error(), "remote ref does not exist") {
 		return nil
 	}

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -37,6 +37,22 @@ func RemotePrune(r Runner, remote string, dryRun bool) ([]string, error) {
 	return parsePrunedRefs(out), nil
 }
 
+// DeleteRemoteBranch deletes a branch on the given remote.
+// An already-gone remote ref is treated as success (idempotent).
+func DeleteRemoteBranch(r Runner, remote, branch string) error {
+	_, err := r.Run("push", remote, "--delete", branch)
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(err.Error(), "remote ref does not exist") {
+		return nil
+	}
+	return errhint.WithFix(
+		fmt.Errorf("delete remote branch %s/%s: %w", remote, branch, err),
+		"check remote access, then run: git push "+remote+" --delete "+branch,
+	)
+}
+
 // AddRemote adds a new remote with the given name and URL.
 func AddRemote(r Runner, name, url string) error {
 	_, err := r.Run("remote", "add", name, url)

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -13,6 +13,9 @@ type RemoteFailure struct {
 	Err    error
 }
 
+// DefaultRemote is the conventional name for the primary upstream remote.
+const DefaultRemote = "origin"
+
 // RemoteExists reports whether a remote with the given name is configured.
 func RemoteExists(r Runner, name string) bool {
 	_, err := r.Run("remote", "get-url", name)

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -7,6 +7,57 @@ import (
 	"testing"
 )
 
+func TestDeleteRemoteBranchSuccess(t *testing.T) {
+	var captured []string
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			captured = args
+			return "", nil
+		},
+	}
+	if err := DeleteRemoteBranch(r, "origin", "feature/done"); err != nil {
+		t.Fatalf("DeleteRemoteBranch: %v", err)
+	}
+	want := []string{"push", "origin", "--delete", "feature/done"}
+	if len(captured) != len(want) {
+		t.Fatalf("args = %v, want %v", captured, want)
+	}
+	for i, w := range want {
+		if captured[i] != w {
+			t.Errorf("args[%d] = %q, want %q", i, captured[i], w)
+		}
+	}
+}
+
+func TestDeleteRemoteBranchRefGoneIsIdempotent(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("error: remote ref does not exist")
+		},
+	}
+	if err := DeleteRemoteBranch(r, "origin", "gone-branch"); err != nil {
+		t.Fatalf("expected nil for already-gone remote ref, got: %v", err)
+	}
+}
+
+func TestDeleteRemoteBranchFailure(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("connection refused")
+		},
+	}
+	err := DeleteRemoteBranch(r, "origin", "feature/x")
+	if err == nil {
+		t.Fatal("expected non-nil error for remote failure")
+	}
+	if !strings.Contains(err.Error(), "delete remote branch") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "delete remote branch")
+	}
+	if !strings.Contains(err.Error(), "To fix:") {
+		t.Errorf("error = %q, want it to contain hint", err.Error())
+	}
+}
+
 func TestRemoteExistsTrue(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -10,8 +10,6 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-const mcpRemoteOrigin = "origin"
-
 func registerCleanTool(s *server.MCPServer, hctx *HandlerContext) {
 	tool := mcp.NewTool("clean",
 		mcp.WithDescription("Clean up stale worktree references, merged branches, or stale worktrees"),
@@ -92,8 +90,8 @@ func mcpCleanMerged(r git.Runner, hctx *HandlerContext, dryRun bool) (*mcp.CallT
 
 	// Fetch latest (non-fatal)
 	mergeRef := mainBranch
-	if err := git.Fetch(r, mcpRemoteOrigin); err == nil {
-		mergeRef = mcpRemoteOrigin + "/" + mainBranch
+	if err := git.Fetch(r, git.DefaultRemote); err == nil {
+		mergeRef = git.DefaultRemote + "/" + mainBranch
 	}
 
 	mergedResult, err := operations.FindMergedCandidates(r, mergeRef, mainBranch)
@@ -121,7 +119,7 @@ func mcpCleanMerged(r git.Runner, hctx *HandlerContext, dryRun bool) (*mcp.CallT
 	for i, item := range opItems {
 		items[i] = cleanedItem{Branch: item.Branch, Path: item.Path, RemoteDeleted: item.RemoteDeleted}
 		if item.RemoteError != nil {
-			warnings = append(warnings, fmt.Sprintf("failed to delete remote branch %s/%s: %v", mcpRemoteOrigin, item.Branch, item.RemoteError))
+			warnings = append(warnings, fmt.Sprintf("failed to delete remote branch %s/%s: %v", git.DefaultRemote, item.Branch, item.RemoteError))
 		}
 	}
 	return marshalResult(cleanResult{

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -10,6 +10,8 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+const mcpRemoteOrigin = "origin"
+
 func registerCleanTool(s *server.MCPServer, hctx *HandlerContext) {
 	tool := mcp.NewTool("clean",
 		mcp.WithDescription("Clean up stale worktree references, merged branches, or stale worktrees"),
@@ -90,8 +92,8 @@ func mcpCleanMerged(r git.Runner, hctx *HandlerContext, dryRun bool) (*mcp.CallT
 
 	// Fetch latest (non-fatal)
 	mergeRef := mainBranch
-	if err := git.Fetch(r, "origin"); err == nil {
-		mergeRef = "origin/" + mainBranch
+	if err := git.Fetch(r, mcpRemoteOrigin); err == nil {
+		mergeRef = mcpRemoteOrigin + "/" + mainBranch
 	}
 
 	mergedResult, err := operations.FindMergedCandidates(r, mergeRef, mainBranch)
@@ -113,16 +115,20 @@ func mcpCleanMerged(r git.Runner, hctx *HandlerContext, dryRun bool) (*mcp.CallT
 	}
 
 	// Force mode: no confirmation prompts
-	opItems := operations.RemoveCandidates(r, mergedResult.Candidates, nil)
+	opItems := operations.RemoveCandidates(r, mergedResult.Candidates, true, nil)
+	warnings := mergedResult.Warnings
 	items := make([]cleanedItem, len(opItems))
 	for i, item := range opItems {
-		items[i] = cleanedItem{Branch: item.Branch, Path: item.Path}
+		items[i] = cleanedItem{Branch: item.Branch, Path: item.Path, RemoteDeleted: item.RemoteDeleted}
+		if item.RemoteError != nil {
+			warnings = append(warnings, fmt.Sprintf("failed to delete remote branch %s/%s: %v", mcpRemoteOrigin, item.Branch, item.RemoteError))
+		}
 	}
 	return marshalResult(cleanResult{
 		Mode:     "merged",
 		DryRun:   false,
 		Removed:  items,
-		Warnings: mergedResult.Warnings,
+		Warnings: warnings,
 	})
 }
 
@@ -155,7 +161,7 @@ func mcpCleanStale(r git.Runner, hctx *HandlerContext, dryRun bool, staleDays in
 		toRemove[i] = c.CleanCandidate
 	}
 
-	opItems := operations.RemoveCandidates(r, toRemove, nil)
+	opItems := operations.RemoveCandidates(r, toRemove, false, nil)
 	items := make([]cleanedItem, len(opItems))
 	for i, item := range opItems {
 		items[i] = cleanedItem{Branch: item.Branch, Path: item.Path}

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -112,8 +112,10 @@ func mcpCleanMerged(r git.Runner, hctx *HandlerContext, dryRun bool) (*mcp.CallT
 		})
 	}
 
-	// Force mode: no confirmation prompts
-	opItems := operations.RemoveCandidates(r, mergedResult.Candidates, true, nil)
+	// Force mode: no confirmation prompts. Probe origin once and pass the result
+	// directly so RemoveCandidates does not re-issue git remote get-url per candidate.
+	originPresent := git.RemoteExists(r, git.DefaultRemote)
+	opItems := operations.RemoveCandidates(r, mergedResult.Candidates, originPresent, nil)
 	warnings := mergedResult.Warnings
 	items := make([]cleanedItem, len(opItems))
 	for i, item := range opItems {

--- a/internal/mcp/tool_clean_test.go
+++ b/internal/mcp/tool_clean_test.go
@@ -740,6 +740,92 @@ func TestMcpCleanPruneMultiRemote(t *testing.T) {
 	}
 }
 
+// newCleanMergedWithRemoteRunner builds a runner for merged-clean tests with remote support.
+// If pushErr is nil, push --delete succeeds; otherwise it returns pushErr.
+// pushCalled is incremented when push --delete is invoked (nil = ignore).
+func newCleanMergedWithRemoteRunner(porcelain, mergedBranches string, pushErr error, pushCalled *int) *mockRunner {
+	return &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitFetch {
+				return "", nil
+			}
+			if len(args) >= 3 && args[0] == gitRemote && args[1] == "get-url" {
+				return "https://github.com/owner/repo.git", nil
+			}
+			if len(args) >= 3 && args[0] == "push" && args[2] == "--delete" {
+				if pushCalled != nil {
+					*pushCalled++
+				}
+				return "", pushErr
+			}
+			key := mockCmdKey(args)
+			switch key {
+			case gitBranch + " " + gitMerged:
+				return mergedBranches, nil
+			case gitWorktree + " " + gitList:
+				return porcelain, nil
+			case gitWorktree + " " + gitRemove:
+				return "", nil
+			}
+			if isBranchDelete(args) {
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+}
+
+func TestCleanToolMergedDeletesRemoteBranch(t *testing.T) {
+	porcelain := worktreePorcelain(
+		struct{ path, branch string }{"/repo", "main"},
+		struct{ path, branch string }{"/wt/feature-done", branchFeatureDone},
+	)
+	pushCalled := 0
+	r := newCleanMergedWithRemoteRunner(porcelain, mergedFeatureDoneOutput, nil, &pushCalled)
+
+	result := callTool(t, handleClean(testContext(r)), map[string]any{"mode": modeMerged})
+	data := unmarshalJSON[cleanResult](t, result)
+	if len(data.Removed) != 1 {
+		t.Fatalf("expected 1 removed, got %d", len(data.Removed))
+	}
+	if !data.Removed[0].RemoteDeleted {
+		t.Error("expected remote_deleted=true in result")
+	}
+	if pushCalled == 0 {
+		t.Error("expected git push --delete to be called")
+	}
+}
+
+func TestCleanToolMergedRemoteFailureSurfacesInWarnings(t *testing.T) {
+	porcelain := worktreePorcelain(
+		struct{ path, branch string }{"/repo", "main"},
+		struct{ path, branch string }{"/wt/feature-done", branchFeatureDone},
+	)
+	r := newCleanMergedWithRemoteRunner(porcelain, mergedFeatureDoneOutput, errors.New("connection refused"), nil)
+
+	result := callTool(t, handleClean(testContext(r)), map[string]any{"mode": modeMerged})
+	if result.IsError {
+		t.Fatal("expected success result even when remote delete fails")
+	}
+	data := unmarshalJSON[cleanResult](t, result)
+	if len(data.Warnings) == 0 {
+		t.Error("expected Warnings to be populated when remote delete fails")
+	}
+	found := false
+	for _, w := range data.Warnings {
+		if strings.Contains(w, "remote") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Warnings = %v, expected an entry mentioning 'remote'", data.Warnings)
+	}
+	if len(data.Removed) != 1 || data.Removed[0].RemoteDeleted {
+		t.Error("expected remote_deleted=false when push --delete fails")
+	}
+}
+
 func TestMcpCleanPrunePartialFailure(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -95,6 +95,7 @@ type cleanResult struct {
 
 // cleanedItem represents a single cleaned branch/worktree.
 type cleanedItem struct {
-	Branch string `json:"branch"`
-	Path   string `json:"path,omitempty"`
+	Branch        string `json:"branch"`
+	Path          string `json:"path,omitempty"`
+	RemoteDeleted bool   `json:"remote_deleted,omitempty"`
 }

--- a/internal/operations/clean.go
+++ b/internal/operations/clean.go
@@ -113,12 +113,11 @@ func FindStaleCandidates(r git.Runner, mainBranch string, staleDays int) (StaleR
 }
 
 // RemoveCandidates removes worktrees and their branches, returning the outcome of each.
-// When deleteRemote is true (merged mode), it also deletes the branch on origin after
-// the worktree is successfully removed.
-func RemoveCandidates(r git.Runner, candidates []CleanCandidate, deleteRemote bool, onProgress progress.Func) []CleanedItem {
-	// Probe origin once before the loop — eliminates N redundant git remote get-url
-	// calls and closes the TOCTOU gap between the CLI dry-run preview and actual deletion.
-	originPresent := deleteRemote && git.RemoteExists(r, git.DefaultRemote)
+// When originPresent is true the remote branch is also deleted after the worktree is
+// removed. Callers are responsible for probing RemoteExists before invoking — passing
+// a pre-resolved boolean avoids redundant git remote get-url calls per candidate and
+// ensures the CLI dry-run preview and actual deletion share a single probe result.
+func RemoveCandidates(r git.Runner, candidates []CleanCandidate, originPresent bool, onProgress progress.Func) []CleanedItem {
 	items := make([]CleanedItem, 0, len(candidates))
 	for _, c := range candidates {
 		progress.Notifyf(onProgress, "Removing %s...", c.Branch)

--- a/internal/operations/clean.go
+++ b/internal/operations/clean.go
@@ -27,6 +27,8 @@ type CleanedItem struct {
 	Path            string
 	WorktreeRemoved bool
 	BranchDeleted   bool
+	RemoteDeleted   bool  // true if the remote branch was successfully deleted
+	RemoteError     error // non-nil if remote branch deletion failed
 	Error           error // non-nil if removal or branch deletion failed
 }
 
@@ -41,6 +43,8 @@ type StaleResult struct {
 	Candidates []StaleCandidate
 	Warnings   []string
 }
+
+const remoteOrigin = "origin"
 
 // FindMergedCandidates returns worktrees whose branches are merged into mergeRef.
 // It checks both regular merges and squash-merges.
@@ -111,18 +115,36 @@ func FindStaleCandidates(r git.Runner, mainBranch string, staleDays int) (StaleR
 }
 
 // RemoveCandidates removes worktrees and their branches, returning the outcome of each.
-func RemoveCandidates(r git.Runner, candidates []CleanCandidate, onProgress progress.Func) []CleanedItem {
+// When deleteRemote is true (merged mode), it also deletes the branch on origin after
+// the worktree is successfully removed.
+func RemoveCandidates(r git.Runner, candidates []CleanCandidate, deleteRemote bool, onProgress progress.Func) []CleanedItem {
 	items := make([]CleanedItem, 0, len(candidates))
 	for _, c := range candidates {
 		progress.Notifyf(onProgress, "Removing %s...", c.Branch)
 		wtRemoved, brDeleted, err := removeAndCleanup(r, c.Path, c.Branch)
-		items = append(items, CleanedItem{
+		item := CleanedItem{
 			Branch:          c.Branch,
 			Path:            c.Path,
 			WorktreeRemoved: wtRemoved,
 			BranchDeleted:   brDeleted,
 			Error:           err,
-		})
+		}
+		if deleteRemote && wtRemoved {
+			deleteRemoteForItem(r, c.Branch, &item)
+		}
+		items = append(items, item)
 	}
 	return items
+}
+
+// deleteRemoteForItem deletes the remote branch for an item, if origin exists.
+func deleteRemoteForItem(r git.Runner, branch string, item *CleanedItem) {
+	if !git.RemoteExists(r, remoteOrigin) {
+		return
+	}
+	if err := git.DeleteRemoteBranch(r, remoteOrigin, branch); err != nil {
+		item.RemoteError = err
+		return
+	}
+	item.RemoteDeleted = true
 }

--- a/internal/operations/clean.go
+++ b/internal/operations/clean.go
@@ -44,8 +44,6 @@ type StaleResult struct {
 	Warnings   []string
 }
 
-const remoteOrigin = "origin"
-
 // FindMergedCandidates returns worktrees whose branches are merged into mergeRef.
 // It checks both regular merges and squash-merges.
 func FindMergedCandidates(r git.Runner, mergeRef, mainBranch string) (MergedResult, error) {
@@ -118,6 +116,9 @@ func FindStaleCandidates(r git.Runner, mainBranch string, staleDays int) (StaleR
 // When deleteRemote is true (merged mode), it also deletes the branch on origin after
 // the worktree is successfully removed.
 func RemoveCandidates(r git.Runner, candidates []CleanCandidate, deleteRemote bool, onProgress progress.Func) []CleanedItem {
+	// Probe origin once before the loop — eliminates N redundant git remote get-url
+	// calls and closes the TOCTOU gap between the CLI dry-run preview and actual deletion.
+	originPresent := deleteRemote && git.RemoteExists(r, git.DefaultRemote)
 	items := make([]CleanedItem, 0, len(candidates))
 	for _, c := range candidates {
 		progress.Notifyf(onProgress, "Removing %s...", c.Branch)
@@ -129,7 +130,7 @@ func RemoveCandidates(r git.Runner, candidates []CleanCandidate, deleteRemote bo
 			BranchDeleted:   brDeleted,
 			Error:           err,
 		}
-		if deleteRemote && wtRemoved {
+		if originPresent && wtRemoved {
 			deleteRemoteForItem(r, c.Branch, &item)
 		}
 		items = append(items, item)
@@ -137,12 +138,10 @@ func RemoveCandidates(r git.Runner, candidates []CleanCandidate, deleteRemote bo
 	return items
 }
 
-// deleteRemoteForItem deletes the remote branch for an item, if origin exists.
+// deleteRemoteForItem deletes the remote branch on git.DefaultRemote.
+// Caller must verify the remote exists before invoking.
 func deleteRemoteForItem(r git.Runner, branch string, item *CleanedItem) {
-	if !git.RemoteExists(r, remoteOrigin) {
-		return
-	}
-	if err := git.DeleteRemoteBranch(r, remoteOrigin, branch); err != nil {
+	if err := git.DeleteRemoteBranch(r, git.DefaultRemote, branch); err != nil {
 		item.RemoteError = err
 		return
 	}

--- a/internal/operations/clean_test.go
+++ b/internal/operations/clean_test.go
@@ -13,6 +13,7 @@ const (
 	gitCmdLog      = "log"
 	gitCmdWorktree = "worktree"
 	gitSubcmdAdd   = "add"
+	gitCmdPush     = "push"
 )
 
 // porcelainEntries builds porcelain-format output for git worktree list.
@@ -257,7 +258,7 @@ func TestRemoveCandidatesMixedResults(t *testing.T) {
 		{Path: "/wt/c", Branch: "feature/c"},
 	}
 
-	items := RemoveCandidates(r, candidates, nil)
+	items := RemoveCandidates(r, candidates, false, nil)
 	if len(items) != 3 {
 		t.Fatalf("expected 3 items, got %d", len(items))
 	}
@@ -287,7 +288,7 @@ func TestRemoveCandidatesProgressCallbacks(t *testing.T) {
 		{Path: "/wt/b", Branch: "feature/b"},
 	}
 
-	RemoveCandidates(r, candidates, onProgress)
+	RemoveCandidates(r, candidates, false, onProgress)
 	if len(messages) != 2 {
 		t.Fatalf("expected 2 progress messages, got %d", len(messages))
 	}
@@ -379,5 +380,129 @@ func TestFindMergedCandidatesListWorktreesError(t *testing.T) {
 	_, err := FindMergedCandidates(r, "origin/main", branchMain)
 	if err == nil {
 		t.Fatal("expected error when ListWorktrees fails")
+	}
+}
+
+// remoteExistsRun returns a run func that answers "remote get-url origin" successfully.
+func remoteExistsRun(inner func(args ...string) (string, error)) func(args ...string) (string, error) {
+	return func(args ...string) (string, error) {
+		if len(args) >= 3 && args[0] == gitCmdRemote && args[1] == "get-url" {
+			return "https://github.com/owner/repo.git", nil
+		}
+		return inner(args...)
+	}
+}
+
+func TestRemoveCandidatesRemoteDeleteSuccess(t *testing.T) {
+	pushCalled := false
+	r := &mockRunner{
+		run: remoteExistsRun(func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitCmdPush {
+				pushCalled = true
+				return "", nil
+			}
+			// worktree remove and branch delete succeed
+			return "", nil
+		}),
+		runInDir: noopRunInDir,
+	}
+
+	candidates := []CleanCandidate{{Path: "/wt/a", Branch: "feature/a"}}
+	items := RemoveCandidates(r, candidates, true, nil)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if !items[0].RemoteDeleted {
+		t.Error("expected RemoteDeleted=true")
+	}
+	if items[0].RemoteError != nil {
+		t.Errorf("expected nil RemoteError, got: %v", items[0].RemoteError)
+	}
+	if !pushCalled {
+		t.Error("expected git push --delete to be called")
+	}
+}
+
+func TestRemoveCandidatesRemoteDeleteFailureStillCountsItem(t *testing.T) {
+	r := &mockRunner{
+		run: remoteExistsRun(func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitCmdPush {
+				return "", errors.New("connection refused")
+			}
+			return "", nil
+		}),
+		runInDir: noopRunInDir,
+	}
+
+	candidates := []CleanCandidate{{Path: "/wt/a", Branch: "feature/a"}}
+	items := RemoveCandidates(r, candidates, true, nil)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	// worktree was removed successfully
+	if !items[0].WorktreeRemoved {
+		t.Error("expected WorktreeRemoved=true")
+	}
+	if items[0].RemoteDeleted {
+		t.Error("expected RemoteDeleted=false on failure")
+	}
+	if items[0].RemoteError == nil {
+		t.Error("expected non-nil RemoteError")
+	}
+}
+
+func TestRemoveCandidatesNoOriginSkipsRemoteDelete(t *testing.T) {
+	pushCalled := false
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitCmdPush {
+				pushCalled = true
+				return "", nil
+			}
+			// remote get-url fails → no origin
+			if len(args) >= 2 && args[0] == gitCmdRemote && args[1] == "get-url" {
+				return "", errors.New("no such remote")
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	}
+
+	candidates := []CleanCandidate{{Path: "/wt/a", Branch: "feature/a"}}
+	items := RemoveCandidates(r, candidates, true, nil)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].RemoteDeleted {
+		t.Error("expected RemoteDeleted=false when no origin")
+	}
+	if pushCalled {
+		t.Error("expected no push call when origin absent")
+	}
+}
+
+func TestRemoveCandidatesDeleteRemoteFalseSkipsRemote(t *testing.T) {
+	pushCalled := false
+	r := &mockRunner{
+		run: remoteExistsRun(func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitCmdPush {
+				pushCalled = true
+				return "", nil
+			}
+			return "", nil
+		}),
+		runInDir: noopRunInDir,
+	}
+
+	candidates := []CleanCandidate{{Path: "/wt/a", Branch: "feature/a"}}
+	items := RemoveCandidates(r, candidates, false, nil)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0].RemoteDeleted {
+		t.Error("expected RemoteDeleted=false when deleteRemote=false")
+	}
+	if pushCalled {
+		t.Error("expected no push call when deleteRemote=false")
 	}
 }

--- a/internal/operations/clean_test.go
+++ b/internal/operations/clean_test.go
@@ -465,29 +465,3 @@ func TestRemoveCandidatesNoOriginSkipsRemoteDelete(t *testing.T) {
 		t.Error("expected no push call when originPresent=false")
 	}
 }
-
-func TestRemoveCandidatesDeleteRemoteFalseSkipsRemote(t *testing.T) {
-	pushCalled := false
-	r := &mockRunner{
-		run: func(args ...string) (string, error) {
-			if len(args) > 0 && args[0] == gitCmdPush {
-				pushCalled = true
-				return "", nil
-			}
-			return "", nil
-		},
-		runInDir: noopRunInDir,
-	}
-
-	candidates := []CleanCandidate{{Path: "/wt/a", Branch: "feature/a"}}
-	items := RemoveCandidates(r, candidates, false, nil)
-	if len(items) != 1 {
-		t.Fatalf("expected 1 item, got %d", len(items))
-	}
-	if items[0].RemoteDeleted {
-		t.Error("expected RemoteDeleted=false when deleteRemote=false")
-	}
-	if pushCalled {
-		t.Error("expected no push call when deleteRemote=false")
-	}
-}

--- a/internal/operations/clean_test.go
+++ b/internal/operations/clean_test.go
@@ -383,32 +383,21 @@ func TestFindMergedCandidatesListWorktreesError(t *testing.T) {
 	}
 }
 
-// remoteExistsRun returns a run func that answers "remote get-url origin" successfully.
-func remoteExistsRun(inner func(args ...string) (string, error)) func(args ...string) (string, error) {
-	return func(args ...string) (string, error) {
-		if len(args) >= 3 && args[0] == gitCmdRemote && args[1] == "get-url" {
-			return "https://github.com/owner/repo.git", nil
-		}
-		return inner(args...)
-	}
-}
-
 func TestRemoveCandidatesRemoteDeleteSuccess(t *testing.T) {
 	pushCalled := false
 	r := &mockRunner{
-		run: remoteExistsRun(func(args ...string) (string, error) {
+		run: func(args ...string) (string, error) {
 			if len(args) > 0 && args[0] == gitCmdPush {
 				pushCalled = true
 				return "", nil
 			}
-			// worktree remove and branch delete succeed
 			return "", nil
-		}),
+		},
 		runInDir: noopRunInDir,
 	}
 
 	candidates := []CleanCandidate{{Path: "/wt/a", Branch: "feature/a"}}
-	items := RemoveCandidates(r, candidates, true, nil)
+	items := RemoveCandidates(r, candidates, true, nil) // originPresent=true passed by caller
 	if len(items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(items))
 	}
@@ -425,12 +414,12 @@ func TestRemoveCandidatesRemoteDeleteSuccess(t *testing.T) {
 
 func TestRemoveCandidatesRemoteDeleteFailureStillCountsItem(t *testing.T) {
 	r := &mockRunner{
-		run: remoteExistsRun(func(args ...string) (string, error) {
+		run: func(args ...string) (string, error) {
 			if len(args) > 0 && args[0] == gitCmdPush {
 				return "", errors.New("connection refused")
 			}
 			return "", nil
-		}),
+		},
 		runInDir: noopRunInDir,
 	}
 
@@ -439,7 +428,6 @@ func TestRemoveCandidatesRemoteDeleteFailureStillCountsItem(t *testing.T) {
 	if len(items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(items))
 	}
-	// worktree was removed successfully
 	if !items[0].WorktreeRemoved {
 		t.Error("expected WorktreeRemoved=true")
 	}
@@ -452,6 +440,7 @@ func TestRemoveCandidatesRemoteDeleteFailureStillCountsItem(t *testing.T) {
 }
 
 func TestRemoveCandidatesNoOriginSkipsRemoteDelete(t *testing.T) {
+	// Caller resolved RemoteExists=false and passes originPresent=false.
 	pushCalled := false
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
@@ -459,38 +448,34 @@ func TestRemoveCandidatesNoOriginSkipsRemoteDelete(t *testing.T) {
 				pushCalled = true
 				return "", nil
 			}
-			// remote get-url fails → no origin
-			if len(args) >= 2 && args[0] == gitCmdRemote && args[1] == "get-url" {
-				return "", errors.New("no such remote")
-			}
 			return "", nil
 		},
 		runInDir: noopRunInDir,
 	}
 
 	candidates := []CleanCandidate{{Path: "/wt/a", Branch: "feature/a"}}
-	items := RemoveCandidates(r, candidates, true, nil)
+	items := RemoveCandidates(r, candidates, false, nil) // originPresent=false → no push
 	if len(items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(items))
 	}
 	if items[0].RemoteDeleted {
-		t.Error("expected RemoteDeleted=false when no origin")
+		t.Error("expected RemoteDeleted=false when originPresent=false")
 	}
 	if pushCalled {
-		t.Error("expected no push call when origin absent")
+		t.Error("expected no push call when originPresent=false")
 	}
 }
 
 func TestRemoveCandidatesDeleteRemoteFalseSkipsRemote(t *testing.T) {
 	pushCalled := false
 	r := &mockRunner{
-		run: remoteExistsRun(func(args ...string) (string, error) {
+		run: func(args ...string) (string, error) {
 			if len(args) > 0 && args[0] == gitCmdPush {
 				pushCalled = true
 				return "", nil
 			}
 			return "", nil
-		}),
+		},
 		runInDir: noopRunInDir,
 	}
 

--- a/tests/e2e/clean_test.go
+++ b/tests/e2e/clean_test.go
@@ -545,6 +545,114 @@ func TestCleanPrunesNonOriginRemote(t *testing.T) {
 	}
 }
 
+// cleanMergeSetupWithRemote creates a worktree, commits, pushes branch to origin,
+// merges into main, then pushes main to origin — so rimba sees the merge via origin/main.
+func cleanMergeSetupWithRemote(t *testing.T, repo, task string) (wtPath, branch string) {
+	t.Helper()
+	rimbaSuccess(t, repo, "add", task)
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch = resolver.BranchName(defaultPrefix, task)
+	wtPath = resolver.WorktreePath(wtDir, branch)
+
+	testutil.CreateFile(t, wtPath, task+".txt", "content from "+task)
+	testutil.GitCmd(t, wtPath, "add", ".")
+	testutil.GitCmd(t, wtPath, "commit", "-m", "add "+task)
+	testutil.GitCmd(t, wtPath, "push", "-u", "origin", branch)
+	testutil.GitCmd(t, repo, "merge", branch)
+	testutil.GitCmd(t, repo, "push", "origin", "main")
+	return wtPath, branch
+}
+
+func TestCleanMergedDeletesRemoteBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, _ := setupRepoWithBareOrigin(t)
+	wtPath, branch := cleanMergeSetupWithRemote(t, repo, "remote-clean")
+
+	r := rimbaSuccess(t, repo, "clean", flagMergedE2E, flagForceE2E)
+	assertContains(t, r.Stdout, msgRemovedWorktree)
+	assertContains(t, r.Stdout, msgDeletedBranch)
+	assertContains(t, r.Stdout, "Deleted remote branch: origin/"+branch)
+	assertFileNotExists(t, wtPath)
+
+	// Local branch gone.
+	out := testutil.GitCmd(t, repo, "branch", flagBranchList)
+	if strings.Contains(out, branch) {
+		t.Error("expected local branch to be deleted")
+	}
+	// Remote branch gone.
+	out = testutil.GitCmd(t, repo, "branch", "-r")
+	if strings.Contains(out, "origin/"+branch) {
+		t.Error("expected remote branch to be deleted")
+	}
+}
+
+func TestCleanMergedDryRunShowsRemote(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, _ := setupRepoWithBareOrigin(t)
+	_, branch := cleanMergeSetupWithRemote(t, repo, "remote-dry")
+
+	r := rimbaSuccess(t, repo, "clean", flagMergedE2E, flagDryRunE2E)
+	assertContains(t, r.Stdout, "will delete remote: origin/"+branch)
+
+	// Remote branch must still be present (dry run).
+	out := testutil.GitCmd(t, repo, "branch", "-r")
+	if !strings.Contains(out, "origin/"+branch) {
+		t.Error("expected remote branch to still exist after dry run")
+	}
+}
+
+func TestCleanStaleKeepsRemote(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, _ := setupRepoWithBareOrigin(t)
+
+	rimbaSuccess(t, repo, "add", "stale-remote")
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.BranchName(defaultPrefix, "stale-remote")
+	wtPath := resolver.WorktreePath(wtDir, branch)
+
+	testutil.GitCmd(t, wtPath, "push", "-u", "origin", branch)
+
+	r := rimbaSuccess(t, repo, "clean", flagStaleE2E, flagForceE2E, "--stale-days", "0")
+	assertContains(t, r.Stdout, "Cleaned 1 stale worktree(s)")
+	assertFileNotExists(t, wtPath)
+
+	// Remote branch should remain (stale mode is local-only).
+	out := testutil.GitCmd(t, repo, "branch", "-r")
+	if !strings.Contains(out, "origin/"+branch) {
+		t.Error("expected remote branch to remain after --stale clean")
+	}
+}
+
+func TestCleanMergedIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, _ := setupRepoWithBareOrigin(t)
+	cleanMergeSetupWithRemote(t, repo, "idempotent")
+
+	// First run: clean the merged worktree (local + remote).
+	rimbaSuccess(t, repo, "clean", flagMergedE2E, flagForceE2E)
+
+	// Second run on already-clean state: should be a no-op with no failure messages.
+	r := rimbaSuccess(t, repo, "clean", flagMergedE2E, flagForceE2E)
+	assertContains(t, r.Stdout, "No merged worktrees found")
+	assertNotContains(t, r.Stdout, "Failed")
+	assertNotContains(t, r.Stderr, "Failed")
+}
+
 func TestCleanPrunesCustomRefspec(t *testing.T) {
 	if testing.Short() {
 		t.Skip(skipE2E)


### PR DESCRIPTION
## Summary
<!-- Describe what changed and why. Use bullet points. -->
- `DeleteBranch` is now idempotent: git's "branch 'X' not found" error returns nil instead of propagating as a per-item failure
- New `git.DeleteRemoteBranch`: `push <remote> --delete <branch>`, idempotent on "remote ref does not exist", wraps real failures with an `errhint` recovery hint
- `operations.RemoveCandidates` gains a `deleteRemote bool` param and two new `CleanedItem` fields (`RemoteDeleted`, `RemoteError`); a `deleteRemoteForItem` helper keeps cyclomatic complexity under 15
- `rimba clean --merged --force` now also deletes the merged branch on `origin` after removing the worktree (gated on `RemoteExists`)
- `rimba clean --merged --dry-run` previews `will delete remote: origin/<branch>` per candidate when origin is configured
- Per-item output: "Deleted remote branch: origin/<branch>" on success, or a `git push origin --delete` recovery hint on failure (worktree count unchanged)
- `rimba clean --stale` is explicitly local-only (`deleteRemote=false`)
- MCP `clean` merged mode passes `deleteRemote=true`; remote failures fold into the `Warnings` slice
- `git.DefaultRemote` exported as single source of truth; private `remoteOrigin`/`mcpRemoteOrigin` copies removed
- `RemoteExists` hoisted before the candidate loop — one probe for N candidates, closes TOCTOU gap

## Test Plan
<!-- How did you verify this works? Check the boxes. -->
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

### Type-tailored checks ([feat])
- [x] `TestDeleteBranchNotFoundIsIdempotent` — nil on "branch 'X' not found"
- [x] `TestDeleteBranchNotFoundWithoutBranchKeywordPropagates` — tighter substring match
- [x] `TestDeleteRemoteBranchSuccess`, `TestDeleteRemoteBranchRefGoneIsIdempotent`, `TestDeleteRemoteBranchFailure`
- [x] `TestRemoveCandidatesRemoteDeleteSuccess/Failure/NoOrigin/DeleteRemoteFalse`
- [x] `TestCleanToolMergedDeletesRemoteBranch`, `TestCleanToolMergedRemoteFailureSurfacesInWarnings`
- [x] `TestCleanMergedDeletesRemoteBranch`, `TestCleanMergedDryRunShowsRemote`, `TestCleanStaleKeepsRemote`, `TestCleanMergedIdempotent`

## Issue

Closes #231