### PR TITLE
[ci] harden CI posture: least-privilege token, timeouts, pin govulncheck (#227)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -45,6 +49,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -77,11 +82,12 @@ jobs:
 
   vuln:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
-      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
       - run: govulncheck ./...

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,9 +5,13 @@ on:
     types: [opened, edited, synchronize]
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate-pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Validate PR title
         if: github.event.pull_request.user.login != 'dependabot[bot]'


### PR DESCRIPTION
## Summary

- Add `permissions: contents: read` at the top level of `ci.yml` and `pr.yml`, removing ambient write-scope `GITHUB_TOKEN` inheritance on all runs including `push: [main]`. `release.yml` already declares explicit permissions (`contents: write` for goreleaser); this change brings the other two files to the same posture of explicit, minimal grants.
- Add `timeout-minutes: 15` to `lint`, `build`, and `vuln` jobs in `ci.yml` — the three that previously had no bound (a network stall would run to the 6-hour default). `coverage`, `e2e`, and `race` already had this.
- Add `timeout-minutes: 5` to `validate-pr` in `pr.yml` — pure shell pattern-matching, no network or build.
- Pin `govulncheck` from `@latest` to `@v1.3.0` (tagged 2026-04-22, confirmed via Go module proxy). Running `@latest` on a trusted `push` run is an integrity risk; pinning ensures a known, reviewed binary.

## Test Plan

- [x] `actionlint .github/workflows/ci.yml .github/workflows/pr.yml` → exit 0, no findings
- [x] `grep -c 'contents: read' ci.yml pr.yml` → 1 each
- [x] `grep -c 'timeout-minutes' ci.yml` → 6 (3 pre-existing + 3 new)
- [x] `grep -c 'timeout-minutes: 5' pr.yml` → 1
- [x] `grep 'govulncheck@' ci.yml` → `@v1.3.0`; no `@latest` remaining
- [x] `golang.org/x/vuln@v1.3.0` confirmed resolvable on Go module proxy

## Issue

Closes #227