### PR TITLE
[fix] harden concurrency: Collect auto-guard, --concurrency validation, filterDirtyWorktrees refactor

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"sync"
+	"sync/atomic"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/errhint"
@@ -14,6 +14,7 @@ import (
 	"github.com/lugassawan/rimba/internal/hint"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
+	"github.com/lugassawan/rimba/internal/parallel"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/spinner"
 	"github.com/lugassawan/rimba/internal/termcolor"
@@ -117,6 +118,12 @@ func execValidateFlags(opts execOpts) error {
 	if err := validateTypeFilter(opts.typeFilter); err != nil {
 		return err
 	}
+	if opts.concurrency < 0 {
+		return errhint.WithFix(
+			errors.New("--concurrency must be >= 0"),
+			"run: rimba exec --concurrency <n>  (n >= 0; 0 = unlimited)",
+		)
+	}
 	return nil
 }
 
@@ -218,46 +225,40 @@ func init() {
 	rootCmd.AddCommand(execCmd)
 }
 
+type dirtyResult struct {
+	dirty   bool
+	warning string
+}
+
 // filterDirtyWorktrees filters worktrees to only those with uncommitted changes.
 // If IsDirty returns an error for a worktree, it is treated as dirty (included)
 // and a warning is emitted to cmd.ErrOrStderr() so the error is visible.
 func filterDirtyWorktrees(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, worktrees []resolver.WorktreeInfo) []resolver.WorktreeInfo {
-	isDirty := make([]bool, len(worktrees))
-	warnings := make([]string, len(worktrees))
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, 8)
+	n := len(worktrees)
+	var done atomic.Int32
 
-	for i, wt := range worktrees {
-		s.Update(fmt.Sprintf("Checking dirty status... (%d/%d)", i+1, len(worktrees)))
-		wg.Add(1)
-		go func(idx int, path string) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
+	results := parallel.Collect[dirtyResult](n, 8, func(i int) dirtyResult {
+		count := done.Add(1)
+		s.Update(fmt.Sprintf("Checking dirty status... (%d/%d)", count, n))
 
-			dirty, err := git.IsDirty(r, path)
-			if err != nil {
-				warnings[idx] = fmt.Sprintf("Warning: cannot check dirty status for %s: %v", path, err)
-				isDirty[idx] = true
-				return
-			}
-			if dirty {
-				isDirty[idx] = true
-			}
-		}(i, wt.Path)
-	}
-	wg.Wait()
+		path := worktrees[i].Path
+		dirty, err := git.IsDirty(r, path)
+		if err != nil {
+			return dirtyResult{dirty: true, warning: fmt.Sprintf("Warning: cannot check dirty status for %s: %v", path, err)}
+		}
+		return dirtyResult{dirty: dirty}
+	})
 
-	for _, w := range warnings {
-		if w != "" {
-			fmt.Fprintln(cmd.ErrOrStderr(), w)
+	for _, res := range results {
+		if res.warning != "" {
+			fmt.Fprintln(cmd.ErrOrStderr(), res.warning)
 		}
 	}
 
 	var out []resolver.WorktreeInfo
-	for i, wt := range worktrees {
-		if isDirty[i] {
-			out = append(out, wt)
+	for i, res := range results {
+		if res.dirty {
+			out = append(out, worktrees[i])
 		}
 	}
 	return out

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -93,6 +93,11 @@ type execOpts struct {
 	concurrency int
 }
 
+type dirtyResult struct {
+	dirty   bool
+	warning string
+}
+
 func execReadFlags(cmd *cobra.Command) execOpts {
 	all, _ := cmd.Flags().GetBool(flagAll)
 	typeFilter, _ := cmd.Flags().GetString(flagType)
@@ -223,11 +228,6 @@ func init() {
 	_ = execCmd.RegisterFlagCompletionFunc(flagType, typeFilterCompletion())
 
 	rootCmd.AddCommand(execCmd)
-}
-
-type dirtyResult struct {
-	dirty   bool
-	warning string
 }
 
 // filterDirtyWorktrees filters worktrees to only those with uncommitted changes.

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -238,11 +238,10 @@ func filterDirtyWorktrees(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, 
 	var done atomic.Int32
 
 	results := parallel.Collect[dirtyResult](n, 8, func(i int) dirtyResult {
-		count := done.Add(1)
-		s.Update(fmt.Sprintf("Checking dirty status... (%d/%d)", count, n))
-
 		path := worktrees[i].Path
 		dirty, err := git.IsDirty(r, path)
+		count := done.Add(1)
+		s.Update(fmt.Sprintf("Checking dirty status... (%d/%d)", count, n))
 		if err != nil {
 			return dirtyResult{dirty: true, warning: fmt.Sprintf("Warning: cannot check dirty status for %s: %v", path, err)}
 		}

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -371,6 +371,9 @@ func TestExecValidateFlagsNegativeConcurrency(t *testing.T) {
 	if !strings.Contains(err.Error(), "concurrency") {
 		t.Errorf("error %q does not mention 'concurrency'", err.Error())
 	}
+	if !strings.Contains(err.Error(), "To fix:") {
+		t.Errorf("error %q missing actionable fix hint", err.Error())
+	}
 }
 
 func TestExecBuildTargets(t *testing.T) {

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -353,6 +353,24 @@ func TestExecValidateFlagsOK(t *testing.T) {
 	if err := execValidateFlags(execOpts{typeFilter: "feature"}); err != nil {
 		t.Errorf("unexpected error for valid type: %v", err)
 	}
+	// zero concurrency is valid (unlimited)
+	if err := execValidateFlags(execOpts{all: true, concurrency: 0}); err != nil {
+		t.Errorf("unexpected error for concurrency=0: %v", err)
+	}
+	// positive concurrency is valid
+	if err := execValidateFlags(execOpts{all: true, concurrency: 4}); err != nil {
+		t.Errorf("unexpected error for concurrency=4: %v", err)
+	}
+}
+
+func TestExecValidateFlagsNegativeConcurrency(t *testing.T) {
+	err := execValidateFlags(execOpts{all: true, concurrency: -1})
+	if err == nil {
+		t.Fatal("expected error for negative concurrency")
+	}
+	if !strings.Contains(err.Error(), "concurrency") {
+		t.Errorf("error %q does not mention 'concurrency'", err.Error())
+	}
 }
 
 func TestExecBuildTargets(t *testing.T) {

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -4,9 +4,13 @@ import "sync"
 
 // Collect runs fn for each index [0, n) with bounded concurrency,
 // collecting results into a slice that preserves index order.
+// A concurrency value <= 0 is treated as "auto" (= n, i.e. unlimited).
 func Collect[T any](n, concurrency int, fn func(i int) T) []T {
 	if n == 0 {
 		return nil
+	}
+	if concurrency <= 0 {
+		concurrency = n
 	}
 
 	results := make([]T, n)

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -33,6 +33,25 @@ func TestCollectZeroItems(t *testing.T) {
 	}
 }
 
+func TestCollectAutoConcurrency(t *testing.T) {
+	// concurrency=0 must not deadlock; treat as n (auto).
+	results := parallel.Collect(5, 0, func(i int) int { return i })
+	if len(results) != 5 {
+		t.Fatalf("got %d results, want 5", len(results))
+	}
+	for i, v := range results {
+		if v != i {
+			t.Errorf("results[%d] = %d, want %d", i, v, i)
+		}
+	}
+
+	// negative concurrency also treated as auto.
+	results2 := parallel.Collect(3, -1, func(i int) int { return i * 10 })
+	if len(results2) != 3 {
+		t.Fatalf("got %d results, want 3", len(results2))
+	}
+}
+
 func TestCollectBoundsConcurrency(t *testing.T) {
 	const maxConcurrency = 2
 	var running atomic.Int32

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -50,6 +50,11 @@ func TestCollectAutoConcurrency(t *testing.T) {
 	if len(results2) != 3 {
 		t.Fatalf("got %d results, want 3", len(results2))
 	}
+	for i, v := range results2 {
+		if v != i*10 {
+			t.Errorf("results2[%d] = %d, want %d", i, v, i*10)
+		}
+	}
 }
 
 func TestCollectBoundsConcurrency(t *testing.T) {


### PR DESCRIPTION
## Summary

- **`parallel.Collect` self-deadlock guard**: `make(chan struct{}, 0)` is unbuffered; when `concurrency=0` and `n>0` the first goroutine blocks on send forever. Added `if concurrency <= 0 { concurrency = n }` after the `n==0` early return, mirroring `executor.go:49`.
- **`--concurrency` flag validation**: `rimba exec --concurrency -5` was silently coerced to "unlimited" by the executor's `<=0` guard. Now rejects `< 0` in `execValidateFlags` with an `errhint.WithFix` actionable error; `0` stays valid ("unlimited").
- **`filterDirtyWorktrees` refactor**: replaced hand-rolled `sync.WaitGroup + chan struct{}` semaphore with `parallel.Collect[dirtyResult]`, preserving the same behavior (error-as-dirty, warning to stderr, order-preserving output, fixed bound of 8).

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)
- [x] Race detector clean (`make test-race`)
- [x] Coverage ≥ 97% (`make test-coverage` → 97.1%)

## Issue

Closes #224