### PR TITLE
[feat] add Gradle CoW clone preset

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,8 +91,13 @@ When `auto_detect` is enabled (default), rimba recognizes these lockfiles automa
 | `yarn.lock` | `node_modules` | `yarn install` | Recursive clone + `.yarn/cache` |
 | `package-lock.json` | `node_modules` | `npm ci` | Recursive clone + install fallback |
 | `go.sum` | `vendor` | `go mod vendor` | Clone only (skip if no match) |
+| `Cargo.lock` | `target` | — | Clone only (skip if no match) |
+| `uv.lock` / `poetry.lock` | `.venv` | — | Clone only + path relocation |
+| `settings.gradle` / `build.gradle` (+ `.kts`) | `.gradle` (+ `build/`) | — | Clone only (skip if no match) |
 
 > **Note:** Dependencies are shared using copy-on-write clones (`cp -c` on macOS, `cp --reflink=auto` on Linux) for near-instant copies on supported filesystems (APFS, Btrfs). Falls back to regular copy on other systems.
+
+> **Gradle design note:** rimba clones project-local build state (`.gradle/` and `build/`) from a sibling worktree when lockfile content hashes match. A stale clone is a harmless warm cache — Gradle re-validates via content hashes on next invocation. Global caches (`~/.gradle/caches`) and Maven's `~/.m2` are **not** cloned; rimba's CoW model is scoped to project-local directories only. Maven support (project-local `target/`) is deferred.
 
 ## Environment Variables
 

--- a/internal/deps/module.go
+++ b/internal/deps/module.go
@@ -17,11 +17,18 @@ const (
 	LockfileUv     = "uv.lock"
 	LockfilePoetry = "poetry.lock"
 
-	DirNodeModules = "node_modules"
-	DirVendor      = "vendor"
-	DirYarnCache   = ".yarn/cache"
-	DirTarget      = "target"
-	DirVenv        = ".venv"
+	LockfileGradleSettings    = "settings.gradle"
+	LockfileGradleSettingsKts = "settings.gradle.kts"
+	LockfileGradle            = "build.gradle"
+	LockfileGradleKts         = "build.gradle.kts"
+
+	DirNodeModules       = "node_modules"
+	DirVendor            = "vendor"
+	DirYarnCache         = ".yarn/cache"
+	DirTarget            = "target"
+	DirVenv              = ".venv"
+	DirGradle            = ".gradle"
+	DirGradleBuildOutput = "build"
 )
 
 // Module represents a detected or configured dependency module.
@@ -91,6 +98,14 @@ var presets = []preset{
 		CloneOnly: true,
 		Relocate:  true,
 	},
+	// Gradle: clone project-local build state (.gradle/ + build/) from a sibling
+	// worktree. CloneOnly with no InstallCmd — rimba never invokes gradle; a stale
+	// clone is a harmless warm cache (Gradle re-validates via content hashes).
+	// settings.* ordered before build.* so a multi-project root is preferred.
+	{Lockfile: LockfileGradleSettings, Dir: DirGradle, ExtraDirs: []string{DirGradleBuildOutput}, CloneOnly: true},
+	{Lockfile: LockfileGradleSettingsKts, Dir: DirGradle, ExtraDirs: []string{DirGradleBuildOutput}, CloneOnly: true},
+	{Lockfile: LockfileGradle, Dir: DirGradle, ExtraDirs: []string{DirGradleBuildOutput}, CloneOnly: true},
+	{Lockfile: LockfileGradleKts, Dir: DirGradle, ExtraDirs: []string{DirGradleBuildOutput}, CloneOnly: true},
 }
 
 // DetectModules scans a worktree for known lockfiles. Root is always scanned.

--- a/internal/deps/module_test.go
+++ b/internal/deps/module_test.go
@@ -429,6 +429,91 @@ func TestMatchPresetsInSubdirSeenDirSkip(t *testing.T) {
 	}
 }
 
+func TestDetectModulesGradleEachTrigger(t *testing.T) {
+	triggers := []struct {
+		lockfile string
+	}{
+		{LockfileGradleSettings},
+		{LockfileGradleSettingsKts},
+		{LockfileGradle},
+		{LockfileGradleKts},
+	}
+
+	for _, tc := range triggers {
+		t.Run(tc.lockfile, func(t *testing.T) {
+			dir := t.TempDir()
+			writeFile(t, dir, tc.lockfile, "# gradle")
+
+			modules, err := DetectModules(dir, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assertModuleCount(t, modules, 1)
+			m := modules[0]
+
+			if m.Dir != DirGradle {
+				t.Errorf(fmtExpectedGot, DirGradle, m.Dir)
+			}
+			if len(m.ExtraDirs) != 1 || m.ExtraDirs[0] != DirGradleBuildOutput {
+				t.Errorf("expected ExtraDirs=[%s], got %v", DirGradleBuildOutput, m.ExtraDirs)
+			}
+			if !m.CloneOnly {
+				t.Error("expected CloneOnly=true for Gradle")
+			}
+			if m.Recursive {
+				t.Error("expected Recursive=false for Gradle")
+			}
+			if m.InstallCmd != "" {
+				t.Errorf("expected empty InstallCmd, got %s", m.InstallCmd)
+			}
+		})
+	}
+}
+
+func TestDetectModulesGradleSettingsWinsOverBuild(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, LockfileGradleSettings, "# settings")
+	writeFile(t, dir, LockfileGradle, "# build")
+
+	modules, err := DetectModules(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertModuleCount(t, modules, 1)
+	if modules[0].Lockfile != LockfileGradleSettings {
+		t.Errorf("expected settings.gradle to win, got %s", modules[0].Lockfile)
+	}
+}
+
+func TestDetectModulesGradleNestedSubdir(t *testing.T) {
+	dir := t.TempDir()
+	subproject := "subproject"
+	if err := os.MkdirAll(filepath.Join(dir, subproject), 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(dir, subproject), LockfileGradleKts, "# kts")
+
+	modules, err := DetectModules(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertModuleCount(t, modules, 1)
+	m := modules[0]
+
+	if m.Dir != filepath.Join(subproject, DirGradle) {
+		t.Errorf("expected %s, got %s", filepath.Join(subproject, DirGradle), m.Dir)
+	}
+	if m.WorkDir != subproject {
+		t.Errorf("expected WorkDir=%s, got %s", subproject, m.WorkDir)
+	}
+	if !m.CloneOnly {
+		t.Error("expected CloneOnly=true for nested Gradle")
+	}
+}
+
 func assertModuleCount(t *testing.T, modules []Module, expected int) {
 	t.Helper()
 	if len(modules) != expected {

--- a/internal/deps/module_test.go
+++ b/internal/deps/module_test.go
@@ -512,6 +512,10 @@ func TestDetectModulesGradleNestedSubdir(t *testing.T) {
 	if !m.CloneOnly {
 		t.Error("expected CloneOnly=true for nested Gradle")
 	}
+	wantExtra := filepath.Join(subproject, DirGradleBuildOutput)
+	if len(m.ExtraDirs) != 1 || m.ExtraDirs[0] != wantExtra {
+		t.Errorf("expected ExtraDirs=[%s], got %v", wantExtra, m.ExtraDirs)
+	}
 }
 
 func assertModuleCount(t *testing.T, modules []Module, expected int) {

--- a/tests/e2e/deps_test.go
+++ b/tests/e2e/deps_test.go
@@ -459,3 +459,54 @@ func assertVenvCloneRewritesPaths(t *testing.T, lockfile, task1, task2 string) {
 	}
 	assertContains(t, r.Stdout, msgClonedFrom)
 }
+
+func TestAddWithDepsCloneGradle(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	cases := []struct {
+		lockfile string
+		task1    string
+		task2    string
+	}{
+		{deps.LockfileGradle, "gradle-1", "gradle-2"},
+		{deps.LockfileGradleKts, "gradle-kts-1", "gradle-kts-2"},
+		{deps.LockfileGradleSettings, "gradle-settings-1", "gradle-settings-2"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.lockfile, func(t *testing.T) {
+			repo := setupInitializedRepo(t)
+			commitLockfile(t, repo, tc.lockfile)
+
+			rimbaSuccess(t, repo, "add", tc.task1)
+
+			cfg := loadConfig(t, repo)
+			wtDir := filepath.Join(repo, cfg.WorktreeDir)
+			branch1 := resolver.BranchName(defaultPrefix, tc.task1)
+			wt1Path := resolver.WorktreePath(wtDir, branch1)
+
+			gradleDir := filepath.Join(wt1Path, deps.DirGradle)
+			if err := os.MkdirAll(gradleDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			testutil.CreateFile(t, gradleDir, "gradle-marker.txt", "cached")
+
+			buildDir := filepath.Join(wt1Path, deps.DirGradleBuildOutput)
+			if err := os.MkdirAll(buildDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			testutil.CreateFile(t, buildDir, "build-marker.txt", "compiled")
+
+			r := rimbaSuccess(t, repo, "add", tc.task2)
+
+			branch2 := resolver.BranchName(defaultPrefix, tc.task2)
+			wt2Path := resolver.WorktreePath(wtDir, branch2)
+
+			assertFileExists(t, filepath.Join(wt2Path, deps.DirGradle, "gradle-marker.txt"))
+			assertFileExists(t, filepath.Join(wt2Path, deps.DirGradleBuildOutput, "build-marker.txt"))
+			assertContains(t, r.Stdout, msgClonedFrom)
+		})
+	}
+}

--- a/tests/e2e/deps_test.go
+++ b/tests/e2e/deps_test.go
@@ -473,6 +473,7 @@ func TestAddWithDepsCloneGradle(t *testing.T) {
 		{deps.LockfileGradle, "gradle-1", "gradle-2"},
 		{deps.LockfileGradleKts, "gradle-kts-1", "gradle-kts-2"},
 		{deps.LockfileGradleSettings, "gradle-settings-1", "gradle-settings-2"},
+		{deps.LockfileGradleSettingsKts, "gradle-settings-kts-1", "gradle-settings-kts-2"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- Add four `CloneOnly` preset rows for Gradle lockfiles (`settings.gradle`, `settings.gradle.kts`, `build.gradle`, `build.gradle.kts`) — clones project-local `.gradle/` and `build/` from a sibling worktree when lockfile content hashes match
- Add `DirGradle`, `DirGradleBuildOutput`, and four `LockfileGradle*` constants to `internal/deps/module.go`; `settings.*` ordered before `build.*` so multi-project roots are preferred via the existing `seenDirs` first-match-wins mechanism
- Backfill stale Cargo, uv, and poetry rows in `docs/configuration.md` (added in #239 but undocumented); add design trade-off note explaining that global `~/.gradle/caches` and Maven `~/.m2` are out of scope and Maven `target/` support is deferred

**Design trade-off:** rimba's CoW model clones dep dirs from a sibling worktree — no env-var injection or symlink infrastructure exists. A stale `.gradle/` clone is a harmless warm cache: Gradle re-validates via content hashes on next invocation. Global caches (`~/.gradle/caches`) and Maven's `~/.m2` require net-new subsystems and are explicitly deferred.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`) — `TestAddWithDepsCloneGradle` covers `build.gradle`, `build.gradle.kts`, and `settings.gradle` end-to-end
- [x] Coverage ≥ 97% (`make test-coverage` — 97.0%)

## Issue

Closes #241