### PR TITLE
[feat] surface skipped nested symlinks in copy_files output

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -187,6 +187,9 @@ func printWorktreeResult(cmd *cobra.Command, header string, result operations.Ad
 	if len(result.Skipped) > 0 {
 		fmt.Fprintf(out, "  Skipped (not found): %v\n", result.Skipped)
 	}
+	if len(result.SkippedSymlinks) > 0 {
+		fmt.Fprintf(out, "  Skipped (symlinks): %v\n", result.SkippedSymlinks)
+	}
 	printInstallResults(out, result.DepsResults)
 	printHookResultsList(out, result.HookResults)
 }

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -168,6 +168,9 @@ var duplicateCmd = &cobra.Command{
 		if len(pcResult.Skipped) > 0 {
 			fmt.Fprintf(out, "  Skipped (not found): %v\n", pcResult.Skipped)
 		}
+		if len(pcResult.SkippedSymlinks) > 0 {
+			fmt.Fprintf(out, "  Skipped (symlinks): %v\n", pcResult.SkippedSymlinks)
+		}
 
 		printInstallResults(out, pcResult.DepsResults)
 		printHookResultsList(out, pcResult.HookResults)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -102,6 +102,9 @@ to see available archived branches.`,
 		if len(pcResult.Skipped) > 0 {
 			fmt.Fprintf(out, "  Skipped (not found): %v\n", pcResult.Skipped)
 		}
+		if len(pcResult.SkippedSymlinks) > 0 {
+			fmt.Fprintf(out, "  Skipped (symlinks): %v\n", pcResult.SkippedSymlinks)
+		}
 
 		printInstallResults(out, pcResult.DepsResults)
 		printHookResultsList(out, pcResult.HookResults)

--- a/internal/fileutil/copy.go
+++ b/internal/fileutil/copy.go
@@ -10,22 +10,30 @@ import (
 const copyErrFmt = "copy %s: %w"
 
 // CopyEntries copies the listed files or directories from src directory to dst directory.
-// Missing source entries are silently skipped. Returns the list of entries actually copied.
-func CopyEntries(src, dst string, entries []string) ([]string, error) {
-	copied := make([]string, 0, len(entries))
+// Missing source entries are silently skipped. Returns the list of entries actually copied
+// and the list of nested symlink paths (relative to src) that were skipped without being copied.
+func CopyEntries(src, dst string, entries []string) (copied []string, skippedSymlinks []string, err error) {
+	copied = make([]string, 0, len(entries))
 	for _, name := range entries {
 		srcPath := filepath.Join(src, name)
 		dstPath := filepath.Join(dst, name)
 
-		ok, err := copyEntry(srcPath, dstPath, name)
-		if err != nil {
-			return copied, err
+		ok, syms, copyErr := copyEntry(srcPath, dstPath, name)
+		if copyErr != nil {
+			return copied, skippedSymlinks, copyErr
 		}
 		if ok {
 			copied = append(copied, name)
 		}
+		for _, p := range syms {
+			rel, relErr := filepath.Rel(src, p)
+			if relErr != nil {
+				rel = p
+			}
+			skippedSymlinks = append(skippedSymlinks, rel)
+		}
 	}
-	return copied, nil
+	return copied, skippedSymlinks, nil
 }
 
 // SkippedEntries returns the entries from requested that are not in copied.
@@ -44,61 +52,65 @@ func SkippedEntries(requested, copied []string) []string {
 }
 
 // copyEntry copies a single file or directory. Returns false if the source does not exist.
-func copyEntry(srcPath, dstPath, name string) (bool, error) {
+func copyEntry(srcPath, dstPath, name string) (bool, []string, error) {
 	info, err := os.Stat(srcPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return false, nil
+			return false, nil, nil
 		}
-		return false, fmt.Errorf(copyErrFmt, name, err)
+		return false, nil, fmt.Errorf(copyErrFmt, name, err)
 	}
 
 	if info.IsDir() {
-		if err := copyDir(srcPath, dstPath); err != nil {
-			return false, fmt.Errorf(copyErrFmt, name, err)
+		syms, err := copyDir(srcPath, dstPath)
+		if err != nil {
+			return false, nil, fmt.Errorf(copyErrFmt, name, err)
 		}
-		return true, nil
+		return true, syms, nil
 	}
 
 	if err := os.MkdirAll(filepath.Dir(dstPath), 0750); err != nil {
-		return false, fmt.Errorf(copyErrFmt, name, err)
+		return false, nil, fmt.Errorf(copyErrFmt, name, err)
 	}
 	if err := copyFile(srcPath, dstPath); err != nil {
-		return false, fmt.Errorf(copyErrFmt, name, err)
+		return false, nil, fmt.Errorf(copyErrFmt, name, err)
 	}
-	return true, nil
+	return true, nil, nil
 }
 
-func copyDir(src, dst string) error {
+func copyDir(src, dst string) ([]string, error) {
 	srcInfo, err := os.Stat(src)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := os.MkdirAll(dst, srcInfo.Mode().Perm()); err != nil {
-		return err
+		return nil, err
 	}
 	entries, err := os.ReadDir(src)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	var skippedSymlinks []string
 	for _, entry := range entries {
-		if err := copyDirEntry(src, dst, entry); err != nil {
-			return err
+		syms, err := copyDirEntry(src, dst, entry)
+		if err != nil {
+			return nil, err
 		}
+		skippedSymlinks = append(skippedSymlinks, syms...)
 	}
-	return nil
+	return skippedSymlinks, nil
 }
 
-func copyDirEntry(src, dst string, entry os.DirEntry) error {
+func copyDirEntry(src, dst string, entry os.DirEntry) ([]string, error) {
 	if entry.Type()&os.ModeSymlink != 0 {
-		return nil // skip symlinks
+		return []string{filepath.Join(src, entry.Name())}, nil
 	}
 	srcPath := filepath.Join(src, entry.Name())
 	dstPath := filepath.Join(dst, entry.Name())
 	if entry.IsDir() {
 		return copyDir(srcPath, dstPath)
 	}
-	return copyFile(srcPath, dstPath)
+	return nil, copyFile(srcPath, dstPath)
 }
 
 func copyFile(src, dst string) (retErr error) {

--- a/internal/fileutil/copy_test.go
+++ b/internal/fileutil/copy_test.go
@@ -36,9 +36,12 @@ func TestCopyEntries(t *testing.T) {
 	// .env.local does NOT exist — should be silently skipped
 
 	files := []string{".env", ".env.local", dotEnvrc, ".tool-versions"}
-	copied, err := fileutil.CopyEntries(src, dst, files)
+	copied, skippedSymlinks, err := fileutil.CopyEntries(src, dst, files)
 	if err != nil {
 		t.Fatalf(msgCopyErr, err)
+	}
+	if len(skippedSymlinks) != 0 {
+		t.Errorf("skippedSymlinks = %v, want empty", skippedSymlinks)
 	}
 
 	want := []string{".env", dotEnvrc}
@@ -71,9 +74,12 @@ func TestCopyEntriesNestedFile(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(subDir, "file.json"), []byte(`{"key":"val"}`), 0644)
 
 	// Copy the nested file path (not the directory)
-	copied, err := fileutil.CopyEntries(src, dst, []string{"sub/file.json"})
+	copied, skippedSymlinks, err := fileutil.CopyEntries(src, dst, []string{"sub/file.json"})
 	if err != nil {
 		t.Fatalf(msgCopyErr, err)
+	}
+	if len(skippedSymlinks) != 0 {
+		t.Errorf("skippedSymlinks = %v, want empty", skippedSymlinks)
 	}
 
 	want := []string{"sub/file.json"}
@@ -120,7 +126,7 @@ func TestCopyEntriesPreservesPermissions(t *testing.T) {
 
 	_ = os.WriteFile(filepath.Join(src, dotEnvrc), []byte("use nix"), 0755)
 
-	copied, err := fileutil.CopyEntries(src, dst, []string{dotEnvrc})
+	copied, _, err := fileutil.CopyEntries(src, dst, []string{dotEnvrc})
 	if err != nil {
 		t.Fatalf(msgCopyErr, err)
 	}
@@ -141,12 +147,15 @@ func TestCopyEntriesEmptyList(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()
 
-	copied, err := fileutil.CopyEntries(src, dst, []string{})
+	copied, skippedSymlinks, err := fileutil.CopyEntries(src, dst, []string{})
 	if err != nil {
 		t.Fatalf("CopyEntries with empty list: %v", err)
 	}
 	if len(copied) != 0 {
 		t.Errorf("expected empty copied list, got %v", copied)
+	}
+	if len(skippedSymlinks) != 0 {
+		t.Errorf("skippedSymlinks = %v, want empty", skippedSymlinks)
 	}
 }
 
@@ -161,7 +170,7 @@ func TestCopyEntriesDstError(t *testing.T) {
 	// which is not an os.IsNotExist error and triggers the wrapped error return.
 	_ = os.Mkdir(filepath.Join(dst, ".env"), 0755)
 
-	_, err := fileutil.CopyEntries(src, dst, []string{".env"})
+	_, _, err := fileutil.CopyEntries(src, dst, []string{".env"})
 	if err == nil {
 		t.Fatal("expected error when dst path is a directory")
 	}
@@ -180,7 +189,7 @@ func TestCopyEntriesCopiesDirectory(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(vscodeDir, settingsJSON), []byte(`{"go.formatTool":"goimports"}`), 0644)
 	_ = os.WriteFile(filepath.Join(vscodeDir, "extensions.json"), []byte(`{"recommendations":[]}`), 0644)
 
-	copied, err := fileutil.CopyEntries(src, dst, []string{dotVscode})
+	copied, _, err := fileutil.CopyEntries(src, dst, []string{dotVscode})
 	if err != nil {
 		t.Fatalf(msgCopyErr, err)
 	}
@@ -214,7 +223,7 @@ func TestCopyEntriesCopiesNestedDirectory(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(src, dotConfig, "top.toml"), []byte("top"), 0644)
 	_ = os.WriteFile(filepath.Join(deepDir, "nested.toml"), []byte("nested"), 0644)
 
-	copied, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	copied, _, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
 	if err != nil {
 		t.Fatalf(msgCopyErr, err)
 	}
@@ -254,7 +263,7 @@ func TestCopyEntriesMixedFilesAndDirs(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(configDir, appTOML), []byte("app"), 0644)
 
 	// .missing does NOT exist — should be skipped
-	copied, err := fileutil.CopyEntries(src, dst, []string{".env", dotConfig, ".missing"})
+	copied, _, err := fileutil.CopyEntries(src, dst, []string{".env", dotConfig, ".missing"})
 	if err != nil {
 		t.Fatalf(msgCopyErr, err)
 	}
@@ -285,7 +294,7 @@ func TestCopyEntriesEmptyDirectory(t *testing.T) {
 	// Create an empty directory
 	_ = os.Mkdir(filepath.Join(src, dotEmpty), 0755)
 
-	copied, err := fileutil.CopyEntries(src, dst, []string{dotEmpty})
+	copied, _, err := fileutil.CopyEntries(src, dst, []string{dotEmpty})
 	if err != nil {
 		t.Fatalf(msgCopyErr, err)
 	}
@@ -312,7 +321,7 @@ func TestCopyEntriesDirPreservesPermissions(t *testing.T) {
 	_ = os.Mkdir(srcDir, 0700)
 	_ = os.WriteFile(filepath.Join(srcDir, "key.pem"), []byte("key"), 0600)
 
-	copied, err := fileutil.CopyEntries(src, dst, []string{dotSecret})
+	copied, _, err := fileutil.CopyEntries(src, dst, []string{dotSecret})
 	if err != nil {
 		t.Fatalf(msgCopyErr, err)
 	}
@@ -349,12 +358,18 @@ func TestCopyEntriesSkipsSymlinksInDir(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(srcDir, "real.toml"), []byte("real"), 0644)
 	_ = os.Symlink("/dev/null", filepath.Join(srcDir, "link.toml"))
 
-	copied, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	copied, skippedSymlinks, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
 	if err != nil {
 		t.Fatalf(msgCopyErr, err)
 	}
 	if len(copied) != 1 {
 		t.Fatalf(msgExpect1Entry, len(copied))
+	}
+
+	// Skipped symlink reported relative to repo root
+	wantSkipped := []string{dotConfig + "/link.toml"}
+	if !reflect.DeepEqual(skippedSymlinks, wantSkipped) {
+		t.Errorf("skippedSymlinks = %v, want %v", skippedSymlinks, wantSkipped)
 	}
 
 	// Real file should exist
@@ -364,6 +379,56 @@ func TestCopyEntriesSkipsSymlinksInDir(t *testing.T) {
 	// Symlink should NOT exist
 	if _, err := os.Lstat(filepath.Join(dst, dotConfig, "link.toml")); !os.IsNotExist(err) {
 		t.Error("link.toml (symlink) should not exist in dst")
+	}
+}
+
+func TestCopyEntriesSkipsNestedSymlink(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// .config/sub/ with a real file and a deeper symlink
+	subDir := filepath.Join(src, dotConfig, "sub")
+	_ = os.MkdirAll(subDir, 0755)
+	_ = os.WriteFile(filepath.Join(subDir, "real.toml"), []byte("deep"), 0644)
+	_ = os.Symlink("/dev/null", filepath.Join(subDir, "link.toml"))
+
+	copied, skippedSymlinks, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	if err != nil {
+		t.Fatalf(msgCopyErr, err)
+	}
+	if len(copied) != 1 {
+		t.Fatalf(msgExpect1Entry, len(copied))
+	}
+
+	wantSkipped := []string{dotConfig + "/sub/link.toml"}
+	if !reflect.DeepEqual(skippedSymlinks, wantSkipped) {
+		t.Errorf("skippedSymlinks = %v, want %v", skippedSymlinks, wantSkipped)
+	}
+
+	// Real nested file should exist
+	if _, err := os.Stat(filepath.Join(dst, dotConfig, "sub", "real.toml")); os.IsNotExist(err) {
+		t.Error("sub/real.toml should exist in dst")
+	}
+	// Nested symlink should NOT exist
+	if _, err := os.Lstat(filepath.Join(dst, dotConfig, "sub", "link.toml")); !os.IsNotExist(err) {
+		t.Error("sub/link.toml (symlink) should not exist in dst")
+	}
+}
+
+func TestCopyEntriesNoSymlinksReturnsEmpty(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	srcDir := filepath.Join(src, dotConfig)
+	_ = os.Mkdir(srcDir, 0755)
+	_ = os.WriteFile(filepath.Join(srcDir, "app.toml"), []byte("app"), 0644)
+
+	_, skippedSymlinks, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	if err != nil {
+		t.Fatalf(msgCopyErr, err)
+	}
+	if len(skippedSymlinks) != 0 {
+		t.Errorf("skippedSymlinks = %v, want empty", skippedSymlinks)
 	}
 }
 
@@ -380,7 +445,7 @@ func TestCopyEntriesStatError(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(src, 0755) })
 
-	_, err := fileutil.CopyEntries(src, dst, []string{".env"})
+	_, _, err := fileutil.CopyEntries(src, dst, []string{".env"})
 	if err == nil {
 		t.Fatal("expected error when source dir is not readable")
 	}
@@ -402,7 +467,7 @@ func TestCopyEntriesDirCopyError(t *testing.T) {
 	// This causes MkdirAll for the nested file to fail.
 	_ = os.WriteFile(filepath.Join(dst, dotConfig), []byte("conflict"), 0644)
 
-	_, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	_, _, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
 	if err == nil {
 		t.Fatal("expected error when dst path conflicts")
 	}
@@ -426,7 +491,7 @@ func TestCopyEntriesReadDirError(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(srcDir, 0755) })
 
-	_, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	_, _, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
 	if err == nil {
 		t.Fatal("expected error when source directory is unreadable")
 	}
@@ -448,7 +513,7 @@ func TestCopyEntriesCopyFileError(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(dst, 0755) })
 
-	_, err := fileutil.CopyEntries(src, dst, []string{".env"})
+	_, _, err := fileutil.CopyEntries(src, dst, []string{".env"})
 	if err == nil {
 		t.Fatal("expected error when destination is read-only")
 	}
@@ -469,7 +534,7 @@ func TestCopyEntriesNestedFileMkdirError(t *testing.T) {
 	// Block parent creation: place a regular file where "deep" dir needs to be
 	_ = os.WriteFile(filepath.Join(dst, "deep"), []byte("conflict"), 0644)
 
-	_, err := fileutil.CopyEntries(src, dst, []string{"deep/sub/file.json"})
+	_, _, err := fileutil.CopyEntries(src, dst, []string{"deep/sub/file.json"})
 	if err == nil {
 		t.Fatal("expected error when MkdirAll for nested file fails")
 	}
@@ -490,7 +555,7 @@ func TestCopyEntriesCopyFileOpenError(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(srcFile, 0644) })
 
-	_, err := fileutil.CopyEntries(src, dst, []string{".env"})
+	_, _, err := fileutil.CopyEntries(src, dst, []string{".env"})
 	if err == nil {
 		t.Fatal("expected error when source file is unreadable")
 	}
@@ -515,7 +580,7 @@ func TestCopyEntriesDirStatError(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(dst, dotConfig), 0755)
 	_ = os.WriteFile(filepath.Join(dst, dotConfig, "sub"), []byte("conflict"), 0644)
 
-	_, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	_, _, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
 	if err == nil {
 		t.Fatal("expected error when nested destination path conflicts")
 	}
@@ -536,7 +601,7 @@ func TestCopyEntriesDirCopyFileError(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(unreadable, 0644) })
 
-	_, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	_, _, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
 	if err == nil {
 		t.Fatal("expected error when file inside directory is unreadable")
 	}
@@ -562,7 +627,7 @@ func TestCopyEntriesRecursiveCopyDirError(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(dstConfig, 0755) })
 
-	_, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
+	_, _, err := fileutil.CopyEntries(src, dst, []string{dotConfig})
 	if err == nil {
 		t.Fatal("expected error when nested directory copy fails")
 	}

--- a/internal/operations/add.go
+++ b/internal/operations/add.go
@@ -37,15 +37,16 @@ type AddParams struct {
 
 // AddResult holds the outcome of creating a worktree.
 type AddResult struct {
-	Task        string
-	Service     string
-	Branch      string
-	Path        string
-	Source      string
-	Copied      []string
-	Skipped     []string // copy_files entries not found
-	DepsResults []deps.InstallResult
-	HookResults []deps.HookResult
+	Task            string
+	Service         string
+	Branch          string
+	Path            string
+	Source          string
+	Copied          []string
+	Skipped         []string // copy_files entries not found
+	SkippedSymlinks []string // nested symlinks inside copied directories
+	DepsResults     []deps.InstallResult
+	HookResults     []deps.HookResult
 }
 
 // AddWorktree creates a new worktree, copies files, installs deps, and runs hooks.
@@ -100,6 +101,7 @@ func AddWorktree(ctx context.Context, r git.Runner, params AddParams, onProgress
 	}
 	result.Copied = pcResult.Copied
 	result.Skipped = pcResult.Skipped
+	result.SkippedSymlinks = pcResult.SkippedSymlinks
 	result.DepsResults = pcResult.DepsResults
 	result.HookResults = pcResult.HookResults
 

--- a/internal/operations/post_create.go
+++ b/internal/operations/post_create.go
@@ -30,10 +30,11 @@ type PostCreateParams struct {
 
 // PostCreateResult holds the outcome of the post-create setup sequence.
 type PostCreateResult struct {
-	Copied      []string
-	Skipped     []string
-	DepsResults []deps.InstallResult
-	HookResults []deps.HookResult
+	Copied          []string
+	Skipped         []string
+	SkippedSymlinks []string
+	DepsResults     []deps.InstallResult
+	HookResults     []deps.HookResult
 }
 
 // PostCreateSetup runs the post-create sequence: copy files, install deps, run hooks.
@@ -43,12 +44,13 @@ func PostCreateSetup(ctx context.Context, r git.Runner, params PostCreateParams,
 
 	// Copy files
 	progress.Notify(onProgress, "Copying files...")
-	copied, err := fileutil.CopyEntries(params.RepoRoot, params.WtPath, params.CopyFiles)
+	copied, skippedSymlinks, err := fileutil.CopyEntries(params.RepoRoot, params.WtPath, params.CopyFiles)
 	if err != nil {
 		return result, fmt.Errorf("failed to copy files: %w\nTo retry, manually copy files to: %s\nTo remove the worktree: rimba remove %s", err, params.WtPath, params.Task)
 	}
 	result.Copied = copied
 	result.Skipped = fileutil.SkippedEntries(params.CopyFiles, copied)
+	result.SkippedSymlinks = skippedSymlinks
 
 	// Dependencies
 	if !params.SkipDeps {

--- a/internal/operations/post_create_test.go
+++ b/internal/operations/post_create_test.go
@@ -9,6 +9,51 @@ import (
 	"testing"
 )
 
+func TestPostCreateSetupReportsSkippedSymlinks(t *testing.T) {
+	tmpDir := t.TempDir()
+	wtPath := filepath.Join(tmpDir, "worktree")
+	if err := os.MkdirAll(wtPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// .config/ dir with a real file and a nested symlink
+	cfgDir := filepath.Join(tmpDir, ".config")
+	if err := os.Mkdir(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, "real.toml"), []byte("real"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/dev/null", filepath.Join(cfgDir, "link.toml")); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &mockRunner{
+		run:      func(args ...string) (string, error) { return "", nil },
+		runInDir: noopRunInDir,
+	}
+
+	result, err := PostCreateSetup(context.Background(), r, PostCreateParams{
+		RepoRoot:  tmpDir,
+		WtPath:    wtPath,
+		Task:      "test-task",
+		CopyFiles: []string{".config"},
+		SkipDeps:  true,
+		SkipHooks: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Copied) != 1 || result.Copied[0] != ".config" {
+		t.Errorf("copied = %v, want [.config]", result.Copied)
+	}
+	wantSymlinks := []string{".config/link.toml"}
+	if len(result.SkippedSymlinks) != 1 || result.SkippedSymlinks[0] != wantSymlinks[0] {
+		t.Errorf("skippedSymlinks = %v, want %v", result.SkippedSymlinks, wantSymlinks)
+	}
+}
+
 func TestPostCreateSetupCopiesFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	wtPath := filepath.Join(tmpDir, "worktree")

--- a/tests/e2e/add_test.go
+++ b/tests/e2e/add_test.go
@@ -422,6 +422,34 @@ func TestAddShowsSkippedFiles(t *testing.T) {
 	assertContains(t, r.Stdout, "Skipped (not found): [.nonexistent .also-missing]")
 }
 
+func TestAddShowsSkippedSymlinks(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupRepo(t)
+
+	// Create a directory with a real file and a nested symlink
+	cfgDir := filepath.Join(repo, ".config")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.CreateFile(t, repo, ".config/real.toml", "content")
+	if err := os.Symlink("/dev/null", filepath.Join(cfgDir, "link.toml")); err != nil {
+		t.Fatal(err)
+	}
+
+	rimbaSuccess(t, repo, "init")
+
+	cfg := loadConfig(t, repo)
+	cfg.CopyFiles = []string{".config"}
+	saveConfig(t, repo, cfg)
+
+	r := rimbaSuccess(t, repo, "add", "symlink-test")
+	assertContains(t, r.Stdout, "Copied: [.config]")
+	assertContains(t, r.Stdout, "Skipped (symlinks):")
+}
+
 // loadConfig is a test helper that loads the rimba config from a repo.
 // It calls FillDefaults to auto-derive missing fields (worktree_dir, default_source).
 func loadConfig(t *testing.T, repo string) *config.Config {


### PR DESCRIPTION
## Summary

- `copyDirEntry` previously returned `nil` for nested symlinks, silently dropping them with no diagnostic — users ended up with incomplete worktrees and no indication why
- Threads `skippedSymlinks []string` up the result chain: `fileutil.CopyEntries` → `PostCreateResult` → `AddResult` → `cmd` print sites, mirroring the existing `Copied`/`Skipped` pattern
- `rimba add`, `duplicate`, and `restore` now print a distinct `Skipped (symlinks): [...]` line when nested symlinks were encountered; copy behavior is unchanged

## Test plan

- [x] `TestCopyEntriesSkipsSymlinksInDir` updated to assert skipped symlink path (`.config/link.toml`) is reported
- [x] `TestCopyEntriesSkipsNestedSymlink` — deeper nesting (`.config/sub/link.toml`) verifies correct relativization through recursion
- [x] `TestCopyEntriesNoSymlinksReturnsEmpty` — no-symlink case returns empty slice
- [x] `TestPostCreateSetupReportsSkippedSymlinks` — unit test at the operations layer
- [x] `TestAddShowsSkippedSymlinks` — e2e test confirms `Skipped (symlinks):` appears in stdout
- [x] 1936 tests pass, 97.0% coverage (≥97% threshold), 0 lint issues

Closes #225