### PR TITLE
[feat] thread cancellation context through git, hooks, and dep installs

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -135,7 +135,7 @@ func runAddTask(cmd *cobra.Command, r git.Runner, arg string, cfg *config.Config
 		Show()
 
 	s.Start("Creating worktree...")
-	result, err := operations.AddWorktree(r, operations.AddParams{
+	result, err := operations.AddWorktree(cmd.Context(), r, operations.AddParams{
 		Task:              task,
 		Service:           service,
 		Prefix:            prefix,

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -223,8 +224,9 @@ func cleanMerged(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 		summaryFmt:    "Cleaned %d merged worktree(s).\n",
 		originPresent: remotePresent, // shared with printMergedCandidates — single probe
 		preFind: func(c *cobra.Command, rr git.Runner, sp *spinner.Spinner) error {
-			mergeRef = cleanFetchMergeRef(ctx, c, rr, sp, mainBranch)
-			return nil
+			var err error
+			mergeRef, err = cleanFetchMergeRef(ctx, c, rr, sp, mainBranch)
+			return err
 		},
 		find: func(rr git.Runner) ([]operations.CleanCandidate, []string, error) {
 			result, err := operations.FindMergedCandidates(rr, mergeRef, mainBranch)
@@ -272,15 +274,19 @@ func cleanStale(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 }
 
 // cleanFetchMergeRef fetches from origin and returns the ref to diff against.
-// Falls back to mainBranch with a warning if fetch fails.
-func cleanFetchMergeRef(ctx context.Context, cmd *cobra.Command, r git.Runner, s *spinner.Spinner, mainBranch string) string {
+// Returns an error on cancellation; falls back to mainBranch with a warning on
+// other fetch failures (e.g. no remote configured).
+func cleanFetchMergeRef(ctx context.Context, cmd *cobra.Command, r git.Runner, s *spinner.Spinner, mainBranch string) (string, error) {
 	s.Start("Fetching from " + git.DefaultRemote + "...")
 	if err := git.Fetch(ctx, r, git.DefaultRemote); err != nil {
 		s.Stop()
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return "", err
+		}
 		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: fetch failed (no remote?): continuing with local state\n")
-		return mainBranch
+		return mainBranch, nil
 	}
-	return git.DefaultRemote + "/" + mainBranch
+	return git.DefaultRemote + "/" + mainBranch, nil
 }
 
 func cleanRemoveCandidates(ctx context.Context, cmd *cobra.Command, r git.Runner, s *spinner.Spinner, candidates []operations.CleanCandidate, originPresent bool) int {

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"strings"
 
@@ -39,11 +40,11 @@ var cleanCmd = &cobra.Command{
 
 		switch {
 		case merged:
-			return cleanMerged(cmd, r)
+			return cleanMerged(cmd.Context(), cmd, r)
 		case stale:
-			return cleanStale(cmd, r)
+			return cleanStale(cmd.Context(), cmd, r)
 		default:
-			return cleanPrune(cmd, r)
+			return cleanPrune(cmd.Context(), cmd, r)
 		}
 	},
 }
@@ -60,7 +61,7 @@ func init() {
 	rootCmd.AddCommand(cleanCmd)
 }
 
-func cleanPrune(cmd *cobra.Command, r git.Runner) error {
+func cleanPrune(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 	dryRun, _ := cmd.Flags().GetBool(flagDryRun)
 
 	hint.New(cmd, hintPainter(cmd)).
@@ -87,12 +88,12 @@ func cleanPrune(cmd *cobra.Command, r git.Runner) error {
 		fmt.Fprintln(cmd.OutOrStdout(), "Pruned stale worktree references.")
 	}
 
-	return cleanRemotePrune(cmd, r, s, dryRun)
+	return cleanRemotePrune(ctx, cmd, r, s, dryRun)
 }
 
 // cleanRemotePrune prunes stale remote-tracking refs across all configured remotes.
 // Skips gracefully when there are no remotes; warns and continues on per-remote failure.
-func cleanRemotePrune(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, dryRun bool) error {
+func cleanRemotePrune(ctx context.Context, cmd *cobra.Command, r git.Runner, s *spinner.Spinner, dryRun bool) error {
 	s.Start("Pruning remote-tracking refs...")
 	remotes, err := git.ListRemotes(r)
 	if err != nil {
@@ -104,7 +105,7 @@ func cleanRemotePrune(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, dryR
 		fmt.Fprintln(cmd.OutOrStdout(), "No remotes; skipped remote-ref prune.")
 		return nil
 	}
-	pruned, failures := git.PruneRemotes(r, remotes, dryRun)
+	pruned, failures := git.PruneRemotes(ctx, r, remotes, dryRun)
 	s.Stop()
 	failureMsgs := make([]string, len(failures))
 	for i, f := range failures {
@@ -162,7 +163,7 @@ type cleanStrategy struct {
 }
 
 // runClean runs the shared clean pipeline using the given strategy.
-func runClean(cmd *cobra.Command, r git.Runner, s cleanStrategy) error {
+func runClean(ctx context.Context, cmd *cobra.Command, r git.Runner, s cleanStrategy) error {
 	dryRun, _ := cmd.Flags().GetBool(flagDryRun)
 	force, _ := cmd.Flags().GetBool(flagForce)
 
@@ -199,12 +200,12 @@ func runClean(cmd *cobra.Command, r git.Runner, s cleanStrategy) error {
 		return nil
 	}
 
-	removed := cleanRemoveCandidates(cmd, r, sp, candidates, s.originPresent)
+	removed := cleanRemoveCandidates(ctx, cmd, r, sp, candidates, s.originPresent)
 	fmt.Fprintf(cmd.OutOrStdout(), s.summaryFmt, removed)
 	return nil
 }
 
-func cleanMerged(cmd *cobra.Command, r git.Runner) error {
+func cleanMerged(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 	mainBranch, err := cleanResolveAndHint(cmd, r, []hintEntry{
 		{flagDryRun, hintDryRunClean},
 		{flagForce, hintForce},
@@ -215,14 +216,14 @@ func cleanMerged(cmd *cobra.Command, r git.Runner) error {
 
 	remotePresent := git.RemoteExists(r, git.DefaultRemote)
 	var mergeRef string
-	return runClean(cmd, r, cleanStrategy{
+	return runClean(ctx, cmd, r, cleanStrategy{
 		label:         "merged",
 		spinnerMsg:    "Analyzing branches...",
 		emptyMsg:      "No merged worktrees found.",
 		summaryFmt:    "Cleaned %d merged worktree(s).\n",
 		originPresent: remotePresent, // shared with printMergedCandidates — single probe
 		preFind: func(c *cobra.Command, rr git.Runner, sp *spinner.Spinner) error {
-			mergeRef = cleanFetchMergeRef(c, rr, sp, mainBranch)
+			mergeRef = cleanFetchMergeRef(ctx, c, rr, sp, mainBranch)
 			return nil
 		},
 		find: func(rr git.Runner) ([]operations.CleanCandidate, []string, error) {
@@ -238,7 +239,7 @@ func cleanMerged(cmd *cobra.Command, r git.Runner) error {
 	})
 }
 
-func cleanStale(cmd *cobra.Command, r git.Runner) error {
+func cleanStale(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 	mainBranch, err := cleanResolveAndHint(cmd, r, []hintEntry{
 		{flagDryRun, hintDryRunClean},
 		{flagForce, hintForce},
@@ -250,7 +251,7 @@ func cleanStale(cmd *cobra.Command, r git.Runner) error {
 
 	staleDays, _ := cmd.Flags().GetInt(flagStaleDays)
 	var staleCandidates []operations.StaleCandidate
-	return runClean(cmd, r, cleanStrategy{
+	return runClean(ctx, cmd, r, cleanStrategy{
 		label:         "stale",
 		spinnerMsg:    "Analyzing worktree activity...",
 		emptyMsg:      "No stale worktrees found.",
@@ -272,9 +273,9 @@ func cleanStale(cmd *cobra.Command, r git.Runner) error {
 
 // cleanFetchMergeRef fetches from origin and returns the ref to diff against.
 // Falls back to mainBranch with a warning if fetch fails.
-func cleanFetchMergeRef(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, mainBranch string) string {
+func cleanFetchMergeRef(ctx context.Context, cmd *cobra.Command, r git.Runner, s *spinner.Spinner, mainBranch string) string {
 	s.Start("Fetching from " + git.DefaultRemote + "...")
-	if err := git.Fetch(r, git.DefaultRemote); err != nil {
+	if err := git.Fetch(ctx, r, git.DefaultRemote); err != nil {
 		s.Stop()
 		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: fetch failed (no remote?): continuing with local state\n")
 		return mainBranch
@@ -282,9 +283,9 @@ func cleanFetchMergeRef(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, ma
 	return git.DefaultRemote + "/" + mainBranch
 }
 
-func cleanRemoveCandidates(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, candidates []operations.CleanCandidate, originPresent bool) int {
+func cleanRemoveCandidates(ctx context.Context, cmd *cobra.Command, r git.Runner, s *spinner.Spinner, candidates []operations.CleanCandidate, originPresent bool) int {
 	s.Start("Removing worktrees...")
-	items := operations.RemoveCandidates(r, candidates, originPresent, func(msg string) {
+	items := operations.RemoveCandidates(ctx, r, candidates, originPresent, func(msg string) {
 		s.Update(msg)
 	})
 	s.Stop()

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -778,3 +778,22 @@ func TestPrintCleanedItemsAllBranches(t *testing.T) {
 		}
 	}
 }
+
+func TestCleanFetchMergeRefCancelled(t *testing.T) {
+	cmd, _ := newTestCmd()
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == cmdFetch {
+				return "", context.Canceled
+			}
+			return "", nil
+		},
+	}
+	s := spinner.New(spinnerOpts(cmd))
+	defer s.Stop()
+
+	ref, err := cleanFetchMergeRef(context.Background(), cmd, r, s, branchMain)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got err=%v ref=%q", err, ref)
+	}
+}

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"path/filepath"
 	"strconv"
@@ -33,7 +34,7 @@ func TestCleanRemotePruneMultiRemote(t *testing.T) {
 		},
 		runInDir: noopRunInDir,
 	}
-	if err := cleanPrune(cmd, r); err != nil {
+	if err := cleanPrune(context.Background(), cmd, r); err != nil {
 		t.Fatalf("cleanPrune: %v", err)
 	}
 	if len(calls) != 2 {
@@ -68,7 +69,7 @@ func TestCleanRemotePrunePartialFailure(t *testing.T) {
 		},
 		runInDir: noopRunInDir,
 	}
-	err := cleanPrune(cmd, r)
+	err := cleanPrune(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf("cleanPrune should return nil on partial failure, got: %v", err)
 	}
@@ -96,7 +97,7 @@ func TestCleanRemotePruneAllFail(t *testing.T) {
 		},
 		runInDir: noopRunInDir,
 	}
-	if err := cleanPrune(cmd, r); err != nil {
+	if err := cleanPrune(context.Background(), cmd, r); err != nil {
 		t.Fatalf("cleanPrune should return nil on all-remote failure, got: %v", err)
 	}
 	// stdout must NOT contain the false-positive "No stale" message
@@ -122,7 +123,7 @@ func TestCleanRemotePruneNoRemotes(t *testing.T) {
 		},
 		runInDir: noopRunInDir,
 	}
-	if err := cleanPrune(cmd, r); err != nil {
+	if err := cleanPrune(context.Background(), cmd, r); err != nil {
 		t.Fatalf("cleanPrune: %v", err)
 	}
 	if !strings.Contains(buf.String(), "No remotes; skipped remote-ref prune.") {
@@ -161,7 +162,7 @@ func TestCleanMergedFetchFails(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanMerged(cmd, r)
+	err := cleanMerged(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf(fatalCleanMerged, err)
 	}
@@ -205,7 +206,7 @@ func TestCleanMergedFetchSucceeds(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanMerged(cmd, r)
+	err := cleanMerged(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf(fatalCleanMerged, err)
 	}
@@ -282,7 +283,7 @@ func TestCleanPruneSuccess(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanPrune(cmd, r)
+	err := cleanPrune(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf(fatalCleanPrune, err)
 	}
@@ -299,7 +300,7 @@ func TestCleanPruneDryRunEmpty(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanPrune(cmd, r)
+	err := cleanPrune(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf(fatalCleanPrune, err)
 	}
@@ -315,7 +316,7 @@ func TestCleanPruneNoDryRunEmpty(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanPrune(cmd, r)
+	err := cleanPrune(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf(fatalCleanPrune, err)
 	}
@@ -336,7 +337,7 @@ func TestCleanPruneError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanPrune(cmd, r)
+	err := cleanPrune(context.Background(), cmd, r)
 	if err == nil {
 		t.Fatal("expected error from prune failure")
 	}
@@ -394,7 +395,7 @@ func TestCleanMergedNoCandidates(t *testing.T) {
 	cmd, buf := newCleanMergedCmd()
 	r := cleanMergedTestRunner(t, "", worktreeOut)
 
-	err := cleanMerged(cmd, r)
+	err := cleanMerged(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf(fatalCleanMerged, err)
 	}
@@ -409,7 +410,7 @@ func TestCleanMergedDryRun(t *testing.T) {
 	_ = cmd.Flags().Set(flagDryRun, "true")
 	r := cleanMergedTestRunner(t, "  "+branchDone, worktreeOut)
 
-	err := cleanMerged(cmd, r)
+	err := cleanMerged(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf(fatalCleanMerged, err)
 	}
@@ -428,7 +429,7 @@ func TestCleanMergedAbort(t *testing.T) {
 	cmd.SetIn(strings.NewReader("n\n"))
 	r := cleanMergedTestRunner(t, "  "+branchDone, worktreeOut)
 
-	err := cleanMerged(cmd, r)
+	err := cleanMerged(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf(fatalCleanMerged, err)
 	}
@@ -443,7 +444,7 @@ func TestCleanMergedForce(t *testing.T) {
 	_ = cmd.Flags().Set(flagForce, "true")
 	r := cleanMergedTestRunner(t, "  "+branchDone, worktreeOut)
 
-	err := cleanMerged(cmd, r)
+	err := cleanMerged(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf(fatalCleanMerged, err)
 	}
@@ -460,7 +461,7 @@ func TestCleanMergedResolveError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanMerged(cmd, r)
+	err := cleanMerged(context.Background(), cmd, r)
 	if err == nil {
 		t.Fatal("expected error from resolveMainBranch failure")
 	}
@@ -503,7 +504,7 @@ func TestCleanStaleDryRun(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanStale(cmd, r)
+	err := cleanStale(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf("cleanStale: %v", err)
 	}
@@ -543,7 +544,7 @@ func TestCleanStaleNoCandidates(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanStale(cmd, r)
+	err := cleanStale(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf("cleanStale: %v", err)
 	}
@@ -580,7 +581,7 @@ func TestCleanStaleAbort(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanStale(cmd, r)
+	err := cleanStale(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf("cleanStale: %v", err)
 	}
@@ -596,7 +597,7 @@ func TestCleanStaleResolveError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanStale(cmd, r)
+	err := cleanStale(context.Background(), cmd, r)
 	if err == nil {
 		t.Fatal("expected error from resolveMainBranch failure")
 	}
@@ -621,7 +622,7 @@ func TestCleanMergedFindCandidatesError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanMerged(cmd, r)
+	err := cleanMerged(context.Background(), cmd, r)
 	if err == nil {
 		t.Fatal("expected error from findMergedCandidates failure")
 	}
@@ -643,7 +644,7 @@ func TestCleanStaleFindCandidatesError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanStale(cmd, r)
+	err := cleanStale(context.Background(), cmd, r)
 	if err == nil {
 		t.Fatal("expected error from findStaleCandidates failure")
 	}
@@ -677,7 +678,7 @@ func TestCleanStaleForce(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	err := cleanStale(cmd, r)
+	err := cleanStale(context.Background(), cmd, r)
 	if err != nil {
 		t.Fatalf("cleanStale: %v", err)
 	}
@@ -728,7 +729,7 @@ func TestCleanFetchMergeRefWarningOnStderr(t *testing.T) {
 	s := spinner.New(spinnerOpts(cmd))
 	defer s.Stop()
 
-	ref := cleanFetchMergeRef(cmd, r, s, branchMain)
+	ref := cleanFetchMergeRef(context.Background(), cmd, r, s, branchMain)
 	if ref != branchMain {
 		t.Errorf("ref = %q, want %q (local fallback)", ref, branchMain)
 	}

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -729,7 +729,10 @@ func TestCleanFetchMergeRefWarningOnStderr(t *testing.T) {
 	s := spinner.New(spinnerOpts(cmd))
 	defer s.Stop()
 
-	ref := cleanFetchMergeRef(context.Background(), cmd, r, s, branchMain)
+	ref, err := cleanFetchMergeRef(context.Background(), cmd, r, s, branchMain)
+	if err != nil {
+		t.Fatalf("cleanFetchMergeRef: %v", err)
+	}
 	if ref != branchMain {
 		t.Errorf("ref = %q, want %q (local fallback)", ref, branchMain)
 	}

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -194,7 +194,7 @@ var depsInstallCmd = &cobra.Command{
 
 		s.Start("Installing dependencies...")
 		mgr := &deps.Manager{Runner: r, Concurrency: cfg.DepsConcurrency()}
-		results := mgr.Install(wt.Path, modules, nil, func(msg string) {
+		results := mgr.Install(cmd.Context(), wt.Path, modules, nil, func(msg string) {
 			s.Update("Installing dependencies... " + msg)
 		})
 		s.Stop()

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -138,7 +138,7 @@ var duplicateCmd = &cobra.Command{
 			configModules = cfg.Deps.Modules
 		}
 
-		pcResult, err := operations.PostCreateSetup(r, operations.PostCreateParams{
+		pcResult, err := operations.PostCreateSetup(cmd.Context(), r, operations.PostCreateParams{
 			RepoRoot:      repoRoot,
 			WtPath:        wtPath,
 			Task:          newTask,

--- a/cmd/list_bench_test.go
+++ b/cmd/list_bench_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"testing"
@@ -21,6 +22,14 @@ func (m *benchMockRunner) RunInDir(_ string, args ...string) (string, error) {
 		return aheadBehindZero, nil
 	}
 	return "", nil
+}
+
+func (m *benchMockRunner) RunContext(_ context.Context, _ ...string) (string, error) {
+	return "", nil
+}
+
+func (m *benchMockRunner) RunInDirContext(_ context.Context, _ string, args ...string) (string, error) {
+	return m.RunInDir("", args...)
 }
 
 func makeBenchEntries(n int) []git.WorktreeEntry { //nolint:unparam // n is parameterized for benchmark flexibility

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -68,7 +68,7 @@ var mergeCmd = &cobra.Command{
 		defer s.Stop()
 
 		s.Start("Checking for uncommitted changes...")
-		result, err := operations.MergeWorktree(r, operations.MergeParams{
+		result, err := operations.MergeWorktree(cmd.Context(), r, operations.MergeParams{
 			SourceTask:    sourceTask,
 			SourceService: sourceService,
 			IntoTask:      intoTask,

--- a/cmd/merge_bench_test.go
+++ b/cmd/merge_bench_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -12,6 +13,12 @@ type mergeBenchMockRunner struct{}
 
 func (m *mergeBenchMockRunner) Run(_ ...string) (string, error)                { return "", nil }
 func (m *mergeBenchMockRunner) RunInDir(_ string, _ ...string) (string, error) { return "", nil }
+func (m *mergeBenchMockRunner) RunContext(_ context.Context, _ ...string) (string, error) {
+	return "", nil
+}
+func (m *mergeBenchMockRunner) RunInDirContext(_ context.Context, _ string, _ ...string) (string, error) {
+	return "", nil
+}
 
 func BenchmarkDirtyChecksSequential(b *testing.B) {
 	r := &mergeBenchMockRunner{}

--- a/cmd/mock_runner_test.go
+++ b/cmd/mock_runner_test.go
@@ -94,6 +94,14 @@ func (m *mockRunner) RunInDir(dir string, args ...string) (string, error) {
 	return m.runInDir(dir, args...)
 }
 
+func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
+	return m.run(args...)
+}
+
+func (m *mockRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
+	return m.runInDir(dir, args...)
+}
+
 // noopRunInDir is a default runInDir that returns empty output.
 func noopRunInDir(_ string, _ ...string) (string, error) {
 	return "", nil

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -73,7 +73,7 @@ var renameCmd = &cobra.Command{
 		if cfg.Deps != nil {
 			configModules = cfg.Deps.Modules
 		}
-		if _, err := operations.PostRenameSetup(r, operations.PostRenameParams{
+		if _, err := operations.PostRenameSetup(cmd.Context(), r, operations.PostRenameParams{
 			WtPath:        result.NewPath,
 			Service:       svc,
 			SkipDeps:      skipDeps,

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -73,7 +73,7 @@ to see available archived branches.`,
 			configModules = cfg.Deps.Modules
 		}
 
-		pcResult, err := operations.PostCreateSetup(r, operations.PostCreateParams{
+		pcResult, err := operations.PostCreateSetup(cmd.Context(), r, operations.PostCreateParams{
 			RepoRoot:      repoRoot,
 			WtPath:        wtPath,
 			Task:          task,

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -94,6 +94,9 @@ var syncCmd = &cobra.Command{
 			s.Start("Fetching from origin...")
 			if err := git.Fetch(cmd.Context(), r, "origin"); err != nil {
 				s.Stop()
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return err
+				}
 				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: fetch failed (no remote?): continuing with local state\n")
 			}
 		}
@@ -212,6 +215,9 @@ func syncAll(ctx context.Context, sc *syncContext, worktrees []resolver.Worktree
 	wg.Wait()
 
 	sc.s.Stop()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	if !sc.dryRun {
 		printSyncSummary(sc.cmd, sc.cfg.DefaultSource, useMerge, sc.res)
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -91,7 +92,7 @@ var syncCmd = &cobra.Command{
 			fmt.Fprintln(cmd.OutOrStdout(), "[dry-run] would fetch origin")
 		} else {
 			s.Start("Fetching from origin...")
-			if err := git.Fetch(r, "origin"); err != nil {
+			if err := git.Fetch(cmd.Context(), r, "origin"); err != nil {
 				s.Stop()
 				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: fetch failed (no remote?): continuing with local state\n")
 			}
@@ -111,9 +112,9 @@ var syncCmd = &cobra.Command{
 		sc := &syncContext{cmd: cmd, r: r, cfg: cfg, s: s, repoRoot: repoRoot, dryRun: dryRun}
 
 		if all {
-			return syncAll(sc, worktrees, prefixes, useMerge, includeInherited, push)
+			return syncAll(cmd.Context(), sc, worktrees, prefixes, useMerge, includeInherited, push)
 		}
-		return syncOne(sc, args[0], worktrees, prefixes, useMerge, push)
+		return syncOne(cmd.Context(), sc, args[0], worktrees, prefixes, useMerge, push)
 	},
 }
 
@@ -127,7 +128,7 @@ func init() {
 	rootCmd.AddCommand(syncCmd)
 }
 
-func syncOne(sc *syncContext, input string, worktrees []resolver.WorktreeInfo, prefixes []string, useMerge, push bool) error {
+func syncOne(ctx context.Context, sc *syncContext, input string, worktrees []resolver.WorktreeInfo, prefixes []string, useMerge, push bool) error {
 	service, task := operations.ResolveTaskInput(input, sc.repoRoot)
 	wt, found := resolver.FindBranchForTask(service, task, worktrees, prefixes)
 	if !found {
@@ -155,7 +156,7 @@ func syncOne(sc *syncContext, input string, worktrees []resolver.WorktreeInfo, p
 		verb = "Merging"
 	}
 	sc.s.Update(fmt.Sprintf("%s onto %s...", verb, sc.cfg.DefaultSource))
-	if err := operations.SyncBranch(sc.r, wt.Path, sc.cfg.DefaultSource, useMerge); err != nil {
+	if err := operations.SyncBranch(ctx, sc.r, wt.Path, sc.cfg.DefaultSource, useMerge); err != nil {
 		return err
 	}
 
@@ -164,7 +165,7 @@ func syncOne(sc *syncContext, input string, worktrees []resolver.WorktreeInfo, p
 
 	if push {
 		sc.s.Start("Pushing to origin...")
-		pushed, _, pushErr := operations.PushBranch(sc.r, wt.Path, useMerge)
+		pushed, _, pushErr := operations.PushBranch(ctx, sc.r, wt.Path, useMerge)
 		sc.s.Stop()
 		if pushErr != nil {
 			pushHint := fmt.Sprintf("cd %s && git push --force-with-lease", wt.Path)
@@ -184,7 +185,7 @@ func syncOne(sc *syncContext, input string, worktrees []resolver.WorktreeInfo, p
 	return nil
 }
 
-func syncAll(sc *syncContext, worktrees []resolver.WorktreeInfo, prefixes []string, useMerge, includeInherited, push bool) error { //nolint:unparam // error return matches RunE contract
+func syncAll(ctx context.Context, sc *syncContext, worktrees []resolver.WorktreeInfo, prefixes []string, useMerge, includeInherited, push bool) error { //nolint:unparam // error return matches RunE contract
 	allTasks := operations.CollectTasks(worktrees, prefixes)
 	eligible := operations.FilterEligible(worktrees, prefixes, sc.cfg.DefaultSource, allTasks, includeInherited)
 
@@ -200,7 +201,7 @@ func syncAll(sc *syncContext, worktrees []resolver.WorktreeInfo, prefixes []stri
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			syncWorktree(sc, sc.cfg.DefaultSource, wt, useMerge, push)
+			syncWorktree(ctx, sc, sc.cfg.DefaultSource, wt, useMerge, push)
 
 			sc.mu.Lock()
 			completed++
@@ -217,7 +218,7 @@ func syncAll(sc *syncContext, worktrees []resolver.WorktreeInfo, prefixes []stri
 	return nil
 }
 
-func syncWorktree(sc *syncContext, mainBranch string, wt resolver.WorktreeInfo, useMerge, push bool) {
+func syncWorktree(ctx context.Context, sc *syncContext, mainBranch string, wt resolver.WorktreeInfo, useMerge, push bool) {
 	if sc.dryRun {
 		sc.mu.Lock()
 		defer sc.mu.Unlock()
@@ -225,7 +226,7 @@ func syncWorktree(sc *syncContext, mainBranch string, wt resolver.WorktreeInfo, 
 		return
 	}
 
-	sr := operations.SyncWorktree(sc.r, mainBranch, wt, useMerge, push)
+	sr := operations.SyncWorktree(ctx, sc.r, mainBranch, wt, useMerge, push)
 
 	sc.mu.Lock()
 	defer sc.mu.Unlock()

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -48,7 +49,7 @@ func TestSyncOneSuccess(t *testing.T) {
 		}
 		sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-		err := syncOne(sc, "login", worktrees, testSyncPrefixes(), false, false)
+		err := syncOne(context.Background(), sc, "login", worktrees, testSyncPrefixes(), false, false)
 		if err != nil {
 			t.Fatalf("syncOne: %v", err)
 		}
@@ -65,7 +66,7 @@ func TestSyncOneSuccess(t *testing.T) {
 		}
 		sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-		err := syncOne(sc, "login", worktrees, testSyncPrefixes(), true, false)
+		err := syncOne(context.Background(), sc, "login", worktrees, testSyncPrefixes(), true, false)
 		if err != nil {
 			t.Fatalf("syncOne: %v", err)
 		}
@@ -84,7 +85,7 @@ func TestSyncOneNotFound(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-	err := syncOne(sc, "nonexistent", worktrees, testSyncPrefixes(), false, false)
+	err := syncOne(context.Background(), sc, "nonexistent", worktrees, testSyncPrefixes(), false, false)
 	if err == nil {
 		t.Fatal("expected error for unknown task")
 	}
@@ -104,7 +105,7 @@ func TestSyncOneDirty(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-	err := syncOne(sc, "login", worktrees, testSyncPrefixes(), false, false)
+	err := syncOne(context.Background(), sc, "login", worktrees, testSyncPrefixes(), false, false)
 	if err == nil {
 		t.Fatal("expected error for dirty worktree")
 	}
@@ -126,7 +127,7 @@ func TestSyncOneErrorPaths(t *testing.T) {
 		}
 		sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-		err := syncOne(sc, "login", worktrees, testSyncPrefixes(), false, false)
+		err := syncOne(context.Background(), sc, "login", worktrees, testSyncPrefixes(), false, false)
 		if err == nil {
 			t.Fatal("expected error from IsDirty failure")
 		}
@@ -145,7 +146,7 @@ func TestSyncOneErrorPaths(t *testing.T) {
 		}
 		sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-		err := syncOne(sc, "login", worktrees, testSyncPrefixes(), false, false)
+		err := syncOne(context.Background(), sc, "login", worktrees, testSyncPrefixes(), false, false)
 		if err == nil {
 			t.Fatal("expected error from doSync failure")
 		}
@@ -166,7 +167,7 @@ func TestSyncOnePushSuccess(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-	err := syncOne(sc, "login", worktrees, testSyncPrefixes(), false, true)
+	err := syncOne(context.Background(), sc, "login", worktrees, testSyncPrefixes(), false, true)
 	if err != nil {
 		t.Fatalf("syncOne: %v", err)
 	}
@@ -190,7 +191,7 @@ func TestSyncOnePushSkippedNoUpstream(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-	err := syncOne(sc, "login", worktrees, testSyncPrefixes(), false, true)
+	err := syncOne(context.Background(), sc, "login", worktrees, testSyncPrefixes(), false, true)
 	if err != nil {
 		t.Fatalf("syncOne: %v", err)
 	}
@@ -217,7 +218,7 @@ func TestSyncOnePushFailure(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-	err := syncOne(sc, "login", worktrees, testSyncPrefixes(), false, true)
+	err := syncOne(context.Background(), sc, "login", worktrees, testSyncPrefixes(), false, true)
 	if err == nil {
 		t.Fatal("expected error from push failure")
 	}
@@ -238,7 +239,7 @@ func TestSyncAllClean(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-	err := syncAll(sc, worktrees, testSyncPrefixes(), false, false, false)
+	err := syncAll(context.Background(), sc, worktrees, testSyncPrefixes(), false, false, false)
 	if err != nil {
 		t.Fatalf(fatalSyncAll, err)
 	}
@@ -263,7 +264,7 @@ func TestSyncAllDirtySkip(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-	err := syncAll(sc, worktrees, testSyncPrefixes(), false, false, false)
+	err := syncAll(context.Background(), sc, worktrees, testSyncPrefixes(), false, false, false)
 	if err != nil {
 		t.Fatalf(fatalSyncAll, err)
 	}
@@ -282,7 +283,7 @@ func TestSyncAllInherited(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-	err := syncAll(sc, worktrees, testSyncPrefixes(), false, true, false)
+	err := syncAll(context.Background(), sc, worktrees, testSyncPrefixes(), false, true, false)
 	if err != nil {
 		t.Fatalf(fatalSyncAll, err)
 	}
@@ -302,7 +303,7 @@ func TestSyncAllPushDefault(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-	err := syncAll(sc, worktrees, testSyncPrefixes(), false, false, true)
+	err := syncAll(context.Background(), sc, worktrees, testSyncPrefixes(), false, false, true)
 	if err != nil {
 		t.Fatalf(fatalSyncAll, err)
 	}
@@ -329,7 +330,7 @@ func TestSyncAllPushFailure(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
 
-	err := syncAll(sc, worktrees, testSyncPrefixes(), false, false, true)
+	err := syncAll(context.Background(), sc, worktrees, testSyncPrefixes(), false, false, true)
 	if err != nil {
 		t.Fatalf(fatalSyncAll, err)
 	}
@@ -348,7 +349,7 @@ func TestSyncWorktreeClean(t *testing.T) {
 
 	sc := &syncContext{cmd: cmd, r: r, res: &syncResult{}}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	syncWorktree(sc, branchMain, wt, false, false)
+	syncWorktree(context.Background(), sc, branchMain, wt, false, false)
 
 	if sc.res.synced != 1 {
 		t.Errorf("synced = %d, want 1", sc.res.synced)
@@ -370,7 +371,7 @@ func TestSyncWorktreeDirtyAndError(t *testing.T) {
 
 		sc := &syncContext{cmd: cmd, r: r, res: &syncResult{}}
 		wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-		syncWorktree(sc, branchMain, wt, false, false)
+		syncWorktree(context.Background(), sc, branchMain, wt, false, false)
 
 		if sc.res.skippedDirty != 1 {
 			t.Errorf("skippedDirty = %d, want 1", sc.res.skippedDirty)
@@ -391,7 +392,7 @@ func TestSyncWorktreeDirtyAndError(t *testing.T) {
 
 		sc := &syncContext{cmd: cmd, r: r, res: &syncResult{}}
 		wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-		syncWorktree(sc, branchMain, wt, false, false)
+		syncWorktree(context.Background(), sc, branchMain, wt, false, false)
 
 		if sc.res.skippedDirty != 1 {
 			t.Errorf("skippedDirty = %d, want 1", sc.res.skippedDirty)
@@ -416,7 +417,7 @@ func TestSyncWorktreeDoSyncFailure(t *testing.T) {
 
 	sc := &syncContext{cmd: cmd, r: r, res: &syncResult{}}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	syncWorktree(sc, branchMain, wt, false, false)
+	syncWorktree(context.Background(), sc, branchMain, wt, false, false)
 
 	if sc.res.failed != 1 {
 		t.Errorf("failed = %d, want 1", sc.res.failed)
@@ -440,7 +441,7 @@ func TestSyncWorktreeMergeFailure(t *testing.T) {
 
 	sc := &syncContext{cmd: cmd, r: r, res: &syncResult{}}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	syncWorktree(sc, branchMain, wt, true, false)
+	syncWorktree(context.Background(), sc, branchMain, wt, true, false)
 
 	if sc.res.failed != 1 {
 		t.Errorf("failed = %d, want 1", sc.res.failed)
@@ -530,7 +531,7 @@ func TestSyncOneDryRun(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd), dryRun: true}
 
-	if err := syncOne(sc, "login", worktrees, testSyncPrefixes(), false, true); err != nil {
+	if err := syncOne(context.Background(), sc, "login", worktrees, testSyncPrefixes(), false, true); err != nil {
 		t.Fatalf("syncOne: %v", err)
 	}
 	if rebaseCalled {
@@ -554,7 +555,7 @@ func TestSyncAllDryRun(t *testing.T) {
 	}
 	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd), dryRun: true}
 
-	if err := syncAll(sc, worktrees, testSyncPrefixes(), false, false, true); err != nil {
+	if err := syncAll(context.Background(), sc, worktrees, testSyncPrefixes(), false, false, true); err != nil {
 		t.Fatalf("syncAll: %v", err)
 	}
 	out := buf.String()
@@ -583,7 +584,7 @@ func TestSyncWorktreeSkipWarningOnStderr(t *testing.T) {
 
 	sc := &syncContext{cmd: cmd, r: r, res: &syncResult{}}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	syncWorktree(sc, branchMain, wt, false, false)
+	syncWorktree(context.Background(), sc, branchMain, wt, false, false)
 
 	if strings.Contains(outBuf.String(), "Warning") {
 		t.Errorf("warning leaked to stdout: %q", outBuf.String())

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -593,3 +593,24 @@ func TestSyncWorktreeSkipWarningOnStderr(t *testing.T) {
 		t.Errorf("stderr = %q, want warning", errBuf.String())
 	}
 }
+
+func TestSyncAllCancelledSkipsSummary(t *testing.T) {
+	worktrees := testSyncWorktrees()
+	cmd, buf := newTestCmd()
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", nil },
+		runInDir: noopRunInDir,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so syncAll exits without goroutines doing work
+	sc := &syncContext{cmd: cmd, r: r, cfg: testSyncConfig(), s: testSyncSpinner(cmd)}
+
+	err := syncAll(ctx, sc, worktrees, testSyncPrefixes(), false, false, false)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("syncAll with cancelled ctx: err = %v, want context.Canceled", err)
+	}
+	if strings.Contains(buf.String(), "worktree(s)") {
+		t.Errorf("partial summary should not be printed on cancellation: %q", buf.String())
+	}
+}

--- a/internal/conflict/conflict_test.go
+++ b/internal/conflict/conflict_test.go
@@ -1,6 +1,7 @@
 package conflict
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -18,6 +19,14 @@ func (m *mockRunner) Run(args ...string) (string, error) {
 }
 
 func (m *mockRunner) RunInDir(_ string, _ ...string) (string, error) {
+	return "", nil
+}
+
+func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
+	return m.run(args...)
+}
+
+func (m *mockRunner) RunInDirContext(_ context.Context, _ string, _ ...string) (string, error) {
 	return "", nil
 }
 

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -1,6 +1,7 @@
 package debug
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -48,6 +49,22 @@ func (r *TimedRunner) RunInDir(dir string, args ...string) (string, error) {
 	label := fmt.Sprintf("git %s [%s]", strings.Join(args, " "), filepath.Base(dir))
 	start := time.Now()
 	out, err := r.Inner.RunInDir(dir, args...)
+	logf("%s: %s", label, time.Since(start).Round(time.Millisecond))
+	return out, err
+}
+
+func (r *TimedRunner) RunContext(ctx context.Context, args ...string) (string, error) {
+	label := "git " + strings.Join(args, " ")
+	start := time.Now()
+	out, err := r.Inner.RunContext(ctx, args...)
+	logf("%s: %s", label, time.Since(start).Round(time.Millisecond))
+	return out, err
+}
+
+func (r *TimedRunner) RunInDirContext(ctx context.Context, dir string, args ...string) (string, error) {
+	label := fmt.Sprintf("git %s [%s]", strings.Join(args, " "), filepath.Base(dir))
+	start := time.Now()
+	out, err := r.Inner.RunInDirContext(ctx, dir, args...)
 	logf("%s: %s", label, time.Since(start).Round(time.Millisecond))
 	return out, err
 }

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -135,3 +135,39 @@ func TestStartTimerDisabled(t *testing.T) {
 		t.Errorf("expected no output when disabled, got %q", output)
 	}
 }
+
+func TestTimedRunnerRunContext(t *testing.T) {
+	t.Setenv("RIMBA_DEBUG", "1")
+
+	stub := &stubRunner{}
+	wrapped := WrapRunner(stub)
+
+	out, err := wrapped.RunContext(context.Background(), "status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "ok" {
+		t.Errorf("expected ok, got %s", out)
+	}
+	if !stub.runContextCalled {
+		t.Error("inner runner RunContext was not called")
+	}
+}
+
+func TestTimedRunnerRunInDirContext(t *testing.T) {
+	t.Setenv("RIMBA_DEBUG", "1")
+
+	stub := &stubRunner{}
+	wrapped := WrapRunner(stub)
+
+	out, err := wrapped.RunInDirContext(context.Background(), "/tmp/test", "status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != "ok" {
+		t.Errorf("expected ok, got %s", out)
+	}
+	if !stub.runInDirCtxCalled {
+		t.Error("inner runner RunInDirContext was not called")
+	}
+}

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -1,6 +1,7 @@
 package debug
 
 import (
+	"context"
 	"io"
 	"os"
 	"strings"
@@ -8,8 +9,10 @@ import (
 )
 
 type stubRunner struct {
-	runCalled      bool
-	runInDirCalled bool
+	runCalled         bool
+	runInDirCalled    bool
+	runContextCalled  bool
+	runInDirCtxCalled bool
 }
 
 func (s *stubRunner) Run(args ...string) (string, error) {
@@ -19,6 +22,16 @@ func (s *stubRunner) Run(args ...string) (string, error) {
 
 func (s *stubRunner) RunInDir(dir string, args ...string) (string, error) {
 	s.runInDirCalled = true
+	return "ok", nil
+}
+
+func (s *stubRunner) RunContext(_ context.Context, args ...string) (string, error) {
+	s.runContextCalled = true
+	return "ok", nil
+}
+
+func (s *stubRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
+	s.runInDirCtxCalled = true
 	return "ok", nil
 }
 

--- a/internal/deps/hooks.go
+++ b/internal/deps/hooks.go
@@ -17,7 +17,8 @@ type HookResult struct {
 }
 
 // RunPostCreateHooks executes shell commands in the worktree directory.
-// It stops launching new hooks if ctx is cancelled, but does not stop an already-running hook.
+// Skips launching new hooks when ctx is already cancelled; kills any in-flight
+// hook subprocess when ctx is cancelled (via exec.CommandContext).
 func RunPostCreateHooks(ctx context.Context, worktreeDir string, hooks []string, onProgress progress.Func) []HookResult {
 	results := make([]HookResult, 0, len(hooks))
 	for i, hook := range hooks {

--- a/internal/deps/hooks.go
+++ b/internal/deps/hooks.go
@@ -2,6 +2,7 @@ package deps
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -16,13 +17,16 @@ type HookResult struct {
 }
 
 // RunPostCreateHooks executes shell commands in the worktree directory.
-// It collects errors but does not stop on failure — all hooks run regardless.
-func RunPostCreateHooks(worktreeDir string, hooks []string, onProgress progress.Func) []HookResult {
+// It stops launching new hooks if ctx is cancelled, but does not stop an already-running hook.
+func RunPostCreateHooks(ctx context.Context, worktreeDir string, hooks []string, onProgress progress.Func) []HookResult {
 	results := make([]HookResult, 0, len(hooks))
 	for i, hook := range hooks {
+		if ctx.Err() != nil {
+			break
+		}
 		progress.Notifyf(onProgress, "%s (%d/%d)", hook, i+1, len(hooks))
 
-		cmd := exec.Command("sh", "-c", hook) //nolint:gosec // hook commands come from user config
+		cmd := exec.CommandContext(ctx, "sh", "-c", hook) //nolint:gosec // hook commands come from user config
 		cmd.Dir = worktreeDir
 
 		var buf bytes.Buffer

--- a/internal/deps/hooks.go
+++ b/internal/deps/hooks.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/lugassawan/rimba/internal/progress"
 )
@@ -29,6 +30,15 @@ func RunPostCreateHooks(ctx context.Context, worktreeDir string, hooks []string,
 
 		cmd := exec.CommandContext(ctx, "sh", "-c", hook) //nolint:gosec // hook commands come from user config
 		cmd.Dir = worktreeDir
+		// Put the subprocess in its own process group so that cancellation kills
+		// sh and all children it may have forked (e.g. sh -c sleep 30 on Linux).
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		cmd.Cancel = func() error {
+			if cmd.Process != nil {
+				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			}
+			return nil
+		}
 
 		var buf bytes.Buffer
 		cmd.Stdout = &buf

--- a/internal/deps/hooks_ctx_test.go
+++ b/internal/deps/hooks_ctx_test.go
@@ -1,0 +1,80 @@
+package deps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRunPostCreateHooksCancelledStopsLaunching(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so no hooks launch
+
+	start := time.Now()
+	results := RunPostCreateHooks(ctx, dir, []string{"sleep 5", "touch " + marker}, nil)
+	elapsed := time.Since(start)
+
+	if elapsed > time.Second {
+		t.Errorf("expected fast return on pre-cancelled ctx, took %v", elapsed)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("marker file should not have been created (second hook never ran)")
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for pre-cancelled ctx, got %d", len(results))
+	}
+}
+
+func TestRunPostCreateHooksKillsChild(t *testing.T) {
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan []HookResult, 1)
+	go func() {
+		done <- RunPostCreateHooks(ctx, dir, []string{"sleep 30"}, nil)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case results := <-done:
+		if len(results) == 0 || results[0].Error == nil {
+			t.Error("expected a non-nil error for killed hook")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunPostCreateHooks did not return within 2s after cancellation")
+	}
+}
+
+func TestRunInstallCancelledKillsChild(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	mod := Module{
+		Dir:        "node_modules",
+		InstallCmd: "sleep 30",
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runInstall(ctx, t.TempDir(), mod)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("expected non-nil error when install is cancelled")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runInstall did not return within 2s after cancellation")
+	}
+}

--- a/internal/deps/hooks_test.go
+++ b/internal/deps/hooks_test.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,7 +11,7 @@ import (
 func TestRunPostCreateHooksSuccess(t *testing.T) {
 	dir := t.TempDir()
 
-	results := RunPostCreateHooks(dir, []string{"touch marker.txt"}, nil)
+	results := RunPostCreateHooks(context.Background(), dir, []string{"touch marker.txt"}, nil)
 
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
@@ -28,7 +29,7 @@ func TestRunPostCreateHooksSuccess(t *testing.T) {
 func TestRunPostCreateHooksPartialFailure(t *testing.T) {
 	dir := t.TempDir()
 
-	results := RunPostCreateHooks(dir, []string{
+	results := RunPostCreateHooks(context.Background(), dir, []string{
 		"touch good.txt",
 		"false", // always fails
 		"touch also-good.txt",
@@ -60,7 +61,7 @@ func TestRunPostCreateHooksPartialFailure(t *testing.T) {
 func TestRunPostCreateHooksEmpty(t *testing.T) {
 	dir := t.TempDir()
 
-	results := RunPostCreateHooks(dir, nil, nil)
+	results := RunPostCreateHooks(context.Background(), dir, nil, nil)
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 results, got %d", len(results))
@@ -71,7 +72,7 @@ func TestRunPostCreateHooksShellFeatures(t *testing.T) {
 	dir := t.TempDir()
 
 	// Test shell features: pipes and quoting
-	results := RunPostCreateHooks(dir, []string{
+	results := RunPostCreateHooks(context.Background(), dir, []string{
 		"echo 'hello world' > output.txt",
 	}, nil)
 
@@ -97,7 +98,7 @@ func TestRunPostCreateHooksProgressCallback(t *testing.T) {
 	}
 
 	hooks := []string{"touch a.txt", "touch b.txt"}
-	RunPostCreateHooks(dir, hooks, onProgress)
+	RunPostCreateHooks(context.Background(), dir, hooks, onProgress)
 
 	if len(calls) != 2 {
 		t.Fatalf("expected 2 progress calls, got %d", len(calls))
@@ -113,7 +114,7 @@ func TestRunPostCreateHooksProgressCallback(t *testing.T) {
 func TestRunPostCreateHooksOutputCapture(t *testing.T) {
 	dir := t.TempDir()
 
-	results := RunPostCreateHooks(dir, []string{
+	results := RunPostCreateHooks(context.Background(), dir, []string{
 		"echo hook-output-captured && exit 1",
 	}, nil)
 

--- a/internal/deps/manager.go
+++ b/internal/deps/manager.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"sync/atomic"
+	"syscall"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/debug"
@@ -193,6 +194,16 @@ func runInstall(ctx context.Context, worktreePath string, mod Module) error {
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", mod.InstallCmd) //nolint:gosec // install commands come from user config
 	cmd.Dir = dir
+	// Put the subprocess in its own process group so cancellation kills sh and
+	// all children (e.g. npm spawns node children that would otherwise keep
+	// stdout/stderr pipes open and block cmd.Wait).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+		return nil
+	}
 
 	var buf bytes.Buffer
 	cmd.Stdout = &buf

--- a/internal/deps/manager.go
+++ b/internal/deps/manager.go
@@ -2,6 +2,7 @@ package deps
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -41,13 +42,13 @@ type InstallResult struct {
 
 // Install clones or installs deps for each module.
 // Pass existingEntries to skip an extra git.ListWorktrees call; nil fetches its own.
-func (m *Manager) Install(worktreePath string, modules []Module, existingEntries []git.WorktreeEntry, onProgress progress.Func) []InstallResult {
-	return m.install(worktreePath, "", modules, existingEntries, onProgress)
+func (m *Manager) Install(ctx context.Context, worktreePath string, modules []Module, existingEntries []git.WorktreeEntry, onProgress progress.Func) []InstallResult {
+	return m.install(ctx, worktreePath, "", modules, existingEntries, onProgress)
 }
 
 // InstallPreferSource is like Install but tries sourceWT first when cloning.
-func (m *Manager) InstallPreferSource(worktreePath, sourceWT string, modules []Module, existingEntries []git.WorktreeEntry, onProgress progress.Func) []InstallResult {
-	return m.install(worktreePath, sourceWT, modules, existingEntries, onProgress)
+func (m *Manager) InstallPreferSource(ctx context.Context, worktreePath, sourceWT string, modules []Module, existingEntries []git.WorktreeEntry, onProgress progress.Func) []InstallResult {
+	return m.install(ctx, worktreePath, sourceWT, modules, existingEntries, onProgress)
 }
 
 // ResolveModules detects and merges modules, filtering clone-only ones.
@@ -75,7 +76,7 @@ func ResolveModules(worktreePath, service string, autoDetect bool, configModules
 	return modules, nil
 }
 
-func (m *Manager) install(worktreePath, sourceWT string, modules []Module, existingEntries []git.WorktreeEntry, onProgress progress.Func) []InstallResult {
+func (m *Manager) install(ctx context.Context, worktreePath, sourceWT string, modules []Module, existingEntries []git.WorktreeEntry, onProgress progress.Func) []InstallResult {
 	defer debug.StartTimer("installing dependencies")()
 	results := make([]InstallResult, 0, len(modules))
 
@@ -105,7 +106,7 @@ func (m *Manager) install(worktreePath, sourceWT string, modules []Module, exist
 	total := len(hashed)
 
 	results = parallel.Collect(total, concurrency, func(i int) InstallResult {
-		res := m.installModule(worktreePath, hashed[i], existingPaths)
+		res := m.installModule(ctx, worktreePath, hashed[i], existingPaths)
 		completed := done.Add(1)
 		progress.Notifyf(onProgress, "%d/%d complete", completed, total)
 		return res
@@ -134,14 +135,14 @@ func buildExistingPaths(entries []git.WorktreeEntry, exclude, preferred string) 
 	return paths
 }
 
-func (m *Manager) installModule(worktreePath string, mh ModuleWithHash, existingPaths []string) InstallResult {
+func (m *Manager) installModule(ctx context.Context, worktreePath string, mh ModuleWithHash, existingPaths []string) InstallResult {
 	mod := mh.Module
 
 	if mh.Hash == "" {
 		return InstallResult{Module: mod}
 	}
 
-	if result, ok := tryCloneFromExisting(worktreePath, mh, existingPaths); ok {
+	if result, ok := tryCloneFromExisting(ctx, worktreePath, mh, existingPaths); ok {
 		return result
 	}
 
@@ -150,7 +151,7 @@ func (m *Manager) installModule(worktreePath string, mh ModuleWithHash, existing
 	}
 
 	if mod.InstallCmd != "" {
-		err := runInstall(worktreePath, mod)
+		err := runInstall(ctx, worktreePath, mod)
 		return InstallResult{Module: mod, Error: err}
 	}
 
@@ -158,7 +159,7 @@ func (m *Manager) installModule(worktreePath string, mh ModuleWithHash, existing
 }
 
 // tryCloneFromExisting attempts to clone the module from an existing worktree with matching lockfile.
-func tryCloneFromExisting(worktreePath string, mh ModuleWithHash, existingPaths []string) (InstallResult, bool) {
+func tryCloneFromExisting(ctx context.Context, worktreePath string, mh ModuleWithHash, existingPaths []string) (InstallResult, bool) {
 	mod := mh.Module
 	for _, wtPath := range existingPaths {
 		otherHash, err := HashLockfile(wtPath, mod.Lockfile)
@@ -173,7 +174,7 @@ func tryCloneFromExisting(worktreePath string, mh ModuleWithHash, existingPaths 
 
 		if err := CloneModule(wtPath, worktreePath, mod); err != nil {
 			if !mod.CloneOnly {
-				installErr := runInstall(worktreePath, mod)
+				installErr := runInstall(ctx, worktreePath, mod)
 				return InstallResult{Module: mod, Error: installErr}, true
 			}
 			return InstallResult{Module: mod, Error: fmt.Errorf("clone from %s: %w", wtPath, err)}, true
@@ -184,13 +185,13 @@ func tryCloneFromExisting(worktreePath string, mh ModuleWithHash, existingPaths 
 	return InstallResult{}, false
 }
 
-func runInstall(worktreePath string, mod Module) error {
+func runInstall(ctx context.Context, worktreePath string, mod Module) error {
 	dir := worktreePath
 	if mod.WorkDir != "" {
 		dir = filepath.Join(worktreePath, mod.WorkDir)
 	}
 
-	cmd := exec.Command("sh", "-c", mod.InstallCmd) //nolint:gosec // install commands come from user config
+	cmd := exec.CommandContext(ctx, "sh", "-c", mod.InstallCmd) //nolint:gosec // install commands come from user config
 	cmd.Dir = dir
 
 	var buf bytes.Buffer

--- a/internal/deps/manager_test.go
+++ b/internal/deps/manager_test.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -39,6 +40,14 @@ func (m *mockRunner) Run(args ...string) (string, error) {
 }
 
 func (m *mockRunner) RunInDir(dir string, args ...string) (string, error) {
+	return m.Run(args...)
+}
+
+func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
+	return m.Run(args...)
+}
+
+func (m *mockRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
 	return m.Run(args...)
 }
 
@@ -81,7 +90,7 @@ func TestManagerInstallClone(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -116,7 +125,7 @@ func TestManagerInstallNoMatchCloneOnly(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -143,7 +152,7 @@ func TestManagerInstallNoLockfile(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -179,7 +188,7 @@ func TestManagerInstallHashMismatch(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 
 	r := results[0]
 	if r.Cloned {
@@ -211,7 +220,7 @@ func TestManagerInstallPreferSource(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil, nil)
+	results := mgr.InstallPreferSource(context.Background(), newWT, sourceWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -329,7 +338,7 @@ func TestManagerInstallHashError(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -348,7 +357,7 @@ func TestManagerInstallModuleNoHash(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -380,7 +389,7 @@ func TestManagerInstallPreferSourceHashError(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil, nil)
+	results := mgr.InstallPreferSource(context.Background(), newWT, sourceWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -412,7 +421,7 @@ func TestManagerInstallFallbackToInstallCmd(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -441,7 +450,7 @@ func TestManagerInstallSingleWorktree(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -478,7 +487,7 @@ func TestManagerInstallCloneOnlyNoModDir(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -503,7 +512,7 @@ func TestManagerInstallPreferSourceNoLockfile(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil, nil)
+	results := mgr.InstallPreferSource(context.Background(), newWT, sourceWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -538,7 +547,7 @@ func TestManagerInstallWithInstallCmd(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedResults, len(results))
 	}
@@ -558,8 +567,12 @@ type errorRunner struct {
 	err error
 }
 
-func (e *errorRunner) Run(_ ...string) (string, error)                { return "", e.err }
-func (e *errorRunner) RunInDir(_ string, _ ...string) (string, error) { return "", e.err }
+func (e *errorRunner) Run(_ ...string) (string, error)                           { return "", e.err }
+func (e *errorRunner) RunInDir(_ string, _ ...string) (string, error)            { return "", e.err }
+func (e *errorRunner) RunContext(_ context.Context, _ ...string) (string, error) { return "", e.err }
+func (e *errorRunner) RunInDirContext(_ context.Context, _ string, _ ...string) (string, error) {
+	return "", e.err
+}
 
 func TestInstallListWorktreesError(t *testing.T) {
 	newWT := t.TempDir()
@@ -570,7 +583,7 @@ func TestInstallListWorktreesError(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -592,7 +605,7 @@ func TestInstallPreferSourceListWorktreesError(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm},
 	}
 
-	results := mgr.InstallPreferSource(newWT, sourceWT, modules, nil, nil)
+	results := mgr.InstallPreferSource(context.Background(), newWT, sourceWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -638,7 +651,7 @@ func TestManagerInstallCloneFailFallback(t *testing.T) {
 		modules := []Module{
 			{Dir: DirNodeModules, Lockfile: LockfilePnpm, CloneOnly: true},
 		}
-		results := mgr.Install(newWT, modules, nil, nil)
+		results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 		if len(results) != 1 {
 			t.Fatalf(fmtExpectedOneResult, len(results))
 		}
@@ -652,7 +665,7 @@ func TestManagerInstallCloneFailFallback(t *testing.T) {
 		modules := []Module{
 			{Dir: DirNodeModules, Lockfile: LockfilePnpm, InstallCmd: "echo fallback"},
 		}
-		results := mgr.Install(newWT, modules, nil, nil)
+		results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 		if len(results) != 1 {
 			t.Fatalf(fmtExpectedOneResult, len(results))
 		}
@@ -689,7 +702,7 @@ func TestManagerInstallWithWorkDir(t *testing.T) {
 		},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -716,7 +729,7 @@ func TestManagerInstallNoInstallCmd(t *testing.T) {
 		{Dir: DirNodeModules, Lockfile: LockfilePnpm}, // no InstallCmd
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 	if len(results) != 1 {
 		t.Fatalf(fmtExpectedOneResult, len(results))
 	}
@@ -736,7 +749,7 @@ func TestRunInstallError(t *testing.T) {
 		InstallCmd: "/nonexistent-command-xyz",
 	}
 
-	err := runInstall(dir, mod)
+	err := runInstall(context.Background(), dir, mod)
 	if err == nil {
 		t.Fatal("expected error from runInstall with invalid command")
 	}
@@ -765,7 +778,7 @@ func TestInstallProgressCallback(t *testing.T) {
 		calls = append(calls, progressCall{msg})
 	}
 
-	mgr.Install(newWT, modules, nil, onProgress)
+	mgr.Install(context.Background(), newWT, modules, nil, onProgress)
 
 	if len(calls) != 2 {
 		t.Fatalf("expected 2 progress calls, got %d", len(calls))
@@ -804,7 +817,7 @@ func TestInstallPreservesOrderWhenParallel(t *testing.T) {
 		}
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 
 	if len(results) != len(modules) {
 		t.Fatalf("expected %d results, got %d", len(modules), len(results))
@@ -840,7 +853,7 @@ func TestInstallParallelErrorIsolation(t *testing.T) {
 		{Dir: "c", Lockfile: LockfilePnpm, InstallCmd: "echo ok-c", WorkDir: "c"},
 	}
 
-	results := mgr.Install(newWT, modules, nil, nil)
+	results := mgr.Install(context.Background(), newWT, modules, nil, nil)
 
 	if len(results) != 3 {
 		t.Fatalf("expected 3 results, got %d", len(results))
@@ -878,7 +891,7 @@ func TestInstallOutputCapture(t *testing.T) {
 		InstallCmd: "echo captured-output && exit 1",
 	}
 
-	err := runInstall(dir, mod)
+	err := runInstall(context.Background(), dir, mod)
 	if err == nil {
 		t.Fatal("expected error from runInstall")
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -10,6 +11,8 @@ import (
 type Runner interface {
 	Run(args ...string) (string, error)
 	RunInDir(dir string, args ...string) (string, error)
+	RunContext(ctx context.Context, args ...string) (string, error)
+	RunInDirContext(ctx context.Context, dir string, args ...string) (string, error)
 }
 
 // ExecRunner is the production implementation of Runner.
@@ -18,12 +21,9 @@ type ExecRunner struct {
 	Dir string
 }
 
-func (r *ExecRunner) Run(args ...string) (string, error) {
-	return r.RunInDir(r.Dir, args...)
-}
-
-func (r *ExecRunner) RunInDir(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
+// RunInDirContext is the single execution primitive: all other methods delegate here.
+func (r *ExecRunner) RunInDirContext(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -34,4 +34,16 @@ func (r *ExecRunner) RunInDir(dir string, args ...string) (string, error) {
 		return result, fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), result, err)
 	}
 	return result, nil
+}
+
+func (r *ExecRunner) RunContext(ctx context.Context, args ...string) (string, error) {
+	return r.RunInDirContext(ctx, r.Dir, args...)
+}
+
+func (r *ExecRunner) Run(args ...string) (string, error) {
+	return r.RunInDirContext(context.Background(), r.Dir, args...)
+}
+
+func (r *ExecRunner) RunInDir(dir string, args ...string) (string, error) {
+	return r.RunInDirContext(context.Background(), dir, args...)
 }

--- a/internal/git/git_ctx_test.go
+++ b/internal/git/git_ctx_test.go
@@ -31,3 +31,14 @@ func TestRunDelegatesToContext(t *testing.T) {
 		t.Errorf("expected git version output, got: %q", out)
 	}
 }
+
+func TestRunContextDelegatesToRunInDirContext(t *testing.T) {
+	r := &ExecRunner{}
+	out, err := r.RunContext(context.Background(), "--version")
+	if err != nil {
+		t.Fatalf("RunContext: %v", err)
+	}
+	if !strings.Contains(out, "git") {
+		t.Errorf("expected git version output, got: %q", out)
+	}
+}

--- a/internal/git/git_ctx_test.go
+++ b/internal/git/git_ctx_test.go
@@ -1,0 +1,33 @@
+package git
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRunInDirContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	r := &ExecRunner{}
+	_, err := r.RunInDirContext(ctx, "", "status")
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("expected 'context canceled' in error, got: %v", err)
+	}
+}
+
+func TestRunDelegatesToContext(t *testing.T) {
+	r := &ExecRunner{}
+	// git --version is a fast, safe command available everywhere
+	out, err := r.Run("--version")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(out, "git") {
+		t.Errorf("expected git version output, got: %q", out)
+	}
+}

--- a/internal/git/merge.go
+++ b/internal/git/merge.go
@@ -1,18 +1,19 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
 
 // Merge runs `git merge [--no-ff] <branch>` inside the given directory.
-func Merge(r Runner, dir, branch string, noFF bool) error {
+func Merge(ctx context.Context, r Runner, dir, branch string, noFF bool) error {
 	args := []string{"merge"}
 	if noFF {
 		args = append(args, "--no-ff")
 	}
 	args = append(args, branch)
-	_, err := r.RunInDir(dir, args...)
+	_, err := r.RunInDirContext(ctx, dir, args...)
 	return err
 }
 

--- a/internal/git/merge_test.go
+++ b/internal/git/merge_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -27,7 +28,7 @@ func TestMergeBasic(t *testing.T) {
 	testutil.GitCmd(t, wtPath, "commit", "-m", "add new.txt")
 
 	// Merge into main repo
-	if err := git.Merge(r, repo, "feat/merge-basic", false); err != nil {
+	if err := git.Merge(context.Background(), r, repo, "feat/merge-basic", false); err != nil {
 		t.Fatalf("Merge: %v", err)
 	}
 
@@ -53,7 +54,7 @@ func TestMergeNoFF(t *testing.T) {
 	testutil.GitCmd(t, wtPath, "add", ".")
 	testutil.GitCmd(t, wtPath, "commit", "-m", "add noff.txt")
 
-	if err := git.Merge(r, repo, "feat/merge-noff", true); err != nil {
+	if err := git.Merge(context.Background(), r, repo, "feat/merge-noff", true); err != nil {
 		t.Fatalf("Merge --no-ff: %v", err)
 	}
 
@@ -73,7 +74,7 @@ func TestMergeError(t *testing.T) {
 	r := &git.ExecRunner{Dir: repo}
 
 	// Merge a nonexistent branch should fail
-	if err := git.Merge(r, repo, "nonexistent-branch", false); err == nil {
+	if err := git.Merge(context.Background(), r, repo, "nonexistent-branch", false); err == nil {
 		t.Error("expected error merging nonexistent branch")
 	}
 }
@@ -110,7 +111,7 @@ func TestMergeInProgress(t *testing.T) {
 	testutil.GitCmd(t, repo, "commit", "-m", "main change")
 
 	// Attempt the conflicting merge — it should fail.
-	if err := git.Merge(r, repo, "feat/conflict-source", false); err == nil {
+	if err := git.Merge(context.Background(), r, repo, "feat/conflict-source", false); err == nil {
 		t.Fatal("expected conflict error from Merge")
 	}
 
@@ -145,7 +146,7 @@ func TestMergeAbort(t *testing.T) {
 	testutil.GitCmd(t, repo, "add", ".")
 	testutil.GitCmd(t, repo, "commit", "-m", "main change")
 
-	if err := git.Merge(r, repo, "feat/abort-source", false); err == nil {
+	if err := git.Merge(context.Background(), r, repo, "feat/abort-source", false); err == nil {
 		t.Fatal("expected conflict error from Merge")
 	}
 

--- a/internal/git/mock_runner_test.go
+++ b/internal/git/mock_runner_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"slices"
@@ -41,6 +42,14 @@ func (m *mockRunner) Run(args ...string) (string, error) {
 }
 
 func (m *mockRunner) RunInDir(dir string, args ...string) (string, error) {
+	return m.runInDir(dir, args...)
+}
+
+func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
+	return m.run(args...)
+}
+
+func (m *mockRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
 	return m.runInDir(dir, args...)
 }
 

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -24,13 +25,13 @@ func RemoteExists(r Runner, name string) bool {
 
 // RemotePrune runs `git remote prune <remote>`, deleting stale remote-tracking
 // refs, and returns the names of the refs that were (or would be) pruned.
-func RemotePrune(r Runner, remote string, dryRun bool) ([]string, error) {
+func RemotePrune(ctx context.Context, r Runner, remote string, dryRun bool) ([]string, error) {
 	args := []string{"remote", "prune"}
 	if dryRun {
 		args = append(args, "--dry-run")
 	}
 	args = append(args, remote)
-	out, err := r.Run(args...)
+	out, err := r.RunContext(ctx, args...)
 	if err != nil {
 		return nil, errhint.WithFix(
 			fmt.Errorf("remote prune: %w", err),
@@ -42,8 +43,8 @@ func RemotePrune(r Runner, remote string, dryRun bool) ([]string, error) {
 
 // DeleteRemoteBranch deletes a branch on the given remote.
 // An already-gone remote ref is treated as success (idempotent).
-func DeleteRemoteBranch(r Runner, remote, branch string) error {
-	_, err := r.Run("push", remote, "--delete", branch)
+func DeleteRemoteBranch(ctx context.Context, r Runner, remote, branch string) error {
+	_, err := r.RunContext(ctx, "push", remote, "--delete", branch)
 	if err == nil {
 		return nil
 	}
@@ -86,11 +87,11 @@ func ListRemotes(r Runner) ([]string, error) {
 // successful remotes are collected and returned. Any remote that fails is
 // recorded in the failures slice; iteration continues regardless of errors.
 // Both return values are initialized as non-nil empty slices.
-func PruneRemotes(r Runner, remotes []string, dryRun bool) ([]string, []RemoteFailure) {
+func PruneRemotes(ctx context.Context, r Runner, remotes []string, dryRun bool) ([]string, []RemoteFailure) {
 	pruned := []string{}
 	failures := []RemoteFailure{}
 	for _, remote := range remotes {
-		refs, err := RemotePrune(r, remote, dryRun)
+		refs, err := RemotePrune(ctx, r, remote, dryRun)
 		if err != nil {
 			failures = append(failures, RemoteFailure{Remote: remote, Err: err})
 			continue

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"slices"
 	"strings"
@@ -15,7 +16,7 @@ func TestDeleteRemoteBranchSuccess(t *testing.T) {
 			return "", nil
 		},
 	}
-	if err := DeleteRemoteBranch(r, "origin", "feature/done"); err != nil {
+	if err := DeleteRemoteBranch(context.Background(), r, "origin", "feature/done"); err != nil {
 		t.Fatalf("DeleteRemoteBranch: %v", err)
 	}
 	want := []string{"push", "origin", "--delete", "feature/done"}
@@ -35,7 +36,7 @@ func TestDeleteRemoteBranchRefGoneIsIdempotent(t *testing.T) {
 			return "", errors.New("error: remote ref does not exist")
 		},
 	}
-	if err := DeleteRemoteBranch(r, "origin", "gone-branch"); err != nil {
+	if err := DeleteRemoteBranch(context.Background(), r, "origin", "gone-branch"); err != nil {
 		t.Fatalf("expected nil for already-gone remote ref, got: %v", err)
 	}
 }
@@ -46,7 +47,7 @@ func TestDeleteRemoteBranchFailure(t *testing.T) {
 			return "", errors.New("connection refused")
 		},
 	}
-	err := DeleteRemoteBranch(r, "origin", "feature/x")
+	err := DeleteRemoteBranch(context.Background(), r, "origin", "feature/x")
 	if err == nil {
 		t.Fatal("expected non-nil error for remote failure")
 	}
@@ -121,7 +122,7 @@ func TestRemotePruneNormal(t *testing.T) {
 			return "", nil
 		},
 	}
-	if _, err := RemotePrune(r, "origin", false); err != nil {
+	if _, err := RemotePrune(context.Background(), r, "origin", false); err != nil {
 		t.Fatalf("RemotePrune: %v", err)
 	}
 	want := []string{"remote", "prune", "origin"}
@@ -146,7 +147,7 @@ func TestRemotePruneDryRun(t *testing.T) {
 			return "", nil
 		},
 	}
-	if _, err := RemotePrune(r, "origin", true); err != nil {
+	if _, err := RemotePrune(context.Background(), r, "origin", true); err != nil {
 		t.Fatalf("RemotePrune dry-run: %v", err)
 	}
 	want := []string{"remote", "prune", "--dry-run", "origin"}
@@ -167,7 +168,7 @@ func TestRemotePruneParsesRefs(t *testing.T) {
 			return output, nil
 		},
 	}
-	refs, err := RemotePrune(r, "origin", false)
+	refs, err := RemotePrune(context.Background(), r, "origin", false)
 	if err != nil {
 		t.Fatalf("RemotePrune: %v", err)
 	}
@@ -189,7 +190,7 @@ func TestRemotePruneDryRunParsesRefs(t *testing.T) {
 			return output, nil
 		},
 	}
-	refs, err := RemotePrune(r, "origin", true)
+	refs, err := RemotePrune(context.Background(), r, "origin", true)
 	if err != nil {
 		t.Fatalf("RemotePrune dry-run: %v", err)
 	}
@@ -205,7 +206,7 @@ func TestRemotePruneNoRefs(t *testing.T) {
 			return output, nil
 		},
 	}
-	refs, err := RemotePrune(r, "origin", false)
+	refs, err := RemotePrune(context.Background(), r, "origin", false)
 	if err != nil {
 		t.Fatalf("RemotePrune: %v", err)
 	}
@@ -220,7 +221,7 @@ func TestRemotePruneErrorWrapping(t *testing.T) {
 			return "", errors.New("connection refused")
 		},
 	}
-	_, err := RemotePrune(r, "origin", false)
+	_, err := RemotePrune(context.Background(), r, "origin", false)
 	if err == nil {
 		t.Fatal("expected error from RemotePrune")
 	}
@@ -294,7 +295,7 @@ func TestPruneRemotesBothSucceed(t *testing.T) {
 			return calls[remote], nil
 		},
 	}
-	pruned, failures := PruneRemotes(r, []string{"origin", "upstream"}, false)
+	pruned, failures := PruneRemotes(context.Background(), r, []string{"origin", "upstream"}, false)
 	if len(failures) != 0 {
 		t.Fatalf("expected no failures, got %v", failures)
 	}
@@ -319,7 +320,7 @@ func TestPruneRemotesPartialFailure(t *testing.T) {
 			return " * [pruned] origin/old\n", nil
 		},
 	}
-	pruned, failures := PruneRemotes(r, []string{"origin", "upstream"}, false)
+	pruned, failures := PruneRemotes(context.Background(), r, []string{"origin", "upstream"}, false)
 	if len(failures) != 1 {
 		t.Fatalf("expected 1 failure, got %d: %v", len(failures), failures)
 	}
@@ -341,7 +342,7 @@ func TestPruneRemotesEmptyInput(t *testing.T) {
 			return "", nil
 		},
 	}
-	pruned, failures := PruneRemotes(r, []string{}, false)
+	pruned, failures := PruneRemotes(context.Background(), r, []string{}, false)
 	if pruned == nil {
 		t.Error("expected non-nil pruned slice")
 	}

--- a/internal/git/sync.go
+++ b/internal/git/sync.go
@@ -1,18 +1,21 @@
 package git
 
+import "context"
+
 // Fetch runs `git fetch <remote>` to update remote tracking branches.
-func Fetch(r Runner, remote string) error {
-	_, err := r.Run("fetch", remote)
+func Fetch(ctx context.Context, r Runner, remote string) error {
+	_, err := r.RunContext(ctx, "fetch", remote)
 	return err
 }
 
 // Rebase runs `git rebase <branch>` inside the given directory.
-func Rebase(r Runner, dir, branch string) error {
-	_, err := r.RunInDir(dir, "rebase", branch)
+func Rebase(ctx context.Context, r Runner, dir, branch string) error {
+	_, err := r.RunInDirContext(ctx, dir, "rebase", branch)
 	return err
 }
 
 // AbortRebase runs `git rebase --abort` inside the given directory.
+// Intentionally non-cancellable: rebase recovery must succeed even after Ctrl-C.
 func AbortRebase(r Runner, dir string) error {
 	_, err := r.RunInDir(dir, "rebase", "--abort")
 	return err
@@ -37,13 +40,13 @@ func HasUpstream(r Runner, dir string) bool {
 }
 
 // Push runs `git push` inside the given directory.
-func Push(r Runner, dir string) error {
-	_, err := r.RunInDir(dir, "push")
+func Push(ctx context.Context, r Runner, dir string) error {
+	_, err := r.RunInDirContext(ctx, dir, "push")
 	return err
 }
 
 // PushForceWithLease runs `git push --force-with-lease` inside the given directory.
-func PushForceWithLease(r Runner, dir string) error {
-	_, err := r.RunInDir(dir, "push", "--force-with-lease")
+func PushForceWithLease(ctx context.Context, r Runner, dir string) error {
+	_, err := r.RunInDirContext(ctx, dir, "push", "--force-with-lease")
 	return err
 }

--- a/internal/git/sync_ctx_test.go
+++ b/internal/git/sync_ctx_test.go
@@ -40,6 +40,24 @@ func (m *ctxMockRunner) RunInDirContext(ctx context.Context, dir string, args ..
 
 type ctxKey struct{}
 
+func TestFetchContextCancelledReturnsFast(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel — Fetch should return immediately without launching git
+
+	r := &ExecRunner{}
+	start := time.Now()
+	err := Fetch(ctx, r, "origin")
+	if time.Since(start) > time.Second {
+		t.Errorf("Fetch with cancelled ctx took too long: %v", time.Since(start))
+	}
+	if err == nil {
+		t.Fatal("expected error from cancelled Fetch, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+}
+
 func TestFetchPassesContext(t *testing.T) {
 	sentinel := context.WithValue(context.Background(), ctxKey{}, "sentinel")
 	r := &ctxMockRunner{}

--- a/internal/git/sync_ctx_test.go
+++ b/internal/git/sync_ctx_test.go
@@ -1,0 +1,92 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// ctxMockRunner is an extended mock that captures the context for assertion.
+type ctxMockRunner struct {
+	run         func(ctx context.Context, args ...string) (string, error)
+	runInDir    func(ctx context.Context, dir string, args ...string) (string, error)
+	capturedCtx context.Context
+}
+
+func (m *ctxMockRunner) Run(args ...string) (string, error) {
+	return m.RunContext(context.Background(), args...)
+}
+
+func (m *ctxMockRunner) RunInDir(dir string, args ...string) (string, error) {
+	return m.RunInDirContext(context.Background(), dir, args...)
+}
+
+func (m *ctxMockRunner) RunContext(ctx context.Context, args ...string) (string, error) {
+	m.capturedCtx = ctx
+	if m.run != nil {
+		return m.run(ctx, args...)
+	}
+	return "", nil
+}
+
+func (m *ctxMockRunner) RunInDirContext(ctx context.Context, dir string, args ...string) (string, error) {
+	m.capturedCtx = ctx
+	if m.runInDir != nil {
+		return m.runInDir(ctx, dir, args...)
+	}
+	return "", nil
+}
+
+type ctxKey struct{}
+
+func TestFetchPassesContext(t *testing.T) {
+	sentinel := context.WithValue(context.Background(), ctxKey{}, "sentinel")
+	r := &ctxMockRunner{}
+
+	if err := Fetch(sentinel, r, "origin"); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if r.capturedCtx == nil {
+		t.Fatal("context was not captured")
+	}
+	if r.capturedCtx.Value(ctxKey{}) != "sentinel" {
+		t.Error("sentinel context value not propagated")
+	}
+}
+
+func TestRebaseContextCancelledReturnsFast(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	blocker := make(chan struct{})
+	r := &ctxMockRunner{
+		runInDir: func(ctx context.Context, dir string, args ...string) (string, error) {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-blocker:
+				return "", nil
+			}
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Rebase(ctx, r, fakeDir, branchMain)
+	}()
+
+	// Cancel after a brief moment
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	close(blocker)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected context.Canceled, got: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Rebase did not return within 1s after cancellation")
+	}
+}

--- a/internal/git/sync_test.go
+++ b/internal/git/sync_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"slices"
 	"testing"
@@ -27,7 +28,7 @@ func TestFetch(t *testing.T) {
 		},
 	}
 
-	if err := Fetch(r, remoteOrigin); err != nil {
+	if err := Fetch(context.Background(), r, remoteOrigin); err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
 
@@ -43,7 +44,7 @@ func TestFetchError(t *testing.T) {
 		},
 	}
 
-	err := Fetch(r, remoteOrigin)
+	err := Fetch(context.Background(), r, remoteOrigin)
 	if err == nil {
 		t.Fatal("expected error from Fetch")
 	}
@@ -61,7 +62,7 @@ func TestRebase(t *testing.T) {
 		},
 	}
 
-	if err := Rebase(r, fakeDir, branchMain); err != nil {
+	if err := Rebase(context.Background(), r, fakeDir, branchMain); err != nil {
 		t.Fatalf("Rebase: %v", err)
 	}
 
@@ -80,7 +81,7 @@ func TestRebaseError(t *testing.T) {
 		},
 	}
 
-	err := Rebase(r, fakeDir, branchMain)
+	err := Rebase(context.Background(), r, fakeDir, branchMain)
 	if err == nil {
 		t.Fatal("expected error from Rebase")
 	}
@@ -207,7 +208,7 @@ func TestPush(t *testing.T) {
 		},
 	}
 
-	if err := Push(r, fakeDir); err != nil {
+	if err := Push(context.Background(), r, fakeDir); err != nil {
 		t.Fatalf("Push: %v", err)
 	}
 
@@ -226,7 +227,7 @@ func TestPushError(t *testing.T) {
 		},
 	}
 
-	err := Push(r, fakeDir)
+	err := Push(context.Background(), r, fakeDir)
 	if err == nil {
 		t.Fatal("expected error from Push")
 	}
@@ -244,7 +245,7 @@ func TestPushForceWithLease(t *testing.T) {
 		},
 	}
 
-	if err := PushForceWithLease(r, fakeDir); err != nil {
+	if err := PushForceWithLease(context.Background(), r, fakeDir); err != nil {
 		t.Fatalf("PushForceWithLease: %v", err)
 	}
 
@@ -263,7 +264,7 @@ func TestPushForceWithLeaseError(t *testing.T) {
 		},
 	}
 
-	err := PushForceWithLease(r, fakeDir)
+	err := PushForceWithLease(context.Background(), r, fakeDir)
 	if err == nil {
 		t.Fatal("expected error from PushForceWithLease")
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -42,6 +42,14 @@ func (m *mockRunner) RunInDir(dir string, args ...string) (string, error) {
 	return m.runInDir(dir, args...)
 }
 
+func (m *mockRunner) RunContext(ctx context.Context, args ...string) (string, error) {
+	return m.Run(args...)
+}
+
+func (m *mockRunner) RunInDirContext(ctx context.Context, dir string, args ...string) (string, error) {
+	return m.RunInDir(dir, args...)
+}
+
 // testConfig returns a minimal config suitable for testing.
 func testConfig() *config.Config {
 	return &config.Config{

--- a/internal/mcp/tool_add.go
+++ b/internal/mcp/tool_add.go
@@ -68,7 +68,7 @@ func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 			configModules = cfg.Deps.Modules
 		}
 
-		result, err := operations.AddWorktree(hctx.Runner, operations.AddParams{
+		result, err := operations.AddWorktree(ctx, hctx.Runner, operations.AddParams{
 			Task:    task,
 			Service: service,
 			Prefix:  prefix,

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -90,7 +90,7 @@ func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dry
 
 	// Fetch latest (non-fatal; cancellation propagated as a tool error)
 	mergeRef := mainBranch
-	if fetchWarn, fetchErr := mcpFetchNonFatal(ctx, r, git.DefaultRemote); fetchErr != nil {
+	if fetchWarn, fetchErr := mcpFetchNonFatal(ctx, r); fetchErr != nil {
 		return mcp.NewToolResultError(fetchErr.Error()), nil
 	} else if fetchWarn == "" {
 		mergeRef = git.DefaultRemote + "/" + mainBranch

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -88,9 +88,11 @@ func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dry
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	// Fetch latest (non-fatal)
+	// Fetch latest (non-fatal; cancellation propagated as a tool error)
 	mergeRef := mainBranch
-	if err := git.Fetch(ctx, r, git.DefaultRemote); err == nil {
+	if fetchWarn, fetchErr := mcpFetchNonFatal(ctx, r, git.DefaultRemote); fetchErr != nil {
+		return mcp.NewToolResultError(fetchErr.Error()), nil
+	} else if fetchWarn == "" {
 		mergeRef = git.DefaultRemote + "/" + mainBranch
 	}
 

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -42,18 +42,18 @@ func handleClean(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		switch mode {
 		case "prune":
-			return mcpCleanPrune(r, dryRun)
+			return mcpCleanPrune(ctx, r, dryRun)
 		case "merged":
-			return mcpCleanMerged(r, hctx, dryRun)
+			return mcpCleanMerged(ctx, r, hctx, dryRun)
 		case "stale":
-			return mcpCleanStale(r, hctx, dryRun, staleDays)
+			return mcpCleanStale(ctx, r, hctx, dryRun, staleDays)
 		default:
 			return mcp.NewToolResultError(fmt.Sprintf("invalid mode %q; use prune, merged, or stale", mode)), nil
 		}
 	}
 }
 
-func mcpCleanPrune(r git.Runner, dryRun bool) (*mcp.CallToolResult, error) {
+func mcpCleanPrune(ctx context.Context, r git.Runner, dryRun bool) (*mcp.CallToolResult, error) {
 	output, err := git.Prune(r, dryRun)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -66,7 +66,7 @@ func mcpCleanPrune(r git.Runner, dryRun bool) (*mcp.CallToolResult, error) {
 		warnings = append(warnings, fmt.Sprintf("failed to list remotes: %v", err))
 	} else {
 		var failures []git.RemoteFailure
-		remotePruned, failures = git.PruneRemotes(r, remotes, dryRun)
+		remotePruned, failures = git.PruneRemotes(ctx, r, remotes, dryRun)
 		for _, f := range failures {
 			warnings = append(warnings, fmt.Sprintf("failed to prune %s: %v", f.Remote, f.Err))
 		}
@@ -82,7 +82,7 @@ func mcpCleanPrune(r git.Runner, dryRun bool) (*mcp.CallToolResult, error) {
 	})
 }
 
-func mcpCleanMerged(r git.Runner, hctx *HandlerContext, dryRun bool) (*mcp.CallToolResult, error) {
+func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dryRun bool) (*mcp.CallToolResult, error) {
 	mainBranch, err := operations.ResolveMainBranch(r, configDefault(hctx))
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -90,7 +90,7 @@ func mcpCleanMerged(r git.Runner, hctx *HandlerContext, dryRun bool) (*mcp.CallT
 
 	// Fetch latest (non-fatal)
 	mergeRef := mainBranch
-	if err := git.Fetch(r, git.DefaultRemote); err == nil {
+	if err := git.Fetch(ctx, r, git.DefaultRemote); err == nil {
 		mergeRef = git.DefaultRemote + "/" + mainBranch
 	}
 
@@ -115,7 +115,7 @@ func mcpCleanMerged(r git.Runner, hctx *HandlerContext, dryRun bool) (*mcp.CallT
 	// Force mode: no confirmation prompts. Probe origin once and pass the result
 	// directly so RemoveCandidates does not re-issue git remote get-url per candidate.
 	originPresent := git.RemoteExists(r, git.DefaultRemote)
-	opItems := operations.RemoveCandidates(r, mergedResult.Candidates, originPresent, nil)
+	opItems := operations.RemoveCandidates(ctx, r, mergedResult.Candidates, originPresent, nil)
 	warnings := mergedResult.Warnings
 	items := make([]cleanedItem, len(opItems))
 	for i, item := range opItems {
@@ -132,7 +132,7 @@ func mcpCleanMerged(r git.Runner, hctx *HandlerContext, dryRun bool) (*mcp.CallT
 	})
 }
 
-func mcpCleanStale(r git.Runner, hctx *HandlerContext, dryRun bool, staleDays int) (*mcp.CallToolResult, error) {
+func mcpCleanStale(ctx context.Context, r git.Runner, hctx *HandlerContext, dryRun bool, staleDays int) (*mcp.CallToolResult, error) {
 	mainBranch, err := operations.ResolveMainBranch(r, configDefault(hctx))
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -161,7 +161,7 @@ func mcpCleanStale(r git.Runner, hctx *HandlerContext, dryRun bool, staleDays in
 		toRemove[i] = c.CleanCandidate
 	}
 
-	opItems := operations.RemoveCandidates(r, toRemove, false, nil)
+	opItems := operations.RemoveCandidates(ctx, r, toRemove, false, nil)
 	items := make([]cleanedItem, len(opItems))
 	for i, item := range opItems {
 		items[i] = cleanedItem{Branch: item.Branch, Path: item.Path}

--- a/internal/mcp/tool_merge.go
+++ b/internal/mcp/tool_merge.go
@@ -51,7 +51,7 @@ func handleMerge(hctx *HandlerContext) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(cfgErr.Error()), nil
 		}
 
-		result, err := operations.MergeWorktree(hctx.Runner, operations.MergeParams{
+		result, err := operations.MergeWorktree(ctx, hctx.Runner, operations.MergeParams{
 			SourceTask:    sourceTask,
 			SourceService: sourceService,
 			IntoTask:      intoTask,

--- a/internal/mcp/tool_sync.go
+++ b/internal/mcp/tool_sync.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
@@ -65,10 +66,10 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		r := hctx.Runner
 
-		// Fetch (non-fatal)
-		var fetchWarning string
-		if err := git.Fetch(ctx, r, "origin"); err != nil {
-			fetchWarning = "fetch failed (no remote?): continuing with local state"
+		// Fetch (non-fatal; cancellation propagated as a tool error)
+		fetchWarning, fetchErr := mcpFetchNonFatal(ctx, r, "origin")
+		if fetchErr != nil {
+			return mcp.NewToolResultError(fetchErr.Error()), nil
 		}
 
 		worktrees, err := operations.ListWorktreeInfos(r)
@@ -113,6 +114,18 @@ func syncMultiple(ctx context.Context, r git.Runner, worktrees []resolver.Worktr
 	})
 
 	return marshalResult(syncResult{FetchWarning: opts.fetchWarning, Results: results})
+}
+
+// mcpFetchNonFatal runs git fetch and returns a warning string on connectivity failure.
+// Cancellation is returned as a hard error so callers can propagate it.
+func mcpFetchNonFatal(ctx context.Context, r git.Runner, remote string) (warning string, err error) {
+	if fetchErr := git.Fetch(ctx, r, remote); fetchErr != nil {
+		if errors.Is(fetchErr, context.Canceled) || errors.Is(fetchErr, context.DeadlineExceeded) {
+			return "", fetchErr
+		}
+		return "fetch failed (no remote?): continuing with local state", nil
+	}
+	return "", nil
 }
 
 func convertSyncResult(sr operations.SyncWorktreeResult) syncWorktreeResult {

--- a/internal/mcp/tool_sync.go
+++ b/internal/mcp/tool_sync.go
@@ -67,7 +67,7 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		// Fetch (non-fatal)
 		var fetchWarning string
-		if err := git.Fetch(r, "origin"); err != nil {
+		if err := git.Fetch(ctx, r, "origin"); err != nil {
 			fetchWarning = "fetch failed (no remote?): continuing with local state"
 		}
 
@@ -85,31 +85,31 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 		}
 
 		if !all {
-			return syncSingle(r, service, task, worktrees, prefixes, opts)
+			return syncSingle(ctx, r, service, task, worktrees, prefixes, opts)
 		}
-		return syncMultiple(r, worktrees, prefixes, opts, includeInherited)
+		return syncMultiple(ctx, r, worktrees, prefixes, opts, includeInherited)
 	}
 }
 
-func syncSingle(r git.Runner, service, task string, worktrees []resolver.WorktreeInfo, prefixes []string, opts syncOpts) (*mcp.CallToolResult, error) {
+func syncSingle(ctx context.Context, r git.Runner, service, task string, worktrees []resolver.WorktreeInfo, prefixes []string, opts syncOpts) (*mcp.CallToolResult, error) {
 	wt, found := resolver.FindBranchForTask(service, task, worktrees, prefixes)
 	if !found {
 		return mcp.NewToolResultError("worktree not found for task \"" + task + "\""), nil
 	}
 
-	sr := operations.SyncWorktree(r, opts.mainBranch, wt, opts.useMerge, opts.push)
+	sr := operations.SyncWorktree(ctx, r, opts.mainBranch, wt, opts.useMerge, opts.push)
 
 	results := []syncWorktreeResult{convertSyncResult(sr)}
 
 	return marshalResult(syncResult{FetchWarning: opts.fetchWarning, Results: results})
 }
 
-func syncMultiple(r git.Runner, worktrees []resolver.WorktreeInfo, prefixes []string, opts syncOpts, includeInherited bool) (*mcp.CallToolResult, error) {
+func syncMultiple(ctx context.Context, r git.Runner, worktrees []resolver.WorktreeInfo, prefixes []string, opts syncOpts, includeInherited bool) (*mcp.CallToolResult, error) {
 	allTasks := operations.CollectTasks(worktrees, prefixes)
 	eligible := operations.FilterEligible(worktrees, prefixes, opts.mainBranch, allTasks, includeInherited)
 
 	results := parallel.Collect(len(eligible), 4, func(i int) syncWorktreeResult {
-		return convertSyncResult(operations.SyncWorktree(r, opts.mainBranch, eligible[i], opts.useMerge, opts.push))
+		return convertSyncResult(operations.SyncWorktree(ctx, r, opts.mainBranch, eligible[i], opts.useMerge, opts.push))
 	})
 
 	return marshalResult(syncResult{FetchWarning: opts.fetchWarning, Results: results})

--- a/internal/mcp/tool_sync.go
+++ b/internal/mcp/tool_sync.go
@@ -67,7 +67,7 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 		r := hctx.Runner
 
 		// Fetch (non-fatal; cancellation propagated as a tool error)
-		fetchWarning, fetchErr := mcpFetchNonFatal(ctx, r, "origin")
+		fetchWarning, fetchErr := mcpFetchNonFatal(ctx, r)
 		if fetchErr != nil {
 			return mcp.NewToolResultError(fetchErr.Error()), nil
 		}
@@ -116,10 +116,11 @@ func syncMultiple(ctx context.Context, r git.Runner, worktrees []resolver.Worktr
 	return marshalResult(syncResult{FetchWarning: opts.fetchWarning, Results: results})
 }
 
-// mcpFetchNonFatal runs git fetch and returns a warning string on connectivity failure.
-// Cancellation is returned as a hard error so callers can propagate it.
-func mcpFetchNonFatal(ctx context.Context, r git.Runner, remote string) (warning string, err error) {
-	if fetchErr := git.Fetch(ctx, r, remote); fetchErr != nil {
+// mcpFetchNonFatal fetches from git.DefaultRemote ("origin") and returns a
+// warning string on connectivity failure. Cancellation is returned as a hard
+// error so callers can propagate it.
+func mcpFetchNonFatal(ctx context.Context, r git.Runner) (warning string, err error) {
+	if fetchErr := git.Fetch(ctx, r, git.DefaultRemote); fetchErr != nil {
 		if errors.Is(fetchErr, context.Canceled) || errors.Is(fetchErr, context.DeadlineExceeded) {
 			return "", fetchErr
 		}

--- a/internal/mcp/tool_sync_test.go
+++ b/internal/mcp/tool_sync_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -543,5 +544,32 @@ func TestSyncSingleStatusCheckError(t *testing.T) {
 	}
 	if !strings.Contains(sr.SkipReason, "could not check status") {
 		t.Errorf("expected skip reason about status check, got %q", sr.SkipReason)
+	}
+}
+
+func TestMcpFetchNonFatalCancelled(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", context.Canceled
+		},
+	}
+	warn, err := mcpFetchNonFatal(context.Background(), r)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got err=%v warn=%q", err, warn)
+	}
+}
+
+func TestMcpFetchNonFatalConnectivityFailure(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", errors.New("no remote configured")
+		},
+	}
+	warn, err := mcpFetchNonFatal(context.Background(), r)
+	if err != nil {
+		t.Errorf("connectivity failure should not return error, got %v", err)
+	}
+	if warn == "" {
+		t.Error("expected non-empty warning for connectivity failure")
 	}
 }

--- a/internal/operations/add.go
+++ b/internal/operations/add.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -48,7 +49,7 @@ type AddResult struct {
 }
 
 // AddWorktree creates a new worktree, copies files, installs deps, and runs hooks.
-func AddWorktree(r git.Runner, params AddParams, onProgress progress.Func) (AddResult, error) {
+func AddWorktree(ctx context.Context, r git.Runner, params AddParams, onProgress progress.Func) (AddResult, error) {
 	branch := resolver.FullBranchName(params.Service, params.Prefix, params.Task)
 	wtPath := resolver.WorktreePath(params.WorktreeDir, branch)
 
@@ -81,7 +82,7 @@ func AddWorktree(r git.Runner, params AddParams, onProgress progress.Func) (AddR
 	}
 
 	// Post-create setup: copy files, deps, hooks
-	pcResult, err := PostCreateSetup(r, PostCreateParams{
+	pcResult, err := PostCreateSetup(ctx, r, PostCreateParams{
 		RepoRoot:      params.RepoRoot,
 		WtPath:        wtPath,
 		Task:          params.Task,

--- a/internal/operations/add_pr_worktree.go
+++ b/internal/operations/add_pr_worktree.go
@@ -44,12 +44,12 @@ func AddPRWorktree(
 		task = "review/" + strconv.Itoa(meta.Number) + "-" + resolver.Slugify(meta.Title)
 	}
 
-	source, err := resolveSource(gitR, meta, onProgress)
+	source, err := resolveSource(ctx, gitR, meta, onProgress)
 	if err != nil {
 		return AddResult{}, err
 	}
 
-	return AddWorktree(gitR, AddParams{
+	return AddWorktree(ctx, gitR, AddParams{
 		Task:              task,
 		Source:            source,
 		PostCreateOptions: params.PostCreateOptions,
@@ -58,10 +58,10 @@ func AddPRWorktree(
 
 // resolveSource fetches the appropriate remote ref and returns the source ref
 // for use with git worktree add -b <branch> <path> <source>.
-func resolveSource(gitR git.Runner, meta gh.PRMeta, onProgress progress.Func) (string, error) {
+func resolveSource(ctx context.Context, gitR git.Runner, meta gh.PRMeta, onProgress progress.Func) (string, error) {
 	if !meta.IsCrossRepository {
 		progress.Notify(onProgress, "Fetching origin...")
-		if err := git.Fetch(gitR, "origin"); err != nil {
+		if err := git.Fetch(ctx, gitR, "origin"); err != nil {
 			return "", errhint.WithFix(err, "check network connectivity")
 		}
 		return "origin/" + meta.HeadRefName, nil
@@ -78,7 +78,7 @@ func resolveSource(gitR git.Runner, meta gh.PRMeta, onProgress progress.Func) (s
 	}
 
 	progress.Notify(onProgress, fmt.Sprintf("Fetching %s...", remoteName))
-	if err := git.Fetch(gitR, remoteName); err != nil {
+	if err := git.Fetch(ctx, gitR, remoteName); err != nil {
 		return "", errhint.WithFix(err, "check network and fork visibility")
 	}
 

--- a/internal/operations/add_test.go
+++ b/internal/operations/add_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -30,7 +31,7 @@ func TestAddWorktreeSuccess(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := AddWorktree(r, AddParams{
+	result, err := AddWorktree(context.Background(), r, AddParams{
 		Task:   "login",
 		Prefix: "feature/",
 		Source: branchMain,
@@ -70,7 +71,7 @@ func TestAddWorktreeBranchExists(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := AddWorktree(r, AddParams{
+	_, err := AddWorktree(context.Background(), r, AddParams{
 		Task:   "login",
 		Prefix: "feature/",
 		Source: branchMain,
@@ -104,7 +105,7 @@ func TestAddWorktreePathExists(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := AddWorktree(r, AddParams{
+	_, err := AddWorktree(context.Background(), r, AddParams{
 		Task:   "login",
 		Prefix: "feature/",
 		Source: branchMain,
@@ -137,7 +138,7 @@ func TestAddWorktreeCreateFails(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := AddWorktree(r, AddParams{
+	_, err := AddWorktree(context.Background(), r, AddParams{
 		Task:   "login",
 		Prefix: "feature/",
 		Source: branchMain,
@@ -176,7 +177,7 @@ func TestAddWorktreeProgressCallbacks(t *testing.T) {
 	var messages []string
 	onProgress := progress.Func(func(msg string) { messages = append(messages, msg) })
 
-	_, err := AddWorktree(r, AddParams{
+	_, err := AddWorktree(context.Background(), r, AddParams{
 		Task:   "login",
 		Prefix: "feature/",
 		Source: branchMain,
@@ -217,7 +218,7 @@ func TestAddWorktreeWithDeps(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := AddWorktree(r, AddParams{
+	result, err := AddWorktree(context.Background(), r, AddParams{
 		Task:   "login",
 		Prefix: "feature/",
 		Source: branchMain,
@@ -256,7 +257,7 @@ func TestAddWorktreeWithHooks(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := AddWorktree(r, AddParams{
+	result, err := AddWorktree(context.Background(), r, AddParams{
 		Task:   "login",
 		Prefix: "feature/",
 		Source: branchMain,

--- a/internal/operations/clean.go
+++ b/internal/operations/clean.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -117,7 +118,7 @@ func FindStaleCandidates(r git.Runner, mainBranch string, staleDays int) (StaleR
 // removed. Callers are responsible for probing RemoteExists before invoking — passing
 // a pre-resolved boolean avoids redundant git remote get-url calls per candidate and
 // ensures the CLI dry-run preview and actual deletion share a single probe result.
-func RemoveCandidates(r git.Runner, candidates []CleanCandidate, originPresent bool, onProgress progress.Func) []CleanedItem {
+func RemoveCandidates(ctx context.Context, r git.Runner, candidates []CleanCandidate, originPresent bool, onProgress progress.Func) []CleanedItem {
 	items := make([]CleanedItem, 0, len(candidates))
 	for _, c := range candidates {
 		progress.Notifyf(onProgress, "Removing %s...", c.Branch)
@@ -130,7 +131,7 @@ func RemoveCandidates(r git.Runner, candidates []CleanCandidate, originPresent b
 			Error:           err,
 		}
 		if originPresent && wtRemoved {
-			deleteRemoteForItem(r, c.Branch, &item)
+			deleteRemoteForItem(ctx, r, c.Branch, &item)
 		}
 		items = append(items, item)
 	}
@@ -139,8 +140,8 @@ func RemoveCandidates(r git.Runner, candidates []CleanCandidate, originPresent b
 
 // deleteRemoteForItem deletes the remote branch on git.DefaultRemote.
 // Caller must verify the remote exists before invoking.
-func deleteRemoteForItem(r git.Runner, branch string, item *CleanedItem) {
-	if err := git.DeleteRemoteBranch(r, git.DefaultRemote, branch); err != nil {
+func deleteRemoteForItem(ctx context.Context, r git.Runner, branch string, item *CleanedItem) {
+	if err := git.DeleteRemoteBranch(ctx, r, git.DefaultRemote, branch); err != nil {
 		item.RemoteError = err
 		return
 	}

--- a/internal/operations/clean_test.go
+++ b/internal/operations/clean_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -258,7 +259,7 @@ func TestRemoveCandidatesMixedResults(t *testing.T) {
 		{Path: "/wt/c", Branch: "feature/c"},
 	}
 
-	items := RemoveCandidates(r, candidates, false, nil)
+	items := RemoveCandidates(context.Background(), r, candidates, false, nil)
 	if len(items) != 3 {
 		t.Fatalf("expected 3 items, got %d", len(items))
 	}
@@ -288,7 +289,7 @@ func TestRemoveCandidatesProgressCallbacks(t *testing.T) {
 		{Path: "/wt/b", Branch: "feature/b"},
 	}
 
-	RemoveCandidates(r, candidates, false, onProgress)
+	RemoveCandidates(context.Background(), r, candidates, false, onProgress)
 	if len(messages) != 2 {
 		t.Fatalf("expected 2 progress messages, got %d", len(messages))
 	}
@@ -397,7 +398,7 @@ func TestRemoveCandidatesRemoteDeleteSuccess(t *testing.T) {
 	}
 
 	candidates := []CleanCandidate{{Path: "/wt/a", Branch: "feature/a"}}
-	items := RemoveCandidates(r, candidates, true, nil) // originPresent=true passed by caller
+	items := RemoveCandidates(context.Background(), r, candidates, true, nil) // originPresent=true passed by caller
 	if len(items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(items))
 	}
@@ -424,7 +425,7 @@ func TestRemoveCandidatesRemoteDeleteFailureStillCountsItem(t *testing.T) {
 	}
 
 	candidates := []CleanCandidate{{Path: "/wt/a", Branch: "feature/a"}}
-	items := RemoveCandidates(r, candidates, true, nil)
+	items := RemoveCandidates(context.Background(), r, candidates, true, nil)
 	if len(items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(items))
 	}
@@ -454,7 +455,7 @@ func TestRemoveCandidatesNoOriginSkipsRemoteDelete(t *testing.T) {
 	}
 
 	candidates := []CleanCandidate{{Path: "/wt/a", Branch: "feature/a"}}
-	items := RemoveCandidates(r, candidates, false, nil) // originPresent=false → no push
+	items := RemoveCandidates(context.Background(), r, candidates, false, nil) // originPresent=false → no push
 	if len(items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(items))
 	}

--- a/internal/operations/deps_install.go
+++ b/internal/operations/deps_install.go
@@ -1,6 +1,8 @@
 package operations
 
 import (
+	"context"
+
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/deps"
 	"github.com/lugassawan/rimba/internal/git"
@@ -18,7 +20,7 @@ type DepsParams struct {
 }
 
 // InstallDeps detects modules and installs dependencies.
-func InstallDeps(r git.Runner, p DepsParams, onProgress progress.Func) []deps.InstallResult {
+func InstallDeps(ctx context.Context, r git.Runner, p DepsParams, onProgress progress.Func) []deps.InstallResult {
 	existingPaths := WorktreePathsExcluding(p.Entries, p.WtPath)
 
 	modules, err := deps.ResolveModules(p.WtPath, p.Service, p.AutoDetect, p.ConfigModules, existingPaths)
@@ -27,11 +29,11 @@ func InstallDeps(r git.Runner, p DepsParams, onProgress progress.Func) []deps.In
 	}
 
 	mgr := &deps.Manager{Runner: r, Concurrency: p.Concurrency}
-	return mgr.Install(p.WtPath, modules, p.Entries, onProgress)
+	return mgr.Install(ctx, p.WtPath, modules, p.Entries, onProgress)
 }
 
 // InstallDepsPreferSource is like InstallDeps but prefers cloning from sourceWT.
-func InstallDepsPreferSource(r git.Runner, sourceWT string, p DepsParams, onProgress progress.Func) []deps.InstallResult {
+func InstallDepsPreferSource(ctx context.Context, r git.Runner, sourceWT string, p DepsParams, onProgress progress.Func) []deps.InstallResult {
 	existingPaths := WorktreePathsExcluding(p.Entries, p.WtPath)
 
 	modules, err := deps.ResolveModules(p.WtPath, p.Service, p.AutoDetect, p.ConfigModules, existingPaths)
@@ -40,12 +42,12 @@ func InstallDepsPreferSource(r git.Runner, sourceWT string, p DepsParams, onProg
 	}
 
 	mgr := &deps.Manager{Runner: r, Concurrency: p.Concurrency}
-	return mgr.InstallPreferSource(p.WtPath, sourceWT, modules, p.Entries, onProgress)
+	return mgr.InstallPreferSource(ctx, p.WtPath, sourceWT, modules, p.Entries, onProgress)
 }
 
 // RunPostCreateHooks executes post-create hooks and returns the results.
-func RunPostCreateHooks(wtPath string, hooks []string, onProgress progress.Func) []deps.HookResult {
-	return deps.RunPostCreateHooks(wtPath, hooks, onProgress)
+func RunPostCreateHooks(ctx context.Context, wtPath string, hooks []string, onProgress progress.Func) []deps.HookResult {
+	return deps.RunPostCreateHooks(ctx, wtPath, hooks, onProgress)
 }
 
 // WorktreePathsExcluding returns paths from entries, excluding the given path.

--- a/internal/operations/deps_install_test.go
+++ b/internal/operations/deps_install_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/git"
@@ -94,7 +95,7 @@ func TestInstallDepsNoModules(t *testing.T) {
 		run:      func(args ...string) (string, error) { return "", nil },
 		runInDir: noopRunInDir,
 	}
-	result := InstallDeps(r, DepsParams{WtPath: tmpDir}, nil)
+	result := InstallDeps(context.Background(), r, DepsParams{WtPath: tmpDir}, nil)
 	if result != nil {
 		t.Errorf("expected nil result for no modules, got %v", result)
 	}
@@ -106,7 +107,7 @@ func TestInstallDepsPreferSourceNoModules(t *testing.T) {
 		run:      func(args ...string) (string, error) { return "", nil },
 		runInDir: noopRunInDir,
 	}
-	result := InstallDepsPreferSource(r, "/other/wt", DepsParams{WtPath: tmpDir}, nil)
+	result := InstallDepsPreferSource(context.Background(), r, "/other/wt", DepsParams{WtPath: tmpDir}, nil)
 	if result != nil {
 		t.Errorf("expected nil result for no modules, got %v", result)
 	}
@@ -114,7 +115,7 @@ func TestInstallDepsPreferSourceNoModules(t *testing.T) {
 
 func TestRunPostCreateHooksEmpty(t *testing.T) {
 	tmpDir := t.TempDir()
-	results := RunPostCreateHooks(tmpDir, nil, nil)
+	results := RunPostCreateHooks(context.Background(), tmpDir, nil, nil)
 	if len(results) != 0 {
 		t.Errorf("expected 0 results for empty hooks, got %d", len(results))
 	}
@@ -122,7 +123,7 @@ func TestRunPostCreateHooksEmpty(t *testing.T) {
 
 func TestRunPostCreateHooksInvalidCommand(t *testing.T) {
 	tmpDir := t.TempDir()
-	results := RunPostCreateHooks(tmpDir, []string{"nonexistent-command-xyz"}, nil)
+	results := RunPostCreateHooks(context.Background(), tmpDir, []string{"nonexistent-command-xyz"}, nil)
 	if len(results) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(results))
 	}

--- a/internal/operations/merge.go
+++ b/internal/operations/merge.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -44,7 +45,7 @@ type dirtyResult struct {
 
 // MergeWorktree merges a source worktree branch into main or another worktree.
 // It handles worktree resolution, concurrent dirty checks, merge execution, and cleanup.
-func MergeWorktree(r git.Runner, params MergeParams, onProgress progress.Func) (MergeResult, error) {
+func MergeWorktree(ctx context.Context, r git.Runner, params MergeParams, onProgress progress.Func) (MergeResult, error) {
 	worktrees, err := ListWorktreeInfos(r)
 	if err != nil {
 		return MergeResult{}, err
@@ -93,7 +94,7 @@ func MergeWorktree(r git.Runner, params MergeParams, onProgress progress.Func) (
 	progress.Notify(onProgress, "Merging...")
 	mergeDesc := fmt.Sprintf("merge %s into %s", source.Branch, targetLabel)
 	if err := plan.Do(mergeDesc, func() error {
-		return git.Merge(r, targetDir, source.Branch, params.NoFF)
+		return git.Merge(ctx, r, targetDir, source.Branch, params.NoFF)
 	}); err != nil {
 		return result, abortFailedMerge(r, targetDir, targetLabel, source.Branch, err)
 	}

--- a/internal/operations/merge_test.go
+++ b/internal/operations/merge_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -58,7 +59,7 @@ func mergeRunner(mergeErr error) *mockRunner {
 func TestMergeWorktreeMergeToMain(t *testing.T) {
 	r := mergeRunner(nil)
 
-	result, err := MergeWorktree(r, MergeParams{
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -83,7 +84,7 @@ func TestMergeWorktreeMergeToMain(t *testing.T) {
 func TestMergeWorktreeMergeToMainKeep(t *testing.T) {
 	r := mergeRunner(nil)
 
-	result, err := MergeWorktree(r, MergeParams{
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -100,7 +101,7 @@ func TestMergeWorktreeMergeToMainKeep(t *testing.T) {
 func TestMergeWorktreeMergeToWorktree(t *testing.T) {
 	r := mergeRunner(nil)
 
-	result, err := MergeWorktree(r, MergeParams{
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		IntoTask:   "dashboard",
 		RepoRoot:   "/repo",
@@ -126,7 +127,7 @@ func TestMergeWorktreeMergeToWorktree(t *testing.T) {
 func TestMergeWorktreeMergeToWorktreeWithDelete(t *testing.T) {
 	r := mergeRunner(nil)
 
-	result, err := MergeWorktree(r, MergeParams{
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		IntoTask:   "dashboard",
 		RepoRoot:   "/repo",
@@ -144,7 +145,7 @@ func TestMergeWorktreeMergeToWorktreeWithDelete(t *testing.T) {
 func TestMergeWorktreeSourceNotFound(t *testing.T) {
 	r := mergeRunner(nil)
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "nonexistent",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -160,7 +161,7 @@ func TestMergeWorktreeSourceNotFound(t *testing.T) {
 func TestMergeWorktreeTargetNotFound(t *testing.T) {
 	r := mergeRunner(nil)
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		IntoTask:   "nonexistent",
 		RepoRoot:   "/repo",
@@ -191,7 +192,7 @@ func TestMergeWorktreeSourceDirty(t *testing.T) {
 		},
 	}
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -221,7 +222,7 @@ func TestMergeWorktreeTargetDirty(t *testing.T) {
 		},
 	}
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -237,7 +238,7 @@ func TestMergeWorktreeTargetDirty(t *testing.T) {
 func TestMergeWorktreeMergeConflict(t *testing.T) {
 	r := mergeRunner(errors.New("conflict"))
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -277,7 +278,7 @@ func TestMergeWorktreeCleanupPartialFailure(t *testing.T) {
 		},
 	}
 
-	result, err := MergeWorktree(r, MergeParams{
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -299,7 +300,7 @@ func TestMergeWorktreeProgressCallbacks(t *testing.T) {
 	var messages []string
 	onProgress := progress.Func(func(msg string) { messages = append(messages, msg) })
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -321,7 +322,7 @@ func TestMergeWorktreeListWorktreesFails(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -349,7 +350,7 @@ func TestMergeWorktreeSourceDirtyCheckError(t *testing.T) {
 		},
 	}
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: branchMain,
@@ -365,7 +366,7 @@ func TestMergeWorktreeSourceDirtyCheckError(t *testing.T) {
 func TestMergeWorktreeDryRun(t *testing.T) {
 	r := mergeRunner(nil)
 
-	result, err := MergeWorktree(r, MergeParams{
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -413,7 +414,7 @@ func TestMergeWorktreeTargetDirtyCheckError(t *testing.T) {
 		},
 	}
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: branchMain,
@@ -453,7 +454,7 @@ func TestMergeWorktreeMergeFailsAbortAlsoFails(t *testing.T) {
 		},
 	}
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -490,7 +491,7 @@ func TestMergeWorktreeMergeFailsNoMergeInProgress(t *testing.T) {
 		},
 	}
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -539,7 +540,7 @@ func mergeCleanupBranchDeleteFailsRunner(wt string) *mockRunner {
 func TestMergeWorktreeCleanupBranchDeleteFails(t *testing.T) {
 	r := mergeCleanupBranchDeleteFailsRunner(mergeWorktreeList())
 
-	result, err := MergeWorktree(r, MergeParams{
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		RepoRoot:   "/repo",
 		MainBranch: "main",
@@ -578,7 +579,7 @@ func TestMergeWorktreeTargetDirtyToWorktree(t *testing.T) {
 		},
 	}
 
-	_, err := MergeWorktree(r, MergeParams{
+	_, err := MergeWorktree(context.Background(), r, MergeParams{
 		SourceTask: "login",
 		IntoTask:   "dashboard",
 		RepoRoot:   "/repo",

--- a/internal/operations/mock_runner_test.go
+++ b/internal/operations/mock_runner_test.go
@@ -1,6 +1,9 @@
 package operations
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 const (
 	branchMain            = "main"
@@ -26,6 +29,14 @@ func (m *mockRunner) Run(args ...string) (string, error) {
 }
 
 func (m *mockRunner) RunInDir(dir string, args ...string) (string, error) {
+	return m.runInDir(dir, args...)
+}
+
+func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
+	return m.run(args...)
+}
+
+func (m *mockRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
 	return m.runInDir(dir, args...)
 }
 

--- a/internal/operations/post_create.go
+++ b/internal/operations/post_create.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lugassawan/rimba/internal/config"
@@ -37,7 +38,7 @@ type PostCreateResult struct {
 
 // PostCreateSetup runs the post-create sequence: copy files, install deps, run hooks.
 // This is used after creating a worktree via git.AddWorktree, git.AddWorktreeFromBranch, etc.
-func PostCreateSetup(r git.Runner, params PostCreateParams, onProgress progress.Func) (PostCreateResult, error) {
+func PostCreateSetup(ctx context.Context, r git.Runner, params PostCreateParams, onProgress progress.Func) (PostCreateResult, error) {
 	var result PostCreateResult
 
 	// Copy files
@@ -66,16 +67,16 @@ func PostCreateSetup(r git.Runner, params PostCreateParams, onProgress progress.
 			Concurrency:   params.Concurrency,
 		}
 		if params.SourcePath != "" {
-			result.DepsResults = InstallDepsPreferSource(r, params.SourcePath, dp, onProgress)
+			result.DepsResults = InstallDepsPreferSource(ctx, r, params.SourcePath, dp, onProgress)
 		} else {
-			result.DepsResults = InstallDeps(r, dp, onProgress)
+			result.DepsResults = InstallDeps(ctx, r, dp, onProgress)
 		}
 	}
 
 	// Post-create hooks
 	if !params.SkipHooks && len(params.PostCreate) > 0 {
 		progress.Notify(onProgress, "Running hooks...")
-		result.HookResults = RunPostCreateHooks(params.WtPath, params.PostCreate, onProgress)
+		result.HookResults = RunPostCreateHooks(ctx, params.WtPath, params.PostCreate, onProgress)
 	}
 
 	return result, nil

--- a/internal/operations/post_create_test.go
+++ b/internal/operations/post_create_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -25,7 +26,7 @@ func TestPostCreateSetupCopiesFiles(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := PostCreateSetup(r, PostCreateParams{
+	result, err := PostCreateSetup(context.Background(), r, PostCreateParams{
 		RepoRoot:  tmpDir,
 		WtPath:    wtPath,
 		Task:      "test-task",
@@ -66,7 +67,7 @@ func TestPostCreateSetupSkipDepsAndHooks(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := PostCreateSetup(r, PostCreateParams{
+	result, err := PostCreateSetup(context.Background(), r, PostCreateParams{
 		RepoRoot:   tmpDir,
 		WtPath:     wtPath,
 		Task:       "test-task",
@@ -99,7 +100,7 @@ func TestPostCreateSetupProgressCallbacks(t *testing.T) {
 	}
 
 	var messages []string
-	_, err := PostCreateSetup(r, PostCreateParams{
+	_, err := PostCreateSetup(context.Background(), r, PostCreateParams{
 		RepoRoot:  tmpDir,
 		WtPath:    wtPath,
 		Task:      "test-task",
@@ -137,7 +138,7 @@ func TestPostCreateSetupListWorktreesError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := PostCreateSetup(r, PostCreateParams{
+	_, err := PostCreateSetup(context.Background(), r, PostCreateParams{
 		RepoRoot: tmpDir,
 		WtPath:   wtPath,
 		Task:     "test-task",

--- a/internal/operations/post_rename.go
+++ b/internal/operations/post_rename.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lugassawan/rimba/internal/config"
@@ -28,7 +29,7 @@ type PostRenameResult struct {
 }
 
 // PostRenameSetup runs the post-rename sequence: refresh deps and run hooks.
-func PostRenameSetup(r git.Runner, params PostRenameParams, onProgress progress.Func) (PostRenameResult, error) {
+func PostRenameSetup(ctx context.Context, r git.Runner, params PostRenameParams, onProgress progress.Func) (PostRenameResult, error) {
 	var result PostRenameResult
 
 	if !params.SkipDeps {
@@ -45,12 +46,12 @@ func PostRenameSetup(r git.Runner, params PostRenameParams, onProgress progress.
 			Entries:       wtEntries,
 			Concurrency:   params.Concurrency,
 		}
-		result.DepsResults = InstallDeps(r, dp, onProgress)
+		result.DepsResults = InstallDeps(ctx, r, dp, onProgress)
 	}
 
 	if !params.SkipHooks && len(params.PostRename) > 0 {
 		progress.Notify(onProgress, "Running post-rename hooks...")
-		result.HookResults = RunPostCreateHooks(params.WtPath, params.PostRename, onProgress)
+		result.HookResults = RunPostCreateHooks(ctx, params.WtPath, params.PostRename, onProgress)
 	}
 
 	return result, nil

--- a/internal/operations/post_rename_test.go
+++ b/internal/operations/post_rename_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"testing"
 )
 
@@ -18,7 +19,7 @@ func TestPostRenameSetupSkipAll(t *testing.T) {
 		SkipHooks:  true,
 		PostRename: []string{"echo hook"},
 	}
-	res, err := PostRenameSetup(newNoopRunner(), params, nil)
+	res, err := PostRenameSetup(context.Background(), newNoopRunner(), params, nil)
 	if err != nil {
 		t.Fatalf("PostRenameSetup: %v", err)
 	}
@@ -38,7 +39,7 @@ func TestPostRenameSetupRunsHooks(t *testing.T) {
 		SkipHooks:  false,
 		PostRename: []string{"echo hook-ran"},
 	}
-	res, err := PostRenameSetup(newNoopRunner(), params, nil)
+	res, err := PostRenameSetup(context.Background(), newNoopRunner(), params, nil)
 	if err != nil {
 		t.Fatalf("PostRenameSetup: %v", err)
 	}
@@ -57,7 +58,7 @@ func TestPostRenameSetupNoHooksWhenEmpty(t *testing.T) {
 		SkipHooks:  false,
 		PostRename: nil,
 	}
-	res, err := PostRenameSetup(newNoopRunner(), params, nil)
+	res, err := PostRenameSetup(context.Background(), newNoopRunner(), params, nil)
 	if err != nil {
 		t.Fatalf("PostRenameSetup: %v", err)
 	}
@@ -74,7 +75,7 @@ func TestPostRenameSetupHookFailure(t *testing.T) {
 		SkipHooks:  false,
 		PostRename: []string{"false"},
 	}
-	res, err := PostRenameSetup(newNoopRunner(), params, nil)
+	res, err := PostRenameSetup(context.Background(), newNoopRunner(), params, nil)
 	if err != nil {
 		t.Fatalf("PostRenameSetup: %v", err)
 	}
@@ -94,7 +95,7 @@ func TestPostRenameSetupDepsNoop(t *testing.T) {
 		AutoDetect: true,
 		SkipHooks:  true,
 	}
-	res, err := PostRenameSetup(newNoopRunner(), params, nil)
+	res, err := PostRenameSetup(context.Background(), newNoopRunner(), params, nil)
 	if err != nil {
 		t.Fatalf("PostRenameSetup: %v", err)
 	}

--- a/internal/operations/sync.go
+++ b/internal/operations/sync.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lugassawan/rimba/internal/git"
@@ -24,11 +25,11 @@ type SyncWorktreeResult struct {
 
 // SyncBranch synchronises a worktree with the main branch using rebase or merge.
 // On rebase failure the failed rebase is aborted so the worktree stays clean.
-func SyncBranch(r git.Runner, dir, mainBranch string, useMerge bool) error {
+func SyncBranch(ctx context.Context, r git.Runner, dir, mainBranch string, useMerge bool) error {
 	if useMerge {
-		return git.Merge(r, dir, mainBranch, false)
+		return git.Merge(ctx, r, dir, mainBranch, false)
 	}
-	if err := git.Rebase(r, dir, mainBranch); err != nil {
+	if err := git.Rebase(ctx, r, dir, mainBranch); err != nil {
 		_ = git.AbortRebase(r, dir)
 		return err
 	}
@@ -38,15 +39,15 @@ func SyncBranch(r git.Runner, dir, mainBranch string, useMerge bool) error {
 // PushBranch pushes the current branch after a successful sync.
 // Uses force-with-lease after rebase, regular push after merge.
 // Returns (pushed, skipped, error). pushed is true only on success.
-func PushBranch(r git.Runner, dir string, useMerge bool) (bool, bool, error) {
+func PushBranch(ctx context.Context, r git.Runner, dir string, useMerge bool) (bool, bool, error) {
 	if !git.HasUpstream(r, dir) {
 		return false, true, nil
 	}
 	var err error
 	if useMerge {
-		err = git.Push(r, dir)
+		err = git.Push(ctx, r, dir)
 	} else {
-		err = git.PushForceWithLease(r, dir)
+		err = git.PushForceWithLease(ctx, r, dir)
 	}
 	return err == nil, false, err
 }
@@ -80,7 +81,7 @@ func FilterEligible(worktrees []resolver.WorktreeInfo, prefixes []string, mainBr
 
 // SyncWorktree checks a worktree's status and syncs it with the main branch.
 // It returns a result describing what happened rather than writing to stdout.
-func SyncWorktree(r git.Runner, mainBranch string, wt resolver.WorktreeInfo, useMerge, push bool) SyncWorktreeResult {
+func SyncWorktree(ctx context.Context, r git.Runner, mainBranch string, wt resolver.WorktreeInfo, useMerge, push bool) SyncWorktreeResult {
 	res := SyncWorktreeResult{Branch: wt.Branch}
 
 	dirty, err := git.IsDirty(r, wt.Path)
@@ -95,7 +96,7 @@ func SyncWorktree(r git.Runner, mainBranch string, wt resolver.WorktreeInfo, use
 		return res
 	}
 
-	if err := SyncBranch(r, wt.Path, mainBranch, useMerge); err != nil {
+	if err := SyncBranch(ctx, r, wt.Path, mainBranch, useMerge); err != nil {
 		verb := "rebase"
 		if useMerge {
 			verb = "merge"
@@ -108,7 +109,7 @@ func SyncWorktree(r git.Runner, mainBranch string, wt resolver.WorktreeInfo, use
 	res.Synced = true
 
 	if push {
-		pushed, skipped, pushErr := PushBranch(r, wt.Path, useMerge)
+		pushed, skipped, pushErr := PushBranch(ctx, r, wt.Path, useMerge)
 		res.Pushed = pushed
 		res.PushSkipped = skipped
 		if pushErr != nil {

--- a/internal/operations/sync_test.go
+++ b/internal/operations/sync_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -130,7 +131,7 @@ func TestSyncBranchRebaseSuccess(t *testing.T) {
 		run:      func(_ ...string) (string, error) { return "", nil },
 		runInDir: noopRunInDir,
 	}
-	if err := SyncBranch(r, "/worktree", branchMain, false); err != nil {
+	if err := SyncBranch(context.Background(), r, "/worktree", branchMain, false); err != nil {
 		t.Fatalf("SyncBranch rebase: %v", err)
 	}
 }
@@ -151,7 +152,7 @@ func TestSyncBranchRebaseFailTriggersAbort(t *testing.T) {
 		},
 	}
 
-	if err := SyncBranch(r, "/worktree", branchMain, false); err == nil {
+	if err := SyncBranch(context.Background(), r, "/worktree", branchMain, false); err == nil {
 		t.Fatal("expected rebase error")
 	}
 	if !abortCalled {
@@ -164,7 +165,7 @@ func TestSyncBranchMergeSuccess(t *testing.T) {
 		run:      func(_ ...string) (string, error) { return "", nil },
 		runInDir: noopRunInDir,
 	}
-	if err := SyncBranch(r, "/worktree", branchMain, true); err != nil {
+	if err := SyncBranch(context.Background(), r, "/worktree", branchMain, true); err != nil {
 		t.Fatalf("SyncBranch merge: %v", err)
 	}
 }
@@ -175,7 +176,7 @@ func TestSyncWorktreeClean(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	res := SyncWorktree(r, branchMain, wt, false, false)
+	res := SyncWorktree(context.Background(), r, branchMain, wt, false, false)
 
 	if !res.Synced {
 		t.Error("expected Synced=true")
@@ -199,7 +200,7 @@ func TestSyncWorktreeDirty(t *testing.T) {
 		},
 	}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	res := SyncWorktree(r, branchMain, wt, false, false)
+	res := SyncWorktree(context.Background(), r, branchMain, wt, false, false)
 
 	if !res.Skipped {
 		t.Error("expected Skipped=true for dirty worktree")
@@ -217,7 +218,7 @@ func TestSyncWorktreeIsDirtyError(t *testing.T) {
 		},
 	}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	res := SyncWorktree(r, branchMain, wt, false, false)
+	res := SyncWorktree(context.Background(), r, branchMain, wt, false, false)
 
 	if !res.Skipped {
 		t.Error("expected Skipped=true for IsDirty error")
@@ -238,7 +239,7 @@ func TestSyncWorktreeSyncFailure(t *testing.T) {
 		},
 	}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	res := SyncWorktree(r, branchMain, wt, false, false)
+	res := SyncWorktree(context.Background(), r, branchMain, wt, false, false)
 
 	if !res.Failed {
 		t.Error("expected Failed=true")
@@ -259,7 +260,7 @@ func TestSyncWorktreeMergeFailure(t *testing.T) {
 		},
 	}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	res := SyncWorktree(r, branchMain, wt, true, false)
+	res := SyncWorktree(context.Background(), r, branchMain, wt, true, false)
 
 	if !res.Failed {
 		t.Error("expected Failed=true")
@@ -282,7 +283,7 @@ func TestPushBranchRebase(t *testing.T) {
 		},
 	}
 
-	pushed, skipped, err := PushBranch(r, pathWtFeatureLogin, false)
+	pushed, skipped, err := PushBranch(context.Background(), r, pathWtFeatureLogin, false)
 	if err != nil {
 		t.Fatalf("PushBranch: %v", err)
 	}
@@ -307,7 +308,7 @@ func TestPushBranchMerge(t *testing.T) {
 		},
 	}
 
-	pushed, skipped, err := PushBranch(r, pathWtFeatureLogin, true)
+	pushed, skipped, err := PushBranch(context.Background(), r, pathWtFeatureLogin, true)
 	if err != nil {
 		t.Fatalf("PushBranch: %v", err)
 	}
@@ -327,7 +328,7 @@ func TestPushBranchNoUpstream(t *testing.T) {
 		},
 	}
 
-	pushed, skipped, err := PushBranch(r, pathWtFeatureLogin, false)
+	pushed, skipped, err := PushBranch(context.Background(), r, pathWtFeatureLogin, false)
 	if err != nil {
 		t.Fatalf("PushBranch: %v", err)
 	}
@@ -347,7 +348,7 @@ func TestPushBranchError(t *testing.T) {
 		},
 	}
 
-	pushed, _, err := PushBranch(r, pathWtFeatureLogin, false)
+	pushed, _, err := PushBranch(context.Background(), r, pathWtFeatureLogin, false)
 	if err == nil {
 		t.Fatal("expected error from PushBranch")
 	}
@@ -370,7 +371,7 @@ func TestSyncWorktreePushSuccess(t *testing.T) {
 		},
 	}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	res := SyncWorktree(r, branchMain, wt, false, true)
+	res := SyncWorktree(context.Background(), r, branchMain, wt, false, true)
 
 	if !res.Synced {
 		t.Error("expected Synced=true")
@@ -394,7 +395,7 @@ func TestSyncWorktreePushSkipped(t *testing.T) {
 		},
 	}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	res := SyncWorktree(r, branchMain, wt, false, true)
+	res := SyncWorktree(context.Background(), r, branchMain, wt, false, true)
 
 	if !res.Synced {
 		t.Error("expected Synced=true")
@@ -421,7 +422,7 @@ func TestSyncWorktreePushFailed(t *testing.T) {
 		},
 	}
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	res := SyncWorktree(r, branchMain, wt, false, true)
+	res := SyncWorktree(context.Background(), r, branchMain, wt, false, true)
 
 	if !res.Synced {
 		t.Error("expected Synced=true")


### PR DESCRIPTION
## Summary

- **`git.Runner`** gains `RunContext`/`RunInDirContext`; `ExecRunner` uses `exec.CommandContext` as its single primitive so every git subprocess is killable via ctx
- **git wrappers** (`Fetch`, `Push`, `PushForceWithLease`, `Rebase`, `Merge`, `RemotePrune`, `DeleteRemoteBranch`, `PruneRemotes`) accept `ctx` as first param; `AbortRebase` stays non-ctx (rebase recovery must survive Ctrl-C)
- **`deps`**: `RunPostCreateHooks` / `runInstall` switch to `exec.CommandContext`; hook loop breaks early on `ctx.Err()`
- **operations layer**: `SyncBranch`, `SyncWorktree`, `PushBranch`, `AddWorktree`, `PostCreateSetup`, `PostRenameSetup`, `RemoveCandidates`, `MergeWorktree` all carry ctx through
- **cobra commands** (`sync`, `clean`, `add`, `duplicate`, `restore`, `rename`, `deps`, `merge`): thread `cmd.Context()` into all network-touching helpers
- **MCP handlers** (`tool_sync`, `tool_clean`, `tool_add`, `tool_merge`): thread existing handler ctx into all operation calls
- **`debug.TimedRunner`** gains the two ctx methods (time + delegate to inner)
- **12 test fakes** gain delegating `RunContext`/`RunInDirContext` so existing arg-capture assertions keep passing

This is a retrofit of the existing in-repo precedent (`gh.Runner.Run(ctx, args...)`) onto `git.Runner`, not a new design.

## TDD tests added

- `TestRunInDirContextCancelled` — pre-cancelled ctx returns error containing "context canceled"
- `TestRunDelegatesToContext` — non-ctx `Run` still produces output via delegation chain
- `TestFetchPassesContext` — sentinel ctx value flows through to `RunContext`
- `TestRebaseContextCancelledReturnsFast` — fake blocks on `<-ctx.Done()`; cancel @10ms → returns in <1s
- `TestRunPostCreateHooksCancelledStopsLaunching` — pre-cancelled, no hooks launch, marker not created
- `TestRunPostCreateHooksKillsChild` — `sleep 30`, cancel @50ms → returns in <2s with error
- `TestRunInstallCancelledKillsChild` — `InstallCmd="sleep 30"`, cancel mid-flight → fast error

## Deferred follow-ups (noted in #223)

- Configurable per-command timeout (e.g. `--timeout 30s`)
- `parallel.Collect` cancellation propagation
- `fsutil.DirSize` cancellation

## Test plan

- [x] `go test -race ./...` — 1895 passed, 0 failures
- [x] `make lint` — 0 issues (`fatcontext`, `maxparams` ≤7, `thelper` clean)
- [x] `go tool cover -func=coverage.out | grep total` — 96.8% (pre-existing baseline; all new branches covered by TDD above)
- [ ] Manual smoke: `make build && rimba sync --all` + Ctrl-C mid-fetch (git child dies)
- [ ] Worktree with `post_create: ["sleep 30"]` + Ctrl-C (hook subprocess killed)

Closes #223