### PR TITLE
[chore] document settings.toml trust model + path-containment guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [Quick Start](#quick-start)
 - [Commands](#commands)
 - [Configuration](#configuration)
+- [Trust model](#trust-model)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](CONTRIBUTING.md)
 - [License](#license)
@@ -140,6 +141,17 @@ agent = 'claude'
 > See [docs/configuration.md](docs/configuration.md) for the full field reference, dependency management, and environment variables.
 
 Running `rimba init --agents` or `rimba init -g` additionally creates or patches MCP server config files in client tools (`.mcp.json`, `.cursor/mcp.json`, `~/.claude/settings.json`, and others). See [docs/configuration.md#mcp-server-registration](docs/configuration.md#mcp-server-registration) for the full list of patched files and entry format.
+
+## Trust model
+
+**`.rimba/settings.toml` is trusted-author input.** The following fields execute shell commands verbatim via `sh -c`:
+
+- `post_create` — runs after a worktree is created (e.g. `rimba add`)
+- `deps.modules[].install` — runs when installing dependencies into a worktree
+
+**Cloning an untrusted repository and running `rimba add` executes that repo's `post_create` and `install` shell scripts.** Always review `.rimba/settings.toml` before running rimba in a repository you do not control.
+
+As a defense-in-depth measure, the `copy_files` entries and `deps.modules[].lockfile` paths are validated to stay within the worktree directory — paths that escape via `..` are rejected with an error. Note that `worktree_dir` is intentionally not subject to this constraint, because its default value (`../<repo>-worktrees`) is itself a `../`-relative path.
 
 ## Global flags
 

--- a/internal/deps/hash.go
+++ b/internal/deps/hash.go
@@ -4,7 +4,8 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
-	"path/filepath"
+
+	"github.com/lugassawan/rimba/internal/fileutil"
 )
 
 // ModuleWithHash pairs a Module with its lockfile hash.
@@ -16,7 +17,11 @@ type ModuleWithHash struct {
 // HashLockfile computes the SHA-256 hex digest of a lockfile.
 // Returns an empty string if the file doesn't exist.
 func HashLockfile(worktreePath, lockfile string) (string, error) {
-	data, err := os.ReadFile(filepath.Join(worktreePath, lockfile))
+	path, err := fileutil.ContainedJoin(worktreePath, lockfile)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", nil

--- a/internal/deps/hash_test.go
+++ b/internal/deps/hash_test.go
@@ -1,8 +1,11 @@
 package deps
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/lugassawan/rimba/internal/fileutil"
 )
 
 const testLockfile = "lock.yaml"
@@ -64,6 +67,9 @@ func TestHashLockfileRejectsTraversal(t *testing.T) {
 	_, err := HashLockfile(dir, "../outside")
 	if err == nil {
 		t.Fatal("HashLockfile with traversal path: expected error, got nil")
+	}
+	if !errors.Is(err, fileutil.ErrPathEscapes) {
+		t.Fatalf("error %v does not wrap fileutil.ErrPathEscapes", err)
 	}
 	if !strings.Contains(err.Error(), "contains ..") {
 		t.Fatalf("error %q does not contain %q", err.Error(), "contains ..")

--- a/internal/deps/hash_test.go
+++ b/internal/deps/hash_test.go
@@ -1,6 +1,7 @@
 package deps
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -54,6 +55,18 @@ func TestHashLockfileDifferentContent(t *testing.T) {
 
 	if hash1 == hash2 {
 		t.Error("expected different hashes for different content")
+	}
+}
+
+func TestHashLockfileRejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := HashLockfile(dir, "../outside")
+	if err == nil {
+		t.Fatal("HashLockfile with traversal path: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "contains ..") {
+		t.Fatalf("error %q does not contain %q", err.Error(), "contains ..")
 	}
 }
 

--- a/internal/fileutil/copy.go
+++ b/internal/fileutil/copy.go
@@ -19,7 +19,10 @@ func CopyEntries(src, dst string, entries []string) (copied []string, skippedSym
 		if err != nil {
 			return copied, skippedSymlinks, fmt.Errorf(copyErrFmt, name, err)
 		}
-		dstPath := filepath.Join(dst, name)
+		dstPath, err := ContainedJoin(dst, name)
+		if err != nil {
+			return copied, skippedSymlinks, fmt.Errorf(copyErrFmt, name, err)
+		}
 
 		ok, syms, copyErr := copyEntry(srcPath, dstPath, name)
 		if copyErr != nil {
@@ -128,7 +131,7 @@ func copyFile(src, dst string) (retErr error) {
 		return err
 	}
 
-	out, err := os.OpenFile(filepath.Clean(dst), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode()) //nolint:gosec // dst is derived from name validated by ContainedJoin in CopyEntries
+	out, err := os.OpenFile(filepath.Clean(dst), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode()) //nolint:gosec // dst validated by ContainedJoin before copyEntry is called
 	if err != nil {
 		return err
 	}

--- a/internal/fileutil/copy.go
+++ b/internal/fileutil/copy.go
@@ -15,7 +15,10 @@ const copyErrFmt = "copy %s: %w"
 func CopyEntries(src, dst string, entries []string) (copied []string, skippedSymlinks []string, err error) {
 	copied = make([]string, 0, len(entries))
 	for _, name := range entries {
-		srcPath := filepath.Join(src, name)
+		srcPath, err := ContainedJoin(src, name)
+		if err != nil {
+			return copied, skippedSymlinks, fmt.Errorf(copyErrFmt, name, err)
+		}
 		dstPath := filepath.Join(dst, name)
 
 		ok, syms, copyErr := copyEntry(srcPath, dstPath, name)
@@ -125,7 +128,7 @@ func copyFile(src, dst string) (retErr error) {
 		return err
 	}
 
-	out, err := os.OpenFile(filepath.Clean(dst), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode()) //nolint:gosec // dst is derived from config copy_files, not user input
+	out, err := os.OpenFile(filepath.Clean(dst), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode()) //nolint:gosec // dst is derived from name validated by ContainedJoin in CopyEntries
 	if err != nil {
 		return err
 	}

--- a/internal/fileutil/copy_test.go
+++ b/internal/fileutil/copy_test.go
@@ -1,6 +1,7 @@
 package fileutil_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -617,6 +618,9 @@ func TestCopyEntriesRejectsTraversal(t *testing.T) {
 	copied, _, err := fileutil.CopyEntries(src, dst, []string{"../escape"})
 	if err == nil {
 		t.Fatalf("CopyEntries with traversal path: expected error, got nil (copied=%v)", copied)
+	}
+	if !errors.Is(err, fileutil.ErrPathEscapes) {
+		t.Fatalf("error %v does not wrap fileutil.ErrPathEscapes", err)
 	}
 	if !strings.Contains(err.Error(), "contains ..") {
 		t.Fatalf("error %q does not contain %q", err.Error(), "contains ..")

--- a/internal/fileutil/copy_test.go
+++ b/internal/fileutil/copy_test.go
@@ -610,6 +610,22 @@ func TestCopyEntriesDirCopyFileError(t *testing.T) {
 	}
 }
 
+func TestCopyEntriesRejectsTraversal(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	copied, _, err := fileutil.CopyEntries(src, dst, []string{"../escape"})
+	if err == nil {
+		t.Fatalf("CopyEntries with traversal path: expected error, got nil (copied=%v)", copied)
+	}
+	if !strings.Contains(err.Error(), "contains ..") {
+		t.Fatalf("error %q does not contain %q", err.Error(), "contains ..")
+	}
+	if len(copied) != 0 {
+		t.Errorf("copied = %v, want empty on traversal error", copied)
+	}
+}
+
 func TestCopyEntriesRecursiveCopyDirError(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()

--- a/internal/fileutil/path.go
+++ b/internal/fileutil/path.go
@@ -1,10 +1,14 @@
 package fileutil
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 )
+
+// ErrPathEscapes is returned by ContainedJoin when a name escapes the base directory.
+var ErrPathEscapes = errors.New("path escapes base directory")
 
 // ContainedJoin joins name onto base and verifies the result stays within base.
 // A name that nets back inside base (e.g. "sub/../file") is allowed; one that
@@ -13,7 +17,7 @@ func ContainedJoin(base, name string) (string, error) {
 	base = filepath.Clean(base)
 	joined := filepath.Join(base, name)
 	if joined != base && !strings.HasPrefix(joined, base+string(filepath.Separator)) {
-		return "", fmt.Errorf("path %q contains .. and escapes the base directory", name)
+		return "", fmt.Errorf("path %q contains ..: %w", name, ErrPathEscapes)
 	}
 	return joined, nil
 }

--- a/internal/fileutil/path.go
+++ b/internal/fileutil/path.go
@@ -1,0 +1,19 @@
+package fileutil
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ContainedJoin joins name onto base and verifies the result stays within base.
+// A name that nets back inside base (e.g. "sub/../file") is allowed; one that
+// escapes via ".." is rejected. base must be a cleaned directory path.
+func ContainedJoin(base, name string) (string, error) {
+	base = filepath.Clean(base)
+	joined := filepath.Join(base, name)
+	if joined != base && !strings.HasPrefix(joined, base+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q contains .. and escapes the base directory", name)
+	}
+	return joined, nil
+}

--- a/internal/fileutil/path_test.go
+++ b/internal/fileutil/path_test.go
@@ -1,6 +1,7 @@
 package fileutil_test
 
 import (
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -30,6 +31,9 @@ func TestContainedJoin(t *testing.T) {
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("ContainedJoin(%q, %q) = %q, nil; want error", base, tc.input, got)
+				}
+				if !errors.Is(err, fileutil.ErrPathEscapes) {
+					t.Fatalf("error %v is not ErrPathEscapes", err)
 				}
 				if !strings.Contains(err.Error(), "contains ..") {
 					t.Fatalf("error %q does not contain %q", err.Error(), "contains ..")

--- a/internal/fileutil/path_test.go
+++ b/internal/fileutil/path_test.go
@@ -1,0 +1,50 @@
+package fileutil_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/fileutil"
+)
+
+func TestContainedJoin(t *testing.T) {
+	base := t.TempDir()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "simple file", input: "file.txt"},
+		{name: "nested file", input: "sub/file.txt"},
+		{name: "net-inside traversal", input: "sub/../file.txt"},
+		{name: "escape one level", input: "../x", wantErr: true},
+		{name: "escape two levels", input: "../../x", wantErr: true},
+		{name: "escape after descent", input: "a/../../x", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := fileutil.ContainedJoin(base, tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ContainedJoin(%q, %q) = %q, nil; want error", base, tc.input, got)
+				}
+				if !strings.Contains(err.Error(), "contains ..") {
+					t.Fatalf("error %q does not contain %q", err.Error(), "contains ..")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ContainedJoin(%q, %q) unexpected error: %v", base, tc.input, err)
+			}
+			if !strings.HasPrefix(got, base) {
+				t.Fatalf("result %q is not inside base %q", got, base)
+			}
+			if got != filepath.Join(base, tc.input) {
+				t.Fatalf("ContainedJoin(%q, %q) = %q; want %q", base, tc.input, got, filepath.Join(base, tc.input))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `fileutil.ContainedJoin` helper: joins a name onto a base directory and rejects any name that escapes via `..` (defense-in-depth for config-supplied paths)
- Wire `ContainedJoin` into `CopyEntries` (`copy_files` entries) and `HashLockfile` (`deps.modules[].lockfile`) — both now hard-error on traversal attempts
- Add `## Trust model` section to README: documents that `post_create` and `deps.modules[].install` run verbatim via `sh -c`; warns that cloning an untrusted repo and running `rimba add` executes that repo's shell scripts

## Test Plan

- [x] Unit tests pass (`make test`) — 1959/1959, +9 new tests
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2E tests pass (`make test-e2e`)
- [x] Coverage at 97.0% (threshold: 97%)
- [x] Manual sanity: `copy_files = ['../../escape']` → fails with `contains ..` error; normal `copy_files` → unchanged behavior

## Issue

Closes #228