### PR TITLE
[chore] add -- separators to git arg lists (option-injection hardening)

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -360,8 +360,8 @@ func branchPromoteRunFn(repoDir string) func(args ...string) (string, error) {
 			return "", nil
 		case len(args) >= 2 && args[0] == cmdWorktreeTest && args[1] == cmdList:
 			return porcelain, nil
-		case len(args) >= 3 && args[0] == cmdWorktreeTest && args[1] == gitSubcmdWorktreeAdd:
-			_ = os.MkdirAll(args[2], 0o755)
+		case len(args) >= 4 && args[0] == cmdWorktreeTest && args[1] == gitSubcmdWorktreeAdd && args[2] == "--":
+			_ = os.MkdirAll(args[3], 0o755)
 			return "", nil
 		}
 		return "", nil

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -53,7 +53,7 @@ func CurrentBranch(r Runner, dir string) (string, error) {
 
 // Checkout switches the working tree in dir to the given branch.
 func Checkout(r Runner, dir, branch string) error {
-	_, err := r.RunInDir(dir, "switch", branch)
+	_, err := r.RunInDir(dir, "switch", "--", branch)
 	return err
 }
 

--- a/internal/git/mock_runner_test.go
+++ b/internal/git/mock_runner_test.go
@@ -957,3 +957,48 @@ func TestRepoNameError(t *testing.T) {
 	}
 	assertContains(t, err, errNotAGitRepo)
 }
+
+func TestCheckoutInsertsDashDash(t *testing.T) {
+	const branch = "my-branch"
+	var capturedDir string
+	var capturedArgs []string
+	r := &mockRunner{
+		runInDir: func(dir string, args ...string) (string, error) {
+			capturedDir = dir
+			capturedArgs = args
+			return "", nil
+		},
+	}
+
+	if err := Checkout(r, fakeDir, branch); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
+
+	want := []string{"switch", "--", branch}
+	if !slices.Equal(capturedArgs, want) {
+		t.Errorf("args = %v, want %v", capturedArgs, want)
+	}
+	if capturedDir != fakeDir {
+		t.Errorf("dir = %q, want %q", capturedDir, fakeDir)
+	}
+}
+
+func TestAddWorktreeFromBranchInsertsDashDash(t *testing.T) {
+	const branch = "feature/some-task"
+	var capturedArgs []string
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			capturedArgs = args
+			return "", nil
+		},
+	}
+
+	if err := AddWorktreeFromBranch(r, fakePath, branch); err != nil {
+		t.Fatalf("AddWorktreeFromBranch: %v", err)
+	}
+
+	want := []string{cmdWorktree, "add", "--", fakePath, branch}
+	if !slices.Equal(capturedArgs, want) {
+		t.Errorf("args = %v, want %v", capturedArgs, want)
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -33,7 +33,7 @@ func AddWorktree(r Runner, path, branch, source string) error {
 
 // AddWorktreeFromBranch creates a worktree from an existing branch (no -b flag).
 func AddWorktreeFromBranch(r Runner, path, branch string) error {
-	_, err := r.Run(cmdWorktree, "add", path, branch)
+	_, err := r.Run(cmdWorktree, "add", "--", path, branch)
 	return err
 }
 

--- a/internal/operations/add_branch_test.go
+++ b/internal/operations/add_branch_test.go
@@ -38,9 +38,9 @@ func promoteRunFn(repoRoot string, makeWtDir bool) func(args ...string) (string,
 			return "", nil // BranchExists → true
 		case len(args) >= 2 && args[0] == gitCmdWorktree && args[1] == gitSubcmdList:
 			return porcelain, nil
-		case len(args) >= 2 && args[0] == gitCmdWorktree && args[1] == gitSubcmdAdd:
+		case len(args) >= 4 && args[0] == gitCmdWorktree && args[1] == gitSubcmdAdd && args[2] == "--":
 			if makeWtDir {
-				_ = os.MkdirAll(args[2], 0o755)
+				_ = os.MkdirAll(args[3], 0o755)
 			}
 			return "", nil
 		}
@@ -69,7 +69,7 @@ func promoteRunInDirStashA(args []string) (string, bool) {
 		return "", true
 	case len(args) >= 2 && args[0] == cmdRevParse && args[1] == "stash@{0}":
 		return stashSHATest, true
-	case len(args) >= 2 && args[0] == gitCmdSwitch:
+	case len(args) >= 3 && args[0] == gitCmdSwitch && args[1] == "--":
 		return "", true
 	}
 	return "", false
@@ -324,8 +324,8 @@ func wtAddFailsRunInDirFn(ops *[]string) func(dir string, args ...string) (strin
 		if out, ok := promoteRunInDirIdentity(true, args); ok {
 			return out, nil
 		}
-		if len(args) >= 2 && args[0] == gitCmdSwitch {
-			*ops = append(*ops, "switch:"+args[1])
+		if len(args) >= 3 && args[0] == gitCmdSwitch && args[1] == "--" {
+			*ops = append(*ops, "switch:"+args[2])
 		}
 		if len(args) >= 2 && args[0] == gitCmdStash && args[1] == gitSubcmdApply {
 			*ops = append(*ops, "stash:apply")
@@ -400,7 +400,7 @@ func stashOutcomeDispatchA(args []string) (string, bool) {
 		return "", true
 	case len(args) >= 2 && args[0] == cmdRevParse && args[1] == "stash@{0}":
 		return stashSHATest, true
-	case len(args) >= 2 && args[0] == gitCmdSwitch:
+	case len(args) >= 3 && args[0] == gitCmdSwitch && args[1] == "--":
 		return "", true
 	}
 	return "", false


### PR DESCRIPTION
## Summary

- Insert POSIX `--` end-of-options separator before positional `branch`/`path` args in `Checkout` (`git switch`) and `AddWorktreeFromBranch` (`git worktree add`) — a name beginning with `-` would otherwise be parsed as a git option rather than a ref/path
- Add two `mockRunner`-based arg-shape unit tests: `TestCheckoutInsertsDashDash` and `TestAddWorktreeFromBranchInsertsDashDash` (TDD red → green)
- Update three downstream mock helpers in `add_branch_test.go` that captured or matched positional arg indices after the new `--` shifted them (`promoteRunFn`, `wtAddFailsRunInDirFn`, `promoteRunInDirStashA`, `stashOutcomeDispatchA`)

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

## Issue

Closes #229