### PR TITLE
[fix] Windows self-update: atomic binary replace (rename-aside)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -133,6 +133,7 @@ func CommandName() string {
 }
 
 func Execute() error {
+	updater.SweepOldBinary()
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	return rootCmd.ExecuteContext(ctx)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lugassawan/rimba
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/internal/updater/swap_common.go
+++ b/internal/updater/swap_common.go
@@ -11,6 +11,8 @@ const oldBinarySuffix = ".old"
 // renameAside installs newBinary at dst using the rename-aside dance:
 // move dst → dst.old, copy newBinary → dst, chmod to match.
 // On any copy/chmod failure it rolls back by restoring dst.old → dst.
+// If the rollback rename also fails the error is surfaced so the caller
+// knows the binary is absent and the original is recoverable from dst.old.
 func renameAside(tmpPath, dst string) error {
 	info, err := os.Stat(tmpPath)
 	if err != nil {
@@ -24,8 +26,10 @@ func renameAside(tmpPath, dst string) error {
 	}
 
 	if err := copyFile(tmpPath, dst, perm); err != nil {
-		_ = os.Remove(dst)
-		_ = os.Rename(old, dst)
+		_ = os.Remove(dst) // clear any partial write; on Windows Rename fails if dst exists
+		if rbErr := os.Rename(old, dst); rbErr != nil {
+			return fmt.Errorf("installing new binary: %w; rollback failed: %w — original binary is at %s", err, rbErr, old)
+		}
 		return fmt.Errorf("installing new binary: %w", err)
 	}
 
@@ -38,7 +42,9 @@ func copyFile(src, dst string, perm os.FileMode) error {
 		return fmt.Errorf("opening source: %w", err)
 	}
 
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) //nolint:gosec // dst is the resolved current binary path, not user input
+	// Create with narrow permissions; Chmod below sets the final mode without
+	// relying on OpenFile's umask-adjusted result.
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600) //nolint:gosec // dst is the resolved current binary path, not user input
 	if err != nil {
 		_ = in.Close()
 		return fmt.Errorf("creating destination: %w", err)

--- a/internal/updater/swap_common.go
+++ b/internal/updater/swap_common.go
@@ -8,11 +8,10 @@ import (
 
 const oldBinarySuffix = ".old"
 
-// renameAside installs newBinary at dst using the rename-aside dance:
-// move dst → dst.old, copy newBinary → dst, chmod to match.
-// On any copy/chmod failure it rolls back by restoring dst.old → dst.
-// If the rollback rename also fails the error is surfaced so the caller
-// knows the binary is absent and the original is recoverable from dst.old.
+// renameAside installs tmpPath at dst: moves dst → dst.old, copies tmpPath → dst,
+// then chmods to match.  Rolls back (dst.old → dst) on failure; surfaces both the
+// copy error and the rollback error if restore also fails.
+// The caller must pre-set tmpPath permissions; renameAside reads them via Stat.
 func renameAside(tmpPath, dst string) error {
 	info, err := os.Stat(tmpPath)
 	if err != nil {
@@ -26,9 +25,9 @@ func renameAside(tmpPath, dst string) error {
 	}
 
 	if err := copyFile(tmpPath, dst, perm); err != nil {
-		_ = os.Remove(dst) // clear any partial write; on Windows Rename fails if dst exists
+		rmErr := os.Remove(dst) // clear any partial write; on Windows Rename fails if dst exists
 		if rbErr := os.Rename(old, dst); rbErr != nil {
-			return fmt.Errorf("installing new binary: %w; rollback failed: %w — original binary is at %s", err, rbErr, old)
+			return fmt.Errorf("installing new binary: %w; rollback failed (remove: %w, rename: %w) — original binary is at %s", err, rmErr, rbErr, old)
 		}
 		return fmt.Errorf("installing new binary: %w", err)
 	}

--- a/internal/updater/swap_common.go
+++ b/internal/updater/swap_common.go
@@ -1,0 +1,63 @@
+package updater
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+const oldBinarySuffix = ".old"
+
+// renameAside installs newBinary at dst using the rename-aside dance:
+// move dst → dst.old, copy newBinary → dst, chmod to match.
+// On any copy/chmod failure it rolls back by restoring dst.old → dst.
+func renameAside(tmpPath, dst string) error {
+	info, err := os.Stat(tmpPath)
+	if err != nil {
+		return fmt.Errorf("stat new binary: %w", err)
+	}
+	perm := info.Mode().Perm()
+
+	old := dst + oldBinarySuffix
+	if err := os.Rename(dst, old); err != nil {
+		return fmt.Errorf("moving aside old binary: %w", err)
+	}
+
+	if err := copyFile(tmpPath, dst, perm); err != nil {
+		_ = os.Remove(dst)
+		_ = os.Rename(old, dst)
+		return fmt.Errorf("installing new binary: %w", err)
+	}
+
+	return nil
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src) //nolint:gosec // src is the verified temp file path, not user input
+	if err != nil {
+		return fmt.Errorf("opening source: %w", err)
+	}
+
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) //nolint:gosec // dst is the resolved current binary path, not user input
+	if err != nil {
+		_ = in.Close()
+		return fmt.Errorf("creating destination: %w", err)
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		_ = in.Close()
+		_ = out.Close()
+		return fmt.Errorf("writing: %w", err)
+	}
+	_ = in.Close()
+
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("closing destination: %w", err)
+	}
+
+	if err := os.Chmod(dst, perm); err != nil { //nolint:gosec // dst is the resolved current binary path, not user input
+		return fmt.Errorf("setting permissions: %w", err)
+	}
+
+	return nil
+}

--- a/internal/updater/swap_common_test.go
+++ b/internal/updater/swap_common_test.go
@@ -3,6 +3,7 @@ package updater
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -180,6 +181,36 @@ func TestCopyFileMissingSource(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "opening source") {
 		t.Errorf("error = %q, want to contain 'opening source'", err.Error())
+	}
+}
+
+// TestCopyFileChmodError covers the os.Chmod error path: dst is a symlink to
+// /dev/null, which we can open and write to but cannot chmod (not our file).
+func TestCopyFileChmodError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no /dev/null on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("chmod /dev/null succeeds as root")
+	}
+	tmpDir := t.TempDir()
+
+	src := filepath.Join(tmpDir, "src")
+	if err := os.WriteFile(src, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(tmpDir, "dst")
+	if err := os.Symlink("/dev/null", dst); err != nil {
+		t.Fatal(err)
+	}
+
+	err := copyFile(src, dst, 0755)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "setting permissions") {
+		t.Errorf("error = %q, want to contain 'setting permissions'", err.Error())
 	}
 }
 

--- a/internal/updater/swap_common_test.go
+++ b/internal/updater/swap_common_test.go
@@ -1,0 +1,170 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenameAsideSuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dst := filepath.Join(tmpDir, "binary")
+	if err := os.WriteFile(dst, []byte("old content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	src := filepath.Join(tmpDir, "new")
+	if err := os.WriteFile(src, []byte("new content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := renameAside(src, dst); err != nil {
+		t.Fatalf("renameAside: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new content" {
+		t.Errorf("dst content = %q, want %q", got, "new content")
+	}
+
+	old, err := os.ReadFile(dst + oldBinarySuffix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(old) != "old content" {
+		t.Errorf("dst.old content = %q, want %q", old, "old content")
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("dst perm = %04o, want 0755", info.Mode().Perm())
+	}
+}
+
+func TestRenameAsideRollbackOnCopyError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dst := filepath.Join(tmpDir, "binary")
+	if err := os.WriteFile(dst, []byte("original"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A directory as src: os.Open succeeds but io.Copy returns EISDIR.
+	srcDir := t.TempDir()
+
+	err := renameAside(srcDir, dst)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "installing new binary") {
+		t.Errorf("error = %q, want to contain 'installing new binary'", err.Error())
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("dst should be restored after rollback: %v", err)
+	}
+	if string(got) != "original" {
+		t.Errorf("dst content after rollback = %q, want %q", got, "original")
+	}
+
+	if _, err := os.Stat(dst + oldBinarySuffix); !os.IsNotExist(err) {
+		t.Error("dst.old should not exist after successful rollback")
+	}
+}
+
+func TestRenameAsideStatError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	dst := filepath.Join(tmpDir, "binary")
+	if err := os.WriteFile(dst, []byte("original"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	nonexistent := filepath.Join(tmpDir, "nonexistent_new")
+	err := renameAside(nonexistent, dst)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "stat new binary") {
+		t.Errorf("error = %q, want to contain 'stat new binary'", err.Error())
+	}
+
+	got, readErr := os.ReadFile(dst)
+	if readErr != nil || string(got) != "original" {
+		t.Error("dst should be untouched after stat failure")
+	}
+}
+
+func TestRenameAsideMoveAsideError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	src := filepath.Join(tmpDir, "new")
+	if err := os.WriteFile(src, []byte("new content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// dst does not exist: os.Rename fails immediately, nothing is moved.
+	nonexistent := filepath.Join(tmpDir, "does_not_exist")
+
+	err := renameAside(src, nonexistent)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "moving aside old binary") {
+		t.Errorf("error = %q, want to contain 'moving aside old binary'", err.Error())
+	}
+
+	if _, err := os.Stat(nonexistent + oldBinarySuffix); !os.IsNotExist(err) {
+		t.Error("dst.old should not exist when move-aside fails")
+	}
+}
+
+func TestCopyFileMissingSource(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "nonexistent")
+	dst := filepath.Join(tmpDir, "dst")
+
+	err := copyFile(src, dst, 0755)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "opening source") {
+		t.Errorf("error = %q, want to contain 'opening source'", err.Error())
+	}
+}
+
+func TestCopyFileDstNotCreatable(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	src := filepath.Join(tmpDir, "src")
+	if err := os.WriteFile(src, []byte("content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	readOnlyDir := filepath.Join(tmpDir, "ro")
+	if err := os.MkdirAll(readOnlyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(readOnlyDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(readOnlyDir, 0755) })
+
+	dst := filepath.Join(readOnlyDir, "dst")
+	err := copyFile(src, dst, 0755)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "creating destination") {
+		t.Errorf("error = %q, want to contain 'creating destination'", err.Error())
+	}
+}

--- a/internal/updater/swap_common_test.go
+++ b/internal/updater/swap_common_test.go
@@ -128,6 +128,47 @@ func TestRenameAsideMoveAsideError(t *testing.T) {
 	}
 }
 
+// TestRenameAsideRollbackDoubleFailSubcomponents confirms that copy failure and rollback
+// Rename failure can both occur in the same directory context, exercising the sub-errors
+// that feed into renameAside's compound "rollback failed" message.
+func TestRenameAsideRollbackDoubleFailSubcomponents(t *testing.T) {
+	binDir := t.TempDir()
+	dst := filepath.Join(binDir, "binary")
+	old := dst + oldBinarySuffix
+
+	if err := os.WriteFile(dst, []byte("original"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the move-aside that renameAside performs before the copy.
+	if err := os.Rename(dst, old); err != nil {
+		t.Fatal("setup move-aside:", err)
+	}
+
+	if err := os.Chmod(binDir, 0555); err != nil {
+		t.Fatal("chmod:", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(binDir, 0755) })
+
+	src := filepath.Join(t.TempDir(), "src")
+	if err := os.WriteFile(src, []byte("new content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	copyErr := copyFile(src, dst, 0755)
+	if copyErr == nil {
+		t.Fatal("expected copyFile to fail in read-only dir")
+	}
+	if !strings.Contains(copyErr.Error(), "creating destination") {
+		t.Errorf("copyErr = %q, want to contain 'creating destination'", copyErr.Error())
+	}
+
+	rbErr := os.Rename(old, dst)
+	if rbErr == nil {
+		t.Fatal("expected rollback Rename to fail in read-only dir")
+	}
+}
+
 func TestCopyFileMissingSource(t *testing.T) {
 	tmpDir := t.TempDir()
 	src := filepath.Join(tmpDir, "nonexistent")

--- a/internal/updater/swap_common_unix_test.go
+++ b/internal/updater/swap_common_unix_test.go
@@ -1,0 +1,67 @@
+//go:build !windows
+
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestRenameAsideCompoundRollbackFail covers the double-failure branch in
+// renameAside: copyFile fails AND the rollback Rename also fails.
+//
+// A named pipe (FIFO) is used as tmpPath so that os.Open inside copyFile
+// blocks until the goroutine has (a) confirmed the initial rename succeeded
+// by detecting dst.old's appearance, and (b) made binDir read-only — ensuring
+// the directory is non-writable before the copy is attempted, with no race.
+func TestRenameAsideCompoundRollbackFail(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("chmod 0555 has no effect as root")
+	}
+
+	binDir := t.TempDir()
+	dst := filepath.Join(binDir, "binary")
+	old := dst + oldBinarySuffix
+
+	if err := os.WriteFile(dst, []byte("original"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	fifoDir := t.TempDir()
+	fifoPath := filepath.Join(fifoDir, "tmpbin")
+	if err := syscall.Mkfifo(fifoPath, 0644); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(binDir, 0755) })
+
+	go func() {
+		// Poll until renameAside has moved dst → old, then make binDir
+		// read-only so that both the copy attempt and the rollback rename fail.
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(old); err == nil {
+				break
+			}
+			runtime.Gosched()
+		}
+		_ = os.Chmod(binDir, 0555)
+		// Opening the FIFO write end unblocks os.Open(fifoPath) in copyFile;
+		// binDir is already read-only by this point.
+		if w, err := os.OpenFile(fifoPath, os.O_WRONLY, 0); err == nil {
+			_ = w.Close()
+		}
+	}()
+
+	err := renameAside(fifoPath, dst)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "rollback failed") {
+		t.Errorf("error = %q, want to contain 'rollback failed'", err.Error())
+	}
+}

--- a/internal/updater/swap_windows.go
+++ b/internal/updater/swap_windows.go
@@ -2,19 +2,9 @@
 
 package updater
 
-import (
-	"fmt"
-
-	"github.com/lugassawan/rimba/internal/errhint"
-)
-
-// swapBinary is not yet implemented on Windows.
-// The rename-aside mechanism required to replace a running .exe is tracked in
-// https://github.com/lugassawan/rimba/issues/234
-func swapBinary(_, _ string) error {
-	return errhint.WithFix(
-		fmt.Errorf("self-update replace is not yet supported on Windows"),
-		"download the latest release from https://github.com/lugassawan/rimba/releases; "+
-			"Windows self-replace support is tracked in https://github.com/lugassawan/rimba/issues/234",
-	)
+// swapBinary replaces dst with the contents of tmpPath using the rename-aside
+// dance: dst is moved to dst.old (Windows permits renaming a running binary),
+// then tmpPath is copied into dst.  The caller's defer removes tmpPath.
+func swapBinary(tmpPath, dst string) error {
+	return renameAside(tmpPath, dst)
 }

--- a/internal/updater/sweep.go
+++ b/internal/updater/sweep.go
@@ -1,0 +1,10 @@
+package updater
+
+import "os"
+
+// sweepOldBinary removes the leftover exePath.old file left by a prior
+// rename-aside swap.  Errors are swallowed: a running binary cannot delete
+// itself, so the file may legitimately be locked on Windows.
+func sweepOldBinary(exePath string) {
+	_ = os.Remove(exePath + oldBinarySuffix)
+}

--- a/internal/updater/sweep_other.go
+++ b/internal/updater/sweep_other.go
@@ -1,0 +1,6 @@
+//go:build !windows
+
+package updater
+
+// SweepOldBinary is a no-op on non-Windows platforms.
+func SweepOldBinary() {}

--- a/internal/updater/sweep_test.go
+++ b/internal/updater/sweep_test.go
@@ -1,0 +1,36 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSweepOldBinaryRemovesOld(t *testing.T) {
+	tmpDir := t.TempDir()
+	exe := filepath.Join(tmpDir, "rimba")
+	old := exe + oldBinarySuffix
+
+	if err := os.WriteFile(old, []byte("stale"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	sweepOldBinary(exe)
+
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		t.Error("expected exe.old to be removed")
+	}
+}
+
+func TestSweepOldBinaryNoOldFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	exe := filepath.Join(tmpDir, "rimba")
+
+	// No exe.old present — best-effort sweep should not panic.
+	sweepOldBinary(exe)
+}
+
+func TestSweepOldBinaryExported(t *testing.T) {
+	// SweepOldBinary is a no-op on non-Windows; verify it does not panic.
+	SweepOldBinary()
+}

--- a/internal/updater/sweep_test.go
+++ b/internal/updater/sweep_test.go
@@ -30,7 +30,8 @@ func TestSweepOldBinaryNoOldFile(t *testing.T) {
 	sweepOldBinary(exe)
 }
 
-func TestSweepOldBinaryExported(t *testing.T) {
-	// SweepOldBinary is a no-op on non-Windows; verify it does not panic.
+// TestSweepOldBinaryNonWindowsNoOp calls the no-op on non-Windows; sweep_windows.go
+// is compile-checked by the build-cross CI job, not run on Linux.
+func TestSweepOldBinaryNonWindowsNoOp(t *testing.T) {
 	SweepOldBinary()
 }

--- a/internal/updater/sweep_windows.go
+++ b/internal/updater/sweep_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package updater
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// SweepOldBinary removes the exe.old file left by a previous rename-aside
+// swap.  Called at startup so the binary is not the one being deleted.
+// Best-effort: errors are swallowed.
+func SweepOldBinary() {
+	exe, err := os.Executable()
+	if err != nil {
+		return
+	}
+	resolved, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return
+	}
+	sweepOldBinary(resolved)
+}


### PR DESCRIPTION
## Summary

- Implement Windows atomic self-update via the **rename-aside** dance: `rimba.exe` → `rimba.exe.old`, copy new binary → `rimba.exe`, roll back on failure
- Sweep `rimba.exe.old` on next startup via `updater.SweepOldBinary()` wired into `Execute()`
- Core algorithm lives in untagged files (`swap_common.go`, `sweep.go`) so Linux CI fully exercises the logic; build-tagged shims (`swap_windows.go`, `sweep_windows.go`, `sweep_other.go`) provide OS dispatch
- Rollback surfaces a joined error if the restore `Rename` itself fails (binary is recoverable from `.old`)
- File created with narrow `0600` perms; `Chmod` to target perms after close — no umask-affected TOCTOU window

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

### Type-tailored checks (fix)

- [x] `TestRenameAsideSuccess` — dst has new content, `.old` holds the old binary, perms preserved
- [x] `TestRenameAsideRollbackOnCopyError` — copy failure (dir as src → `EISDIR`) triggers rollback: dst restored, no `.old` left
- [x] `TestRenameAsideMoveAsideError` — move-aside on missing dst returns wrapped "moving aside old binary" error, no `.old` created
- [x] `TestRenameAsideStatError` — stat failure on non-existent tmpPath returns early, dst untouched
- [x] `TestCopyFileMissingSource` / `TestCopyFileDstNotCreatable` — copyFile error paths covered
- [x] `TestSweepOldBinaryRemovesOld` / `TestSweepOldBinaryNoOldFile` — sweep logic verified
- [x] `CGO_ENABLED=0 GOOS=windows go build ./...` (amd64 + arm64) — compile-checks the Windows shims without a Windows runner
- [ ] Manual: build `rimba.exe`, run `rimba update` on Windows — binary replaced, `.old` removed on next invocation

## Issue

Closes #234
