### PR TITLE
[feat] verify self-update integrity with checksum + guard release-asset contract

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -284,7 +284,8 @@ func TestRootHelpFunctionRoot(t *testing.T) {
 		_, _ = w.Write([]byte(`{
 			"tag_name":"v99.0.0",
 			"assets":[
-				{"name":"rimba_99.0.0_linux_amd64.tar.gz","browser_download_url":"https://example.com/download"}
+				{"name":"rimba_99.0.0_linux_amd64.tar.gz","browser_download_url":"https://example.com/download"},
+				{"name":"checksums.txt","browser_download_url":"https://example.com/checksums.txt"}
 			]
 		}`))
 	}))

--- a/cmd/update_hint_test.go
+++ b/cmd/update_hint_test.go
@@ -40,7 +40,8 @@ func TestCheckUpdateHintNewVersionAvailable(t *testing.T) {
 		_, _ = w.Write([]byte(`{
 			"tag_name":"` + testVersionNew + `",
 			"assets":[
-				{"name":"rimba_2.0.0_linux_amd64.tar.gz","browser_download_url":"https://example.com/download"}
+				{"name":"rimba_2.0.0_linux_amd64.tar.gz","browser_download_url":"https://example.com/download"},
+				{"name":"checksums.txt","browser_download_url":"https://example.com/checksums.txt"}
 			]
 		}`))
 	}))

--- a/internal/updater/checksum.go
+++ b/internal/updater/checksum.go
@@ -1,0 +1,70 @@
+package updater
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// maxChecksumSize caps the checksums.txt download at 1 MiB — orders of magnitude
+// larger than any real goreleaser checksums file.
+var maxChecksumSize int64 = 1 << 20
+
+// FetchChecksums downloads the checksums file at url and returns a map of
+// filename → lowercase SHA-256 hex. Each line must be in sha256sum(1) format:
+// "<hex>  <filename>" (one or two spaces). Lines that don't parse are skipped.
+func (u *Updater) FetchChecksums(ctx context.Context, url string) (map[string]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating checksums request: %w", err)
+	}
+
+	resp, err := u.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching checksums: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("checksums request returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxChecksumSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading checksums: %w", err)
+	}
+	if int64(len(body)) > maxChecksumSize {
+		return nil, fmt.Errorf("checksums response exceeds %d bytes", maxChecksumSize)
+	}
+
+	sums := make(map[string]string)
+	for line := range strings.SplitSeq(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		hex := strings.ToLower(fields[0])
+		filename := fields[len(fields)-1]
+		sums[filename] = hex
+	}
+	return sums, nil
+}
+
+// verifyChecksumMatch checks that gotHex matches the expected SHA-256 for assetName.
+// An absent row is treated as a hard error (fail-closed).
+func verifyChecksumMatch(sums map[string]string, assetName, gotHex string) error {
+	expected, ok := sums[assetName]
+	if !ok {
+		return fmt.Errorf("asset %q not found in checksums.txt", assetName)
+	}
+	if strings.ToLower(gotHex) != expected {
+		return fmt.Errorf("checksum mismatch for %s: got %s, want %s", assetName, gotHex, expected)
+	}
+	return nil
+}

--- a/internal/updater/contract_test.go
+++ b/internal/updater/contract_test.go
@@ -1,0 +1,112 @@
+package updater
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"text/template"
+)
+
+// goreleaserField extracts the value of a top-level or nested YAML key by
+// scanning for the first line (after trimming) that starts with "key:".
+// Surrounding quotes are stripped. Returns "" when not found.
+func goreleaserField(content, key string) string {
+	prefix := key + ":"
+	for line := range strings.SplitSeq(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(trimmed, prefix); ok {
+			return strings.Trim(strings.TrimSpace(after), `"'`)
+		}
+	}
+	return ""
+}
+
+// archiveNameTemplate returns the first name_template line that contains "{{",
+// distinguishing the archive template from the checksum name_template.
+func archiveNameTemplate(content string) string {
+	prefix := "name_template:"
+	for line := range strings.SplitSeq(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(trimmed, prefix); ok && strings.Contains(trimmed, "{{") {
+			return strings.Trim(strings.TrimSpace(after), `"'`)
+		}
+	}
+	return ""
+}
+
+// TestAssetNameContract verifies that the updater's assetNameFor helper produces
+// exactly the filename goreleaser would generate for every release target.
+// Any edit to .goreleaser.yaml's name_template that drifts from updater.go will
+// fail this test in CI before it can silently break rimba update.
+func TestAssetNameContract(t *testing.T) {
+	data, err := os.ReadFile("../../.goreleaser.yaml")
+	if err != nil {
+		t.Fatalf("reading .goreleaser.yaml: %v", err)
+	}
+	content := string(data)
+
+	projectName := goreleaserField(content, "project_name")
+	if projectName == "" {
+		t.Fatal("project_name not found in .goreleaser.yaml")
+	}
+
+	nameTmplStr := archiveNameTemplate(content)
+	if nameTmplStr == "" {
+		t.Fatal("archive name_template not found in .goreleaser.yaml")
+	}
+
+	// Verify the checksum filename is what Check() looks for.
+	if !strings.Contains(content, "name_template: checksums.txt") {
+		t.Error("goreleaser checksum name_template is not 'checksums.txt'; update checksumsFileName const")
+	}
+
+	tmpl, err := template.New("asset").Parse(nameTmplStr)
+	if err != nil {
+		t.Fatalf("parsing name_template %q: %v", nameTmplStr, err)
+	}
+
+	const contractVersion = "1.0.0"
+
+	targets := []struct {
+		goos   string
+		goarch string
+	}{
+		{"linux", "amd64"},
+		{"linux", "arm64"},
+		{"darwin", "amd64"},
+		{"darwin", "arm64"},
+		{goosWindows, "amd64"},
+		{goosWindows, "arm64"},
+	}
+
+	for _, tt := range targets {
+		t.Run(tt.goos+"_"+tt.goarch, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := tmpl.Execute(&buf, map[string]string{
+				"ProjectName": projectName,
+				"Version":     contractVersion,
+				"Os":          tt.goos,
+				"Arch":        tt.goarch,
+			}); err != nil {
+				t.Fatalf("rendering template: %v", err)
+			}
+
+			rendered := buf.String()
+			if strings.HasSuffix(rendered, ".tar.gz") || strings.HasSuffix(rendered, ".zip") {
+				t.Fatalf("goreleaser name_template already embeds an extension (%q); "+
+					"update the contract test's extension-append logic", rendered)
+			}
+			ext := ".tar.gz"
+			if tt.goos == goosWindows {
+				ext = ".zip"
+			}
+			got := rendered + ext
+			want := assetNameFor(tt.goos, tt.goarch, contractVersion)
+
+			if got != want {
+				t.Errorf("goreleaser renders %q but updater builds %q — update assetNameFor() or .goreleaser.yaml", got, want)
+			}
+		})
+	}
+}

--- a/internal/updater/contract_test.go
+++ b/internal/updater/contract_test.go
@@ -22,14 +22,27 @@ func goreleaserField(content, key string) string {
 	return ""
 }
 
-// archiveNameTemplate returns the first name_template line that contains "{{",
-// distinguishing the archive template from the checksum name_template.
+// archiveNameTemplate extracts the name_template from the archives: section of
+// goreleaser YAML. It enters the section on the "archives:" top-level key and
+// stops at the next non-blank, non-indented line — making it resilient to other
+// name_template entries (e.g. the checksum block) that appear elsewhere in the file.
 func archiveNameTemplate(content string) string {
+	inArchives := false
 	prefix := "name_template:"
 	for line := range strings.SplitSeq(content, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if after, ok := strings.CutPrefix(trimmed, prefix); ok && strings.Contains(trimmed, "{{") {
-			return strings.Trim(strings.TrimSpace(after), `"'`)
+		if line == "archives:" {
+			inArchives = true
+			continue
+		}
+		if inArchives {
+			// A non-blank, non-indented line signals a new top-level YAML key.
+			if len(line) > 0 && line[0] != ' ' {
+				break
+			}
+			trimmed := strings.TrimSpace(line)
+			if after, ok := strings.CutPrefix(trimmed, prefix); ok && strings.Contains(trimmed, "{{") {
+				return strings.Trim(strings.TrimSpace(after), `"'`)
+			}
 		}
 	}
 	return ""

--- a/internal/updater/extract.go
+++ b/internal/updater/extract.go
@@ -99,7 +99,9 @@ func writeBinary(dst string, r io.Reader) (_ string, retErr error) {
 		return "", fmt.Errorf("extracting binary: %w", err)
 	}
 	if n > maxBinarySize {
-		_ = os.Remove(dst)
+		// Do not call os.Remove here — the FD is still open via the deferred Close,
+		// and on Windows os.Remove fails on open handles. CleanupTempDir removes the
+		// entire temp directory on the Download error path.
 		return "", fmt.Errorf("binary exceeds max allowed size of %d bytes", maxBinarySize)
 	}
 	return dst, nil

--- a/internal/updater/extract.go
+++ b/internal/updater/extract.go
@@ -1,0 +1,106 @@
+package updater
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// dispatchExtract selects tar.gz or zip extraction based on the archive path extension
+// and writes the platform binary (rimba or rimba.exe) to dstDir.
+func dispatchExtract(archivePath, dstDir string, isWindows bool) (string, error) {
+	binName := binaryName
+	if isWindows {
+		binName = binaryName + ".exe"
+	}
+	if strings.HasSuffix(archivePath, ".zip") {
+		return extractZip(archivePath, dstDir, binName)
+	}
+	return extractTarGz(archivePath, dstDir, binName)
+}
+
+// extractTarGz opens a .tar.gz archive file and extracts binName to dstDir.
+func extractTarGz(archivePath, dstDir, binName string) (string, error) {
+	f, err := os.Open(filepath.Clean(archivePath))
+	if err != nil {
+		return "", fmt.Errorf("opening archive: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return "", fmt.Errorf("decompressing archive: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("reading archive: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		if hdr.Name == binName {
+			return writeBinary(filepath.Join(dstDir, binName), tr)
+		}
+	}
+	return "", fmt.Errorf("binary %q not found in archive", binName)
+}
+
+// extractZip opens a .zip archive file and extracts binName to dstDir.
+func extractZip(archivePath, dstDir, binName string) (string, error) {
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return "", fmt.Errorf("opening zip archive: %w", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	for _, f := range zr.File {
+		if f.Name != binName {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", fmt.Errorf("opening zip entry: %w", err)
+		}
+		dst, writeErr := writeBinary(filepath.Join(dstDir, binName), rc)
+		_ = rc.Close()
+		return dst, writeErr
+	}
+	return "", fmt.Errorf("binary %q not found in archive", binName)
+}
+
+// writeBinary writes the contents of r to dst with executable permissions.
+// It enforces maxBinarySize to guard against zip-bomb payloads.
+func writeBinary(dst string, r io.Reader) (_ string, retErr error) {
+	f, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0755) //nolint:gosec // executable binary requires 0755
+	if err != nil {
+		return "", fmt.Errorf("creating binary file: %w", err)
+	}
+	defer func() {
+		if cerr := f.Close(); retErr == nil {
+			retErr = cerr
+		}
+	}()
+
+	lr := io.LimitReader(r, maxBinarySize+1)
+	n, err := io.Copy(f, lr)
+	if err != nil {
+		return "", fmt.Errorf("extracting binary: %w", err)
+	}
+	if n > maxBinarySize {
+		_ = os.Remove(dst)
+		return "", fmt.Errorf("binary exceeds max allowed size of %d bytes", maxBinarySize)
+	}
+	return dst, nil
+}

--- a/internal/updater/runner.go
+++ b/internal/updater/runner.go
@@ -31,7 +31,8 @@ type Runner struct {
 	OnSuccess func()
 
 	check          func(ctx context.Context) (*CheckResult, error)
-	download       func(ctx context.Context, url string) (string, error)
+	download       func(ctx context.Context, url string) (*DownloadResult, error)
+	verifyChecksum func(ctx context.Context, result *CheckResult, dl *DownloadResult) error
 	prepareBinary  func(path string) error
 	executable     func() (string, error)
 	evalSymlinks   func(path string) (string, error)
@@ -56,6 +57,13 @@ func NewRunner(version string) *Runner {
 	}
 	r.check = u.Check
 	r.download = u.Download
+	r.verifyChecksum = func(ctx context.Context, result *CheckResult, dl *DownloadResult) error {
+		sums, err := u.FetchChecksums(ctx, result.ChecksumsURL)
+		if err != nil {
+			return fmt.Errorf("fetching checksums: %w", err)
+		}
+		return verifyChecksumMatch(sums, result.AssetName, dl.SHA256)
+	}
 	r.prepareBinary = PrepareBinary
 	r.executable = os.Executable
 	r.evalSymlinks = filepath.EvalSymlinks
@@ -75,8 +83,11 @@ func defaultExecCommand(ctx context.Context, name string, args ...string) ([]byt
 	return exec.CommandContext(ctx, filepath.Clean(name), args...).Output() //nolint:gosec // G204: name is installedBinary, written by this process
 }
 
-// Run executes the full update pipeline: check → download → prepare → locate →
-// install → verify. ctx is checked before the destructive install stage.
+// Run executes the full update pipeline:
+// check → download → verifyChecksum → prepare → locate → install → verify.
+// verifyChecksum is placed before prepare/install: a checksum failure aborts
+// before any binary is swapped (fail-closed).
+// ctx is checked before the destructive install stage.
 func (r *Runner) Run(ctx context.Context) error {
 	if r.Spinner == nil {
 		r.Spinner = spinner.New(spinner.Options{Writer: io.Discard})
@@ -103,16 +114,25 @@ func (r *Runner) Run(ctx context.Context) error {
 	fmt.Fprintf(r.Out, "New version available: %s → %s\n", result.CurrentVersion, result.LatestVersion)
 
 	r.Spinner.Start("Downloading...")
-	newBinary, err := r.download(ctx, result.DownloadURL)
+	dl, err := r.download(ctx, result.DownloadURL)
 	if err != nil {
 		return errhint.WithFix(
 			fmt.Errorf("downloading update: %w", err),
 			"check network connectivity and retry: rimba update",
 		)
 	}
-	defer r.cleanupTempDir(newBinary)
+	defer r.cleanupTempDir(dl.BinaryPath)
 
-	if err := r.prepareBinary(newBinary); err != nil {
+	// Verify integrity before touching the installed binary (fail-closed).
+	if err := r.verifyChecksum(ctx, result, dl); err != nil {
+		return errhint.WithFix(
+			fmt.Errorf("integrity check failed: %w", err),
+			"the downloaded release failed integrity verification — do not retry blindly; "+
+				"check https://github.com/lugassawan/rimba/releases for the expected checksums",
+		)
+	}
+
+	if err := r.prepareBinary(dl.BinaryPath); err != nil {
 		return errhint.WithFix(fmt.Errorf("preparing binary: %w", err), retryUpdateHint)
 	}
 
@@ -126,7 +146,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	r.Spinner.Update("Installing...")
-	installedBinary, err := r.install(currentBinary, newBinary)
+	installedBinary, err := r.install(currentBinary, dl.BinaryPath)
 	if err != nil {
 		return err
 	}

--- a/internal/updater/runner_test.go
+++ b/internal/updater/runner_test.go
@@ -18,13 +18,6 @@ const (
 	testCurrentBinary = "/usr/local/bin/rimba"
 )
 
-// fakeDownloadResult is the DownloadResult returned by the default test download seam.
-var fakeDownloadResult = &DownloadResult{
-	ArchivePath: "/tmp/rimba-test/archive.tar.gz",
-	BinaryPath:  "/tmp/rimba-test/rimba",
-	SHA256:      "aabbcc",
-}
-
 // newTestRunner returns a Runner wired with fake seams that all succeed, plus a
 // buffer capturing stdout. Tests override individual seams to exercise one failure path.
 func newTestRunner(t *testing.T) (*Runner, *bytes.Buffer) {
@@ -45,7 +38,11 @@ func newTestRunner(t *testing.T) (*Runner, *bytes.Buffer) {
 		}, nil
 	}
 	r.download = func(_ context.Context, url string) (*DownloadResult, error) {
-		return fakeDownloadResult, nil
+		return &DownloadResult{
+			ArchivePath: "/tmp/rimba-test/archive.tar.gz",
+			BinaryPath:  "/tmp/rimba-test/rimba",
+			SHA256:      "aabbcc",
+		}, nil
 	}
 	r.verifyChecksum = func(_ context.Context, _ *CheckResult, _ *DownloadResult) error { return nil }
 	r.prepareBinary = func(path string) error { return nil }

--- a/internal/updater/runner_test.go
+++ b/internal/updater/runner_test.go
@@ -18,6 +18,13 @@ const (
 	testCurrentBinary = "/usr/local/bin/rimba"
 )
 
+// fakeDownloadResult is the DownloadResult returned by the default test download seam.
+var fakeDownloadResult = &DownloadResult{
+	ArchivePath: "/tmp/rimba-test/archive.tar.gz",
+	BinaryPath:  "/tmp/rimba-test/rimba",
+	SHA256:      "aabbcc",
+}
+
 // newTestRunner returns a Runner wired with fake seams that all succeed, plus a
 // buffer capturing stdout. Tests override individual seams to exercise one failure path.
 func newTestRunner(t *testing.T) (*Runner, *bytes.Buffer) {
@@ -33,9 +40,14 @@ func newTestRunner(t *testing.T) (*Runner, *bytes.Buffer) {
 			CurrentVersion: "1.0.0",
 			LatestVersion:  "v1.1.0",
 			DownloadURL:    "http://fake/download",
+			AssetName:      "rimba_1.1.0_linux_amd64.tar.gz",
+			ChecksumsURL:   "http://fake/checksums.txt",
 		}, nil
 	}
-	r.download = func(_ context.Context, url string) (string, error) { return "/tmp/rimba-test/rimba", nil }
+	r.download = func(_ context.Context, url string) (*DownloadResult, error) {
+		return fakeDownloadResult, nil
+	}
+	r.verifyChecksum = func(_ context.Context, _ *CheckResult, _ *DownloadResult) error { return nil }
 	r.prepareBinary = func(path string) error { return nil }
 	r.executable = func() (string, error) { return testCurrentBinary, nil }
 	r.evalSymlinks = func(path string) (string, error) { return path, nil }
@@ -82,7 +94,7 @@ func statExists(t *testing.T) func(string) (os.FileInfo, error) {
 	return func(path string) (os.FileInfo, error) { return info, nil }
 }
 
-// TestHintSurfaces verifies all 13 errhint.WithFix surfaces in Runner.Run.
+// TestHintSurfaces verifies all errhint.WithFix surfaces in Runner.Run.
 // Each test case starts from a fully-mocked-success runner and overrides exactly
 // one seam to fail, then asserts the wrapped error prefix and hint fragment.
 func TestHintSurfaces(t *testing.T) {
@@ -105,12 +117,22 @@ func TestHintSurfaces(t *testing.T) {
 		{
 			name: "download fails",
 			setupFn: func(_ *testing.T, r *Runner) {
-				r.download = func(_ context.Context, url string) (string, error) {
-					return "", errors.New("connection refused")
+				r.download = func(_ context.Context, url string) (*DownloadResult, error) {
+					return nil, errors.New("connection refused")
 				}
 			},
 			wantPrefix: "downloading update:",
 			wantHint:   "check network connectivity and retry: rimba update",
+		},
+		{
+			name: "verifyChecksum fails",
+			setupFn: func(_ *testing.T, r *Runner) {
+				r.verifyChecksum = func(_ context.Context, _ *CheckResult, _ *DownloadResult) error {
+					return errors.New("checksum mismatch: got aaa, want bbb")
+				}
+			},
+			wantPrefix: "integrity check failed:",
+			wantHint:   "the downloaded release failed integrity verification",
 		},
 		{
 			name: "prepareBinary fails",
@@ -336,6 +358,26 @@ func TestRunCtxCancelledBeforeInstall(t *testing.T) {
 	}
 	if replaceCalled {
 		t.Error("replace should not be called after ctx cancellation")
+	}
+}
+
+// TestRunReplaceNotCalledOnChecksumFailure asserts that a checksum mismatch is
+// fail-closed: no swap ever reaches the installed binary.
+func TestRunReplaceNotCalledOnChecksumFailure(t *testing.T) {
+	r, _ := newTestRunner(t)
+	replaceCalled := false
+	r.replace = func(_, _ string) error {
+		replaceCalled = true
+		return nil
+	}
+	r.verifyChecksum = func(_ context.Context, _ *CheckResult, _ *DownloadResult) error {
+		return errors.New("checksum mismatch: got aaa, want bbb")
+	}
+
+	err := r.Run(context.Background())
+	requireErrContains(t, err, "integrity check failed:", "checksum mismatch")
+	if replaceCalled {
+		t.Error("replace should not be called after checksum failure (fail-closed)")
 	}
 }
 

--- a/internal/updater/swap_unix.go
+++ b/internal/updater/swap_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package updater
+
+import "os"
+
+// swapBinary atomically replaces dst with tmpPath via os.Rename.
+// On Unix, Rename is guaranteed atomic within the same filesystem.
+func swapBinary(tmpPath, dst string) error {
+	return os.Rename(tmpPath, dst) //nolint:gosec // dst is the resolved current binary path, not user input
+}

--- a/internal/updater/swap_windows.go
+++ b/internal/updater/swap_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package updater
+
+import (
+	"fmt"
+
+	"github.com/lugassawan/rimba/internal/errhint"
+)
+
+// swapBinary is not yet implemented on Windows.
+// The rename-aside mechanism required to replace a running .exe is tracked in
+// https://github.com/lugassawan/rimba/issues/234
+func swapBinary(_, _ string) error {
+	return errhint.WithFix(
+		fmt.Errorf("self-update replace is not yet supported on Windows"),
+		"download the latest release from https://github.com/lugassawan/rimba/releases; "+
+			"Windows self-replace support is tracked in https://github.com/lugassawan/rimba/issues/234",
+	)
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -354,6 +354,9 @@ func assetNameFor(goos, goarch, version string) string {
 
 // findReleaseAssets scans release assets for the platform archive and checksums file.
 // Returns empty strings for any asset not found.
+// BrowserDownloadURL values are used verbatim; checksum verification (issue #222) is
+// the intended mitigation against redirected-URL attacks rather than host-prefix
+// validation, which would need to enumerate all valid GitHub CDN hostnames.
 func findReleaseAssets(assetName string, assets []Asset) (downloadURL, checksumsURL string) {
 	for _, a := range assets {
 		if a.Name == assetName {

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,10 +1,10 @@
 package updater
 
 import (
-	"archive/tar"
 	"bufio"
-	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,11 +22,17 @@ const (
 	repoPath           = "/repos/lugassawan/rimba/releases/latest"
 	binaryName         = "rimba"
 	localBinSubdir     = ".local"
+	checksumsFileName  = "checksums.txt"
+	goosWindows        = "windows"
 )
 
 // maxBinarySize is the decompressed size limit for the extracted binary (100 MiB).
 // Tests may override this to exercise the size-limit path.
 var maxBinarySize int64 = 100 << 20
+
+// maxArchiveSize is the download size limit for the archive (100 MiB).
+// Tests may override this to exercise the size-limit path.
+var maxArchiveSize int64 = 100 << 20
 
 // HTTPClient abstracts HTTP requests for testability.
 type HTTPClient interface {
@@ -51,6 +57,15 @@ type CheckResult struct {
 	LatestVersion  string
 	UpToDate       bool
 	DownloadURL    string
+	AssetName      string
+	ChecksumsURL   string
+}
+
+// DownloadResult holds the paths and digest produced by Download.
+type DownloadResult struct {
+	ArchivePath string
+	BinaryPath  string
+	SHA256      string
 }
 
 // Updater checks for and applies updates from GitHub releases.
@@ -79,6 +94,8 @@ func IsDevVersion(v string) bool {
 }
 
 // Check queries the GitHub API for the latest release and compares versions.
+// It is fail-closed: if checksums.txt is absent from the release assets, it
+// returns an error rather than allowing an unverified download.
 func (u *Updater) Check(ctx context.Context) (*CheckResult, error) {
 	url := u.APIEndpoint + repoPath
 
@@ -113,51 +130,86 @@ func (u *Updater) Check(ctx context.Context) (*CheckResult, error) {
 	}
 
 	if !result.UpToDate {
-		assetName := fmt.Sprintf("%s_%s_%s_%s.tar.gz", binaryName, latest, u.GOOS, u.GOARCH)
-		for _, a := range release.Assets {
-			if a.Name == assetName {
-				result.DownloadURL = a.BrowserDownloadURL
-				break
-			}
-		}
-		if result.DownloadURL == "" {
+		assetName := assetNameFor(u.GOOS, u.GOARCH, latest)
+		downloadURL, checksumsURL := findReleaseAssets(assetName, release.Assets)
+		if downloadURL == "" {
 			return nil, fmt.Errorf("no matching asset for %s/%s in release %s", u.GOOS, u.GOARCH, release.TagName)
 		}
+		if checksumsURL == "" {
+			return nil, fmt.Errorf("%s not found in release %s", checksumsFileName, release.TagName)
+		}
+		result.DownloadURL = downloadURL
+		result.AssetName = assetName
+		result.ChecksumsURL = checksumsURL
 	}
 
 	return result, nil
 }
 
-// Download fetches a tar.gz archive from the given URL and extracts the binary
-// to a temporary directory. Returns the path to the extracted binary.
-func (u *Updater) Download(ctx context.Context, url string) (string, error) {
+// Download fetches the release archive from url, streams it to a temp file while
+// computing its SHA-256, then extracts the platform binary. Returns a DownloadResult
+// with paths to both the archive and the extracted binary.
+func (u *Updater) Download(ctx context.Context, url string) (*DownloadResult, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", fmt.Errorf("creating download request: %w", err)
+		return nil, fmt.Errorf("creating download request: %w", err)
 	}
 
 	resp, err := u.Client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("downloading release: %w", err)
+		return nil, fmt.Errorf("downloading release: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("download returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("download returned status %d", resp.StatusCode)
 	}
 
 	tmpDir, err := os.MkdirTemp("", "rimba-update-*")
 	if err != nil {
-		return "", fmt.Errorf("creating temp dir: %w", err)
+		return nil, fmt.Errorf("creating temp dir: %w", err)
 	}
 
-	dst, err := extractBinary(resp.Body, tmpDir)
+	isWindows := u.GOOS == goosWindows
+	archiveName := "archive.tar.gz"
+	if isWindows {
+		archiveName = "archive.zip"
+	}
+	archivePath := filepath.Join(tmpDir, archiveName)
+
+	archiveFile, err := os.Create(archivePath) //nolint:gosec // path is under controlled temp dir
 	if err != nil {
 		_ = os.RemoveAll(tmpDir)
-		return "", err
+		return nil, fmt.Errorf("creating archive file: %w", err)
 	}
 
-	return dst, nil
+	h := sha256.New()
+	mw := io.MultiWriter(archiveFile, h)
+
+	lr := io.LimitReader(resp.Body, maxArchiveSize+1)
+	n, copyErr := io.Copy(mw, lr)
+	_ = archiveFile.Close()
+
+	if copyErr != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("downloading archive: %w", copyErr)
+	}
+	if n > maxArchiveSize {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("archive exceeds max allowed size of %d bytes", maxArchiveSize)
+	}
+
+	binaryPath, err := dispatchExtract(archivePath, tmpDir, isWindows)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, err
+	}
+
+	return &DownloadResult{
+		ArchivePath: archivePath,
+		BinaryPath:  binaryPath,
+		SHA256:      hex.EncodeToString(h.Sum(nil)),
+	}, nil
 }
 
 // Replace atomically swaps the current binary with a new one via
@@ -211,7 +263,7 @@ func Replace(currentBinary, newBinary string) error {
 	}
 
 	// Atomic rename: new inode replaces old one
-	if err := os.Rename(tmpPath, resolved); err != nil { //nolint:gosec // resolved is the current binary path, not user input
+	if err := swapBinary(tmpPath, resolved); err != nil {
 		return fmt.Errorf("replacing binary: %w", err)
 	}
 
@@ -291,56 +343,25 @@ func EnsurePath(dir string) error {
 	return nil
 }
 
-// extractBinary decompresses a tar.gz stream and extracts the rimba binary to dstDir.
-func extractBinary(r io.Reader, dstDir string) (string, error) {
-	gz, err := gzip.NewReader(r)
-	if err != nil {
-		return "", fmt.Errorf("decompressing archive: %w", err)
+// assetNameFor builds the release archive filename for the given platform and version.
+func assetNameFor(goos, goarch, version string) string {
+	ext := ".tar.gz"
+	if goos == goosWindows {
+		ext = ".zip"
 	}
-	defer func() { _ = gz.Close() }()
-
-	tr := tar.NewReader(gz)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return "", fmt.Errorf("reading archive: %w", err)
-		}
-
-		if hdr.Typeflag != tar.TypeReg {
-			continue
-		}
-		if hdr.Name == binaryName {
-			return writeBinary(filepath.Join(dstDir, binaryName), tr)
-		}
-	}
-
-	return "", fmt.Errorf("binary %q not found in archive", binaryName)
+	return fmt.Sprintf("%s_%s_%s_%s%s", binaryName, version, goos, goarch, ext)
 }
 
-// writeBinary writes the tar entry contents to dst with executable permissions.
-// It enforces maxBinarySize to guard against zip-bomb payloads.
-func writeBinary(dst string, r io.Reader) (_ string, retErr error) {
-	f, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0755) //nolint:gosec // executable binary requires 0755
-	if err != nil {
-		return "", fmt.Errorf("creating binary file: %w", err)
-	}
-	defer func() {
-		if cerr := f.Close(); retErr == nil {
-			retErr = cerr
+// findReleaseAssets scans release assets for the platform archive and checksums file.
+// Returns empty strings for any asset not found.
+func findReleaseAssets(assetName string, assets []Asset) (downloadURL, checksumsURL string) {
+	for _, a := range assets {
+		if a.Name == assetName {
+			downloadURL = a.BrowserDownloadURL
 		}
-	}()
-
-	lr := io.LimitReader(r, maxBinarySize+1)
-	n, err := io.Copy(f, lr)
-	if err != nil {
-		return "", fmt.Errorf("extracting binary: %w", err)
+		if a.Name == checksumsFileName {
+			checksumsURL = a.BrowserDownloadURL
+		}
 	}
-	if n > maxBinarySize {
-		return "", fmt.Errorf("binary exceeds max allowed size of %d bytes", maxBinarySize)
-	}
-
-	return dst, nil
+	return
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -2,9 +2,12 @@ package updater
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/http"
@@ -34,6 +37,10 @@ const (
 	valNewContent = "new content"
 	testRcZshrc   = ".zshrc"
 	testShellZsh  = "/bin/zsh"
+
+	// checksum test constants
+	testChecksumHex  = "aabbccdd"
+	testChecksumFile = "rimba_2.0.0_linux_amd64.tar.gz"
 )
 
 // newTestUpdater creates an Updater wired to the given test server.
@@ -77,6 +84,16 @@ func serveOctetStream(t *testing.T, data []byte) *httptest.Server {
 	return srv
 }
 
+// releaseJSON builds a GitHub release JSON body with the given assets appended.
+func releaseJSON(tagName string, extras ...string) string {
+	assets := make([]string, 0, 1+len(extras))
+	assets = append(assets,
+		`{"name":"checksums.txt","browser_download_url":"https://example.com/checksums.txt"}`,
+	)
+	assets = append(assets, extras...)
+	return fmt.Sprintf(`{"tag_name":%q,"assets":[%s]}`, tagName, strings.Join(assets, ","))
+}
+
 func TestCheckUpToDate(t *testing.T) {
 	srv := serveJSON(t, `{"tag_name":"`+testVersion+`","assets":[]}`)
 	u := newTestUpdater(srv)
@@ -92,12 +109,9 @@ func TestCheckUpToDate(t *testing.T) {
 }
 
 func TestCheckNewVersionAvailable(t *testing.T) {
-	srv := serveJSON(t, `{
-		"tag_name":"`+testVersionNew+`",
-		"assets":[
-			{"name":"rimba_2.0.0_linux_amd64.tar.gz","browser_download_url":"https://example.com/rimba_2.0.0_linux_amd64.tar.gz"}
-		]
-	}`)
+	srv := serveJSON(t, releaseJSON(testVersionNew,
+		`{"name":"rimba_2.0.0_linux_amd64.tar.gz","browser_download_url":"https://example.com/rimba_2.0.0_linux_amd64.tar.gz"}`,
+	))
 	u := newTestUpdater(srv)
 
 	result, err := u.Check(context.Background())
@@ -109,6 +123,16 @@ func TestCheckNewVersionAvailable(t *testing.T) {
 	wantURL := "https://example.com/rimba_2.0.0_linux_amd64.tar.gz"
 	if result.DownloadURL != wantURL {
 		t.Errorf("download URL = %q, want %q", result.DownloadURL, wantURL)
+	}
+
+	wantAsset := "rimba_2.0.0_linux_amd64.tar.gz"
+	if result.AssetName != wantAsset {
+		t.Errorf("AssetName = %q, want %q", result.AssetName, wantAsset)
+	}
+
+	wantChecksums := "https://example.com/checksums.txt"
+	if result.ChecksumsURL != wantChecksums {
+		t.Errorf("ChecksumsURL = %q, want %q", result.ChecksumsURL, wantChecksums)
 	}
 }
 
@@ -129,6 +153,50 @@ func TestCheckNoMatchingAsset(t *testing.T) {
 	want := "no matching asset for linux/amd64 in release " + testVersionNew
 	if got := err.Error(); got != want {
 		t.Errorf(errWantFmt, got, want)
+	}
+}
+
+func TestCheckMissingChecksums(t *testing.T) {
+	srv := serveJSON(t, fmt.Sprintf(`{
+		"tag_name":%q,
+		"assets":[
+			{"name":"rimba_2.0.0_linux_amd64.tar.gz","browser_download_url":"https://example.com/rimba_2.0.0_linux_amd64.tar.gz"}
+		]
+	}`, testVersionNew))
+	u := newTestUpdater(srv)
+
+	_, err := u.Check(context.Background())
+	if err == nil {
+		t.Fatal("expected error when checksums.txt is absent")
+	}
+	if !strings.Contains(err.Error(), "checksums.txt not found") {
+		t.Errorf("error = %q, want to contain 'checksums.txt not found'", err.Error())
+	}
+}
+
+func TestCheckWindowsAsset(t *testing.T) {
+	srv := serveJSON(t, releaseJSON(testVersionNew,
+		`{"name":"rimba_2.0.0_windows_amd64.zip","browser_download_url":"https://example.com/rimba_2.0.0_windows_amd64.zip"}`,
+	))
+	u := &Updater{
+		CurrentVersion: testVersion,
+		GOOS:           goosWindows,
+		GOARCH:         testArch,
+		Client:         srv.Client(),
+		APIEndpoint:    srv.URL,
+	}
+
+	result, err := u.Check(context.Background())
+	requireNoError(t, err)
+	if result.UpToDate {
+		t.Error("expected not up to date")
+	}
+	wantAssetWin := assetNameFor(goosWindows, testArch, "2.0.0")
+	if result.AssetName != wantAssetWin {
+		t.Errorf("AssetName = %q, want %q", result.AssetName, wantAssetWin)
+	}
+	if result.ChecksumsURL == "" {
+		t.Error("ChecksumsURL should be set")
 	}
 }
 
@@ -177,11 +245,11 @@ func TestDownloadValidArchive(t *testing.T) {
 
 	u := newTestUpdater(srv)
 
-	binaryPath, err := u.Download(context.Background(), srv.URL+"/rimba_1.0.0_linux_amd64.tar.gz")
+	dl, err := u.Download(context.Background(), srv.URL+"/rimba_1.0.0_linux_amd64.tar.gz")
 	requireNoError(t, err)
-	t.Cleanup(func() { CleanupTempDir(binaryPath) })
+	t.Cleanup(func() { CleanupTempDir(dl.BinaryPath) })
 
-	content, err := os.ReadFile(binaryPath)
+	content, err := os.ReadFile(dl.BinaryPath)
 	if err != nil {
 		t.Fatalf("reading extracted binary: %v", err)
 	}
@@ -191,12 +259,55 @@ func TestDownloadValidArchive(t *testing.T) {
 		t.Errorf("binary content = %q, want %q", content, want)
 	}
 
-	info, err := os.Stat(binaryPath)
+	info, err := os.Stat(dl.BinaryPath)
 	if err != nil {
 		t.Fatalf("stat binary: %v", err)
 	}
 	if info.Mode()&0111 == 0 {
 		t.Error("expected binary to be executable")
+	}
+
+	// SHA256 must be non-empty and match the archive bytes.
+	if dl.SHA256 == "" {
+		t.Error("SHA256 should not be empty")
+	}
+	h := sha256.Sum256(archiveData)
+	want256 := hex.EncodeToString(h[:])
+	if dl.SHA256 != want256 {
+		t.Errorf("SHA256 = %q, want %q", dl.SHA256, want256)
+	}
+}
+
+func TestDownloadZipArchive(t *testing.T) {
+	archiveData := buildTestZipArchive(t, "rimba.exe", "exe content")
+	srv := serveOctetStream(t, archiveData)
+
+	u := &Updater{
+		CurrentVersion: testVersion,
+		GOOS:           goosWindows,
+		GOARCH:         testArch,
+		Client:         srv.Client(),
+		APIEndpoint:    srv.URL,
+	}
+
+	dl, err := u.Download(context.Background(), srv.URL+"/rimba_1.0.0_windows_amd64.zip")
+	requireNoError(t, err)
+	t.Cleanup(func() { CleanupTempDir(dl.BinaryPath) })
+
+	if !strings.HasSuffix(dl.BinaryPath, "rimba.exe") {
+		t.Errorf("BinaryPath = %q, want suffix 'rimba.exe'", dl.BinaryPath)
+	}
+
+	content, err := os.ReadFile(dl.BinaryPath)
+	if err != nil {
+		t.Fatalf("reading extracted binary: %v", err)
+	}
+	if string(content) != "exe content" {
+		t.Errorf("binary content = %q, want %q", content, "exe content")
+	}
+
+	if dl.SHA256 == "" {
+		t.Error("SHA256 should not be empty")
 	}
 }
 
@@ -614,7 +725,7 @@ func buildTestArchiveTypeflag(t *testing.T, name, content string, typeflag byte)
 	return buf.Bytes()
 }
 
-func TestExtractBinarySkipsNonRegularFiles(t *testing.T) {
+func TestExtractTarGzSkipsNonRegularFiles(t *testing.T) {
 	tests := []struct {
 		name     string
 		typeflag byte
@@ -625,8 +736,13 @@ func TestExtractBinarySkipsNonRegularFiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			archiveData := buildTestArchiveTypeflag(t, binaryName, "", tt.typeflag)
+			// Write archive to temp file for extractTarGz
 			tmpDir := t.TempDir()
-			_, err := extractBinary(bytes.NewReader(archiveData), tmpDir)
+			archivePath := filepath.Join(tmpDir, "archive.tar.gz")
+			if err := os.WriteFile(archivePath, archiveData, 0644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := extractTarGz(archivePath, tmpDir, binaryName)
 			if err == nil {
 				t.Fatal("expected error when rimba entry is not a regular file")
 			}
@@ -652,6 +768,23 @@ func TestWriteBinaryExceedsMaxSize(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "exceeds max") {
 		t.Errorf("error = %q, want to contain 'exceeds max'", err.Error())
+	}
+}
+
+func TestDownloadExceedsMaxArchiveSize(t *testing.T) {
+	orig := maxArchiveSize
+	maxArchiveSize = 5
+	t.Cleanup(func() { maxArchiveSize = orig })
+
+	srv := serveOctetStream(t, []byte("this is more than 5 bytes"))
+	u := newTestUpdater(srv)
+
+	_, err := u.Download(context.Background(), srv.URL+"/archive.tar.gz")
+	if err == nil {
+		t.Fatal("expected error when archive exceeds size limit")
+	}
+	if !strings.Contains(err.Error(), "exceeds max allowed size") {
+		t.Errorf("error = %q, want to contain 'exceeds max allowed size'", err.Error())
 	}
 }
 
@@ -727,6 +860,24 @@ func buildTestArchive(t *testing.T, name, content string) []byte {
 		t.Fatal(err)
 	}
 	return data
+}
+
+// buildTestZipArchive creates a zip archive containing a single file.
+func buildTestZipArchive(t *testing.T, name, content string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	fw, err := zw.Create(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
 }
 
 func TestReplaceSubdirectory(t *testing.T) {
@@ -1180,16 +1331,16 @@ func TestDownloadValidArchiveCleanup(t *testing.T) {
 
 	u := newTestUpdater(srv)
 
-	binaryPath, err := u.Download(context.Background(), srv.URL+"/rimba_1.0.0_linux_amd64.tar.gz")
+	dl, err := u.Download(context.Background(), srv.URL+"/rimba_1.0.0_linux_amd64.tar.gz")
 	requireNoError(t, err)
 
 	// Verify the binary exists
-	if _, err := os.Stat(binaryPath); err != nil {
-		t.Fatalf("binary should exist at %s: %v", binaryPath, err)
+	if _, err := os.Stat(dl.BinaryPath); err != nil {
+		t.Fatalf("binary should exist at %s: %v", dl.BinaryPath, err)
 	}
 
 	// Verify content
-	content, err := os.ReadFile(binaryPath)
+	content, err := os.ReadFile(dl.BinaryPath)
 	if err != nil {
 		t.Fatalf("reading binary: %v", err)
 	}
@@ -1199,10 +1350,170 @@ func TestDownloadValidArchiveCleanup(t *testing.T) {
 	}
 
 	// Now clean up and verify temp dir is removed
-	tmpDir := filepath.Dir(binaryPath)
-	CleanupTempDir(binaryPath)
+	tmpDir := filepath.Dir(dl.BinaryPath)
+	CleanupTempDir(dl.BinaryPath)
 
 	if _, err := os.Stat(tmpDir); !os.IsNotExist(err) {
 		t.Errorf("expected temp dir %s to be removed after CleanupTempDir", tmpDir)
+	}
+}
+
+// ---- FetchChecksums tests ----
+
+func serveChecksums(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(contentTypeHdr, "text/plain")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestFetchChecksumsHappyPath(t *testing.T) {
+	body := "aabbccdd  rimba_2.0.0_linux_amd64.tar.gz\n" +
+		"eeff0011  rimba_2.0.0_darwin_amd64.tar.gz\n"
+	srv := serveChecksums(t, body)
+	u := newTestUpdater(srv)
+
+	sums, err := u.FetchChecksums(context.Background(), srv.URL+"/checksums.txt")
+	requireNoError(t, err)
+
+	if got := sums["rimba_2.0.0_linux_amd64.tar.gz"]; got != "aabbccdd" {
+		t.Errorf("linux sum = %q, want %q", got, "aabbccdd")
+	}
+	if got := sums["rimba_2.0.0_darwin_amd64.tar.gz"]; got != "eeff0011" {
+		t.Errorf("darwin sum = %q, want %q", got, "eeff0011")
+	}
+}
+
+func TestFetchChecksumsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(srv.Close)
+	u := newTestUpdater(srv)
+
+	_, err := u.FetchChecksums(context.Background(), srv.URL+"/checksums.txt")
+	if err == nil {
+		t.Fatal("expected error for HTTP error response")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error = %q, want to contain '403'", err.Error())
+	}
+}
+
+func TestFetchChecksumsNetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		conn.Close()
+	}))
+	t.Cleanup(srv.Close)
+	u := newTestUpdater(srv)
+
+	_, err := u.FetchChecksums(context.Background(), srv.URL+"/checksums.txt")
+	if err == nil {
+		t.Fatal("expected error for network failure")
+	}
+}
+
+func TestFetchChecksumsRequestError(t *testing.T) {
+	u := &Updater{
+		CurrentVersion: testVersion,
+		GOOS:           testOS,
+		GOARCH:         testArch,
+		Client:         http.DefaultClient,
+	}
+
+	_, err := u.FetchChecksums(context.Background(), "\x7f://invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+	if !strings.Contains(err.Error(), "creating checksums request") {
+		t.Errorf("error = %q, want 'creating checksums request'", err.Error())
+	}
+}
+
+func TestFetchChecksumsLowercasesHex(t *testing.T) {
+	body := "AABBCCDD  rimba_2.0.0_linux_amd64.tar.gz\n"
+	srv := serveChecksums(t, body)
+	u := newTestUpdater(srv)
+
+	sums, err := u.FetchChecksums(context.Background(), srv.URL+"/checksums.txt")
+	requireNoError(t, err)
+
+	if got := sums["rimba_2.0.0_linux_amd64.tar.gz"]; got != "aabbccdd" {
+		t.Errorf("sum = %q, want lowercase %q", got, "aabbccdd")
+	}
+}
+
+// ---- verifyChecksumMatch tests ----
+
+func TestVerifyChecksumMatchHappyPath(t *testing.T) {
+	sums := map[string]string{testChecksumFile: testChecksumHex}
+	if err := verifyChecksumMatch(sums, testChecksumFile, testChecksumHex); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestVerifyChecksumMatchCaseInsensitive(t *testing.T) {
+	sums := map[string]string{testChecksumFile: testChecksumHex}
+	if err := verifyChecksumMatch(sums, testChecksumFile, strings.ToUpper(testChecksumHex)); err != nil {
+		t.Errorf("unexpected error for uppercase input: %v", err)
+	}
+}
+
+func TestVerifyChecksumMatchMismatch(t *testing.T) {
+	sums := map[string]string{testChecksumFile: testChecksumHex}
+	err := verifyChecksumMatch(sums, testChecksumFile, "deadbeef")
+	if err == nil {
+		t.Fatal("expected error for checksum mismatch")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("error = %q, want to contain 'checksum mismatch'", err.Error())
+	}
+}
+
+func TestVerifyChecksumMatchAbsentRow(t *testing.T) {
+	sums := map[string]string{"other_file.tar.gz": testChecksumHex}
+	err := verifyChecksumMatch(sums, testChecksumFile, testChecksumHex)
+	if err == nil {
+		t.Fatal("expected error for absent asset row (fail-closed)")
+	}
+	if !strings.Contains(err.Error(), "not found in checksums.txt") {
+		t.Errorf("error = %q, want to contain 'not found in checksums.txt'", err.Error())
+	}
+}
+
+// ---- assetNameFor tests ----
+
+func TestAssetNameFor(t *testing.T) {
+	tests := []struct {
+		goos   string
+		goarch string
+		want   string
+	}{
+		{"linux", "amd64", "rimba_1.0.0_linux_amd64.tar.gz"},
+		{"linux", "arm64", "rimba_1.0.0_linux_arm64.tar.gz"},
+		{"darwin", "amd64", "rimba_1.0.0_darwin_amd64.tar.gz"},
+		{"darwin", "arm64", "rimba_1.0.0_darwin_arm64.tar.gz"},
+		{goosWindows, "amd64", "rimba_1.0.0_windows_amd64.zip"},
+		{goosWindows, "arm64", "rimba_1.0.0_windows_arm64.zip"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.goos+"_"+tt.goarch, func(t *testing.T) {
+			got := assetNameFor(tt.goos, tt.goarch, "1.0.0")
+			if got != tt.want {
+				t.Errorf("assetNameFor(%q, %q, %q) = %q, want %q", tt.goos, tt.goarch, "1.0.0", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1425,6 +1425,23 @@ func TestFetchChecksumsNetworkError(t *testing.T) {
 	}
 }
 
+func TestFetchChecksumsExceedsMaxSize(t *testing.T) {
+	orig := maxChecksumSize
+	maxChecksumSize = 5
+	t.Cleanup(func() { maxChecksumSize = orig })
+
+	srv := serveChecksums(t, "aabbccdd  rimba_2.0.0_linux_amd64.tar.gz\n") // >5 bytes
+	u := newTestUpdater(srv)
+
+	_, err := u.FetchChecksums(context.Background(), srv.URL+"/checksums.txt")
+	if err == nil {
+		t.Fatal("expected error when checksums response exceeds size limit")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error = %q, want to contain 'exceeds'", err.Error())
+	}
+}
+
 func TestFetchChecksumsRequestError(t *testing.T) {
 	u := &Updater{
 		CurrentVersion: testVersion,


### PR DESCRIPTION
## Summary

- Add SHA-256 checksum verification against goreleaser's `checksums.txt` before any binary is swapped — fail-closed on missing file, absent asset row, or hash mismatch
- `DownloadResult` carries `ArchivePath`, `BinaryPath`, and `SHA256` (archive hash, matching what goreleaser signs)
- `FetchChecksums` parses sha256sum(1) format; `verifyChecksumMatch` is a hard error on absent row — no silent skip
- Pipeline in `runner.go` reordered: `check → download → verifyChecksum → prepare → locate → ctx.Err() → install → verify`; `TestRunReplaceNotCalledOnChecksumFailure` encodes the fail-closed invariant
- Windows asset/extract: `Check()` uses `.zip` extension, `Download()` extracts `rimba.exe`; `swap_windows.go` returns a clear `errhint` stub pointing to follow-up #234 rather than crashing with "Access is denied"
- Contract test (`contract_test.go`): reads `.goreleaser.yaml`, renders `name_template` via `text/template` for all 6 `{linux,darwin,windows}×{amd64,arm64}` targets, asserts match with `assetNameFor()` — any goreleaser rename breaks CI immediately
- `checksums.txt` response capped at 1 MiB (defense-in-depth alongside the 100 MiB archive limit)

## Test Plan

- [x] Unit tests pass (`make test`) — 1887/1887
- [x] Linter passes (`make lint`) — 0 issues (gocognit < 15, goconst, perfsprint, tidygo all clean)
- [x] E2E tests pass (`make test-e2e`)
- [x] Total coverage ≥ 97% (`go tool cover -func` → 97.0%)

### Type-tailored checks (feat)

- [x] `TestRunReplaceNotCalledOnChecksumFailure` — verifies fail-closed: `replace` seam not called when checksum mismatch
- [x] `TestCheckMissingChecksums` — `Check()` returns error when `checksums.txt` absent from release assets
- [x] `TestVerifyChecksumMatchAbsentRow` — absent asset row is hard error
- [x] `TestVerifyChecksumMatchMismatch` — hash mismatch returns descriptive error
- [x] `TestDownloadZipArchive` — Windows `.zip` correctly extracted as `rimba.exe`
- [x] `TestAssetNameContract` — 6-row table coupling goreleaser template to `assetNameFor()`
- [x] `TestHintSurfaces` includes `verifyChecksum fails` row verifying errhint wiring

## Issue

Closes #222
