### PR TITLE
[fix] Fix silent dependency-dir corruption in the CoW clone fallback

### DIFF
--- a/internal/deps/clone.go
+++ b/internal/deps/clone.go
@@ -11,13 +11,18 @@ import (
 	"strings"
 )
 
+const (
+	goosDarwin = "darwin"
+	goosLinux  = "linux"
+)
+
 // cowCopyCmd builds the copy-on-write copy command for the host OS.
 // A package var so tests can inject a failing first-copy seam.
 var cowCopyCmd = func(src, dst string) *exec.Cmd {
 	switch runtime.GOOS {
-	case "darwin":
+	case goosDarwin:
 		return exec.Command("cp", "-c", "-R", src, dst)
-	case "linux":
+	case goosLinux:
 		return exec.Command("cp", "--reflink=auto", "-R", src, dst)
 	default:
 		return exec.Command("cp", "-R", src, dst)
@@ -150,7 +155,7 @@ func cowCopy(src, dst string) error {
 	// Only attempt the fallback on platforms where CoW was actually tried.
 	// On the default branch cowCopyCmd already emits a plain cp -R, so
 	// retrying an identical command on failure adds no value.
-	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+	if runtime.GOOS != goosDarwin && runtime.GOOS != goosLinux {
 		return cowErr
 	}
 

--- a/internal/deps/clone.go
+++ b/internal/deps/clone.go
@@ -8,7 +8,21 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
+
+// cowCopyCmd builds the copy-on-write copy command for the host OS.
+// A package var so tests can inject a failing first-copy seam.
+var cowCopyCmd = func(src, dst string) *exec.Cmd {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("cp", "-c", "-R", src, dst)
+	case "linux":
+		return exec.Command("cp", "--reflink=auto", "-R", src, dst)
+	default:
+		return exec.Command("cp", "-R", src, dst)
+	}
+}
 
 // CloneDir copies a directory from src to dst using CoW (copy-on-write) when available.
 // Falls back to regular copy if CoW is not supported.
@@ -119,23 +133,28 @@ func cloneExtraDirs(srcWT, dstWT string, extraDirs []string) error {
 	return nil
 }
 
+func cmdErr(prefix string, out []byte, err error) error {
+	if msg := strings.TrimSpace(string(out)); msg != "" {
+		return fmt.Errorf("%s: %s: %w", prefix, msg, err)
+	}
+	return fmt.Errorf("%s: %w", prefix, err)
+}
+
 func cowCopy(src, dst string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("cp", "-c", "-R", src, dst)
-	case "linux":
-		cmd = exec.Command("cp", "--reflink=auto", "-R", src, dst)
-	default:
-		cmd = exec.Command("cp", "-R", src, dst)
+	out, err := cowCopyCmd(src, dst).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	cowErr := cmdErr("cow copy", out, err)
+
+	// A failed CoW cp can leave a partially written dst; remove it so the
+	// fallback lands src's contents AS dst rather than nested inside dst/<base>.
+	if rmErr := os.RemoveAll(dst); rmErr != nil {
+		return errors.Join(cowErr, fmt.Errorf("clean dst before fallback: %w", rmErr))
 	}
 
-	if err := cmd.Run(); err != nil {
-		if runtime.GOOS == "darwin" || runtime.GOOS == "linux" {
-			fallback := exec.Command("cp", "-R", src, dst)
-			return fallback.Run()
-		}
-		return err
+	if out, fbErr := exec.Command("cp", "-R", src, dst).CombinedOutput(); fbErr != nil {
+		return errors.Join(cowErr, cmdErr("fallback copy", out, fbErr))
 	}
 	return nil
 }

--- a/internal/deps/clone.go
+++ b/internal/deps/clone.go
@@ -147,6 +147,13 @@ func cowCopy(src, dst string) error {
 	}
 	cowErr := cmdErr("cow copy", out, err)
 
+	// Only attempt the fallback on platforms where CoW was actually tried.
+	// On the default branch cowCopyCmd already emits a plain cp -R, so
+	// retrying an identical command on failure adds no value.
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		return cowErr
+	}
+
 	// A failed CoW cp can leave a partially written dst; remove it so the
 	// fallback lands src's contents AS dst rather than nested inside dst/<base>.
 	if rmErr := os.RemoveAll(dst); rmErr != nil {

--- a/internal/deps/clone_test.go
+++ b/internal/deps/clone_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -577,6 +578,9 @@ func TestCloneModuleRecursiveExtraDirError(t *testing.T) {
 // TestCowCopyFallbackNotNested verifies that a partial CoW failure (debris left at dst)
 // is corrected before the fallback: dst is re-cleaned so src lands AS dst, not nested.
 func TestCowCopyFallbackNotNested(t *testing.T) {
+	if runtime.GOOS != goosDarwin && runtime.GOOS != goosLinux {
+		t.Skip("CoW fallback only attempted on darwin/linux")
+	}
 	src := t.TempDir()
 	dst := filepath.Join(t.TempDir(), "dst")
 	writeFile(t, src, "file.txt", "source-content")
@@ -614,6 +618,9 @@ func TestCowCopyFallbackNotNested(t *testing.T) {
 // TestCowCopyDoubleFailurePreservesBothCauses verifies that when both the CoW attempt
 // and the fallback cp fail, the returned error names both causes.
 func TestCowCopyDoubleFailurePreservesBothCauses(t *testing.T) {
+	if runtime.GOOS != goosDarwin && runtime.GOOS != goosLinux {
+		t.Skip("CoW fallback only attempted on darwin/linux")
+	}
 	dst := filepath.Join(t.TempDir(), "dst")
 
 	orig := cowCopyCmd
@@ -636,6 +643,9 @@ func TestCowCopyDoubleFailurePreservesBothCauses(t *testing.T) {
 
 // TestCowCopyRemoveAllError covers the branch where dst cleanup fails after a CoW failure.
 func TestCowCopyRemoveAllError(t *testing.T) {
+	if runtime.GOOS != goosDarwin && runtime.GOOS != goosLinux {
+		t.Skip("CoW fallback only attempted on darwin/linux")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("chmod-based removal-block does not apply when running as root")
 	}

--- a/internal/deps/clone_test.go
+++ b/internal/deps/clone_test.go
@@ -3,6 +3,7 @@ package deps
 import (
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -567,6 +568,88 @@ func TestCloneModuleRecursiveExtraDirError(t *testing.T) {
 	err := CloneModule(srcWT, dstWT, mod)
 	if err == nil {
 		t.Fatal("expected error when ExtraDir clone fails in recursive mode")
+	}
+}
+
+// TestCowCopyFallbackNotNested verifies that a partial CoW failure (debris left at dst)
+// is corrected before the fallback: dst is re-cleaned so src lands AS dst, not nested.
+func TestCowCopyFallbackNotNested(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "dst")
+	writeFile(t, src, "file.txt", "source-content")
+
+	// Pre-create dst with debris to simulate a partially-written CoW copy.
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dst, "debris"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := cowCopyCmd
+	cowCopyCmd = func(s, d string) *exec.Cmd { return exec.Command("false") }
+	t.Cleanup(func() { cowCopyCmd = orig })
+
+	if err := cowCopy(src, dst); err != nil {
+		t.Fatalf("cowCopy returned unexpected error: %v", err)
+	}
+
+	// src's file must land directly at dst/file.txt, not nested as dst/<base(src)>/file.txt.
+	assertFileContent(t, filepath.Join(dst, "file.txt"), "source-content")
+
+	// Debris left by the partial CoW copy must be gone (dst was re-cleaned before fallback).
+	if _, err := os.Stat(filepath.Join(dst, "debris")); !os.IsNotExist(err) {
+		t.Error("expected debris to be removed (dst was not re-cleaned before fallback)")
+	}
+
+	// Nested layout dst/<basename(src)>/* must not exist.
+	if _, err := os.Stat(filepath.Join(dst, filepath.Base(src))); !os.IsNotExist(err) {
+		t.Error("expected fallback to place src contents AS dst, not nested inside dst/<base(src)>")
+	}
+}
+
+// TestCowCopyDoubleFailurePreservesBothCauses verifies that when both the CoW attempt
+// and the fallback cp fail, the returned error names both causes.
+func TestCowCopyDoubleFailurePreservesBothCauses(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "dst")
+
+	orig := cowCopyCmd
+	cowCopyCmd = func(s, d string) *exec.Cmd { return exec.Command("false") }
+	t.Cleanup(func() { cowCopyCmd = orig })
+
+	// Nonexistent src causes the fallback cp -R to also fail.
+	err := cowCopy("/nonexistent/does/not/exist/src", dst)
+	if err == nil {
+		t.Fatal("expected error when both CoW and fallback copy fail")
+	}
+	if !strings.Contains(err.Error(), "cow copy") {
+		t.Errorf("expected 'cow copy' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "fallback copy") {
+		t.Errorf("expected 'fallback copy' in error, got: %v", err)
+	}
+}
+
+// TestCowCopyRemoveAllError covers the branch where dst cleanup fails after a CoW failure.
+func TestCowCopyRemoveAllError(t *testing.T) {
+	parent := t.TempDir()
+	dst := filepath.Join(parent, "target")
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make parent read-only so os.RemoveAll(dst) fails.
+	if err := os.Chmod(parent, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0755) })
+
+	orig := cowCopyCmd
+	cowCopyCmd = func(s, d string) *exec.Cmd { return exec.Command("false") }
+	t.Cleanup(func() { cowCopyCmd = orig })
+
+	if err := cowCopy("/some/src", dst); err == nil {
+		t.Fatal("expected error when RemoveAll cannot delete dst")
 	}
 }
 

--- a/internal/deps/clone_test.go
+++ b/internal/deps/clone_test.go
@@ -459,6 +459,9 @@ func TestCloneExtraDirsCloneError(t *testing.T) {
 }
 
 func TestCloneDirRemoveAllError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("chmod-based removal-block does not apply when running as root")
+	}
 	src := t.TempDir()
 	writeFile(t, src, testDataTxt, "hello")
 
@@ -617,7 +620,8 @@ func TestCowCopyDoubleFailurePreservesBothCauses(t *testing.T) {
 	cowCopyCmd = func(s, d string) *exec.Cmd { return exec.Command("false") }
 	t.Cleanup(func() { cowCopyCmd = orig })
 
-	// Nonexistent src causes the fallback cp -R to also fail.
+	// /nonexistent/... is guaranteed absent on any POSIX host; cp -R will fail,
+	// exercising the fallback-failure branch and the double-cause error chain.
 	err := cowCopy("/nonexistent/does/not/exist/src", dst)
 	if err == nil {
 		t.Fatal("expected error when both CoW and fallback copy fail")
@@ -632,6 +636,9 @@ func TestCowCopyDoubleFailurePreservesBothCauses(t *testing.T) {
 
 // TestCowCopyRemoveAllError covers the branch where dst cleanup fails after a CoW failure.
 func TestCowCopyRemoveAllError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("chmod-based removal-block does not apply when running as root")
+	}
 	parent := t.TempDir()
 	dst := filepath.Join(parent, "target")
 	if err := os.MkdirAll(dst, 0755); err != nil {


### PR DESCRIPTION
## Summary

- `cowCopy` previously ran `cp -R src dst` as a fallback without first removing any partial `dst` left by a failed CoW attempt; POSIX `cp` nests `src` inside an existing `dst/<basename(src)>`, producing a silently corrupt `node_modules`/`vendor`/`target` tree
- Neither the CoW command nor the fallback captured stderr, so failures surfaced as bare `exit status 1` with the original error dropped
- Fix: introduce `cowCopyCmd` as a package-level var (test seam), call `CombinedOutput()` on both attempts, `os.RemoveAll(dst)` before the fallback, and surface both error causes via `errors.Join` when both fail; a `cmdErr` helper avoids the double-colon when stderr is empty

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

Three new regression tests:
- `TestCowCopyFallbackNotNested` — proves non-nested layout after debris cleanup
- `TestCowCopyDoubleFailurePreservesBothCauses` — proves both error causes are preserved
- `TestCowCopyRemoveAllError` — proves RemoveAll failure is surfaced (covers clean-dst branch for ≥97% threshold)

## Issue

Closes #226