### PR TITLE
[test] cover LoadFixture failure path + e2e rimba completion

### DIFF
--- a/tests/e2e/completions_test.go
+++ b/tests/e2e/completions_test.go
@@ -9,8 +9,6 @@ func TestCompletionShells(t *testing.T) {
 		t.Skip(skipE2E)
 	}
 
-	dir := t.TempDir()
-
 	tests := []struct {
 		shell  string
 		marker string
@@ -22,6 +20,7 @@ func TestCompletionShells(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.shell, func(t *testing.T) {
+			dir := t.TempDir()
 			r := rimbaSuccess(t, dir, "completion", tc.shell)
 			assertContains(t, r.Stdout, tc.marker)
 		})

--- a/tests/e2e/completions_test.go
+++ b/tests/e2e/completions_test.go
@@ -1,0 +1,38 @@
+package e2e_test
+
+import (
+	"testing"
+)
+
+func TestCompletionShells(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	dir := t.TempDir()
+
+	tests := []struct {
+		shell  string
+		marker string
+	}{
+		{"bash", "complete"},
+		{"zsh", "#compdef rimba"},
+		{"fish", "complete -c rimba"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.shell, func(t *testing.T) {
+			r := rimbaSuccess(t, dir, "completion", tc.shell)
+			assertContains(t, r.Stdout, tc.marker)
+		})
+	}
+}
+
+func TestCompletionInvalidShell(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	dir := t.TempDir()
+	rimbaFail(t, dir, "completion", "fish2")
+}

--- a/testutil/fixture.go
+++ b/testutil/fixture.go
@@ -4,11 +4,17 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"testing"
 )
 
+// fixtureT is the subset of *testing.T that LoadFixture needs, extracted so the
+// failure path (t.Fatalf) can be exercised with a spy in tests.
+type fixtureT interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
+
 // LoadFixture reads a file at relpath relative to the calling test file's source directory.
-func LoadFixture(t *testing.T, relpath string) string {
+func LoadFixture(t fixtureT, relpath string) string {
 	t.Helper()
 	_, callerFile, _, _ := runtime.Caller(1)
 	path := filepath.Join(filepath.Dir(callerFile), relpath)

--- a/testutil/fixture.go
+++ b/testutil/fixture.go
@@ -21,6 +21,7 @@ func LoadFixture(t fixtureT, relpath string) string {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("LoadFixture %s: %v", relpath, err)
+		return "" // unreachable under *testing.T (Fatalf calls runtime.Goexit); explicit for spy
 	}
 	return string(data)
 }

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -1,6 +1,7 @@
 package testutil_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +9,18 @@ import (
 
 	"github.com/lugassawan/rimba/testutil"
 )
+
+type fixtureTSpy struct {
+	fatalfCalled bool
+	fatalfMsg    string
+}
+
+func (s *fixtureTSpy) Helper() {}
+
+func (s *fixtureTSpy) Fatalf(format string, args ...any) {
+	s.fatalfCalled = true
+	s.fatalfMsg = fmt.Sprintf(format, args...)
+}
 
 func TestPtr(t *testing.T) {
 	p := testutil.Ptr(42)
@@ -39,6 +52,20 @@ func TestCreateFile(t *testing.T) {
 	}
 	if string(data) != "world" {
 		t.Fatalf("content = %q, want %q", string(data), "world")
+	}
+}
+
+func TestLoadFixtureMissingFile(t *testing.T) {
+	spy := &fixtureTSpy{}
+	got := testutil.LoadFixture(spy, "testdata/does-not-exist.txt")
+	if !spy.fatalfCalled {
+		t.Fatal("expected Fatalf to be called for missing fixture")
+	}
+	if got != "" {
+		t.Fatalf("expected empty string on error, got %q", got)
+	}
+	if !strings.Contains(spy.fatalfMsg, "LoadFixture testdata/does-not-exist.txt") {
+		t.Fatalf("expected message to contain %q, got %q", "LoadFixture testdata/does-not-exist.txt", spy.fatalfMsg)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Widen `testutil.LoadFixture`'s first param from `*testing.T` to a minimal unexported `fixtureT` interface (`Helper() + Fatalf()`), enabling spy-based testing of the error branch
- Add `fixtureTSpy` + `TestLoadFixtureMissingFile` in `testutil/testutil_test.go` to cover the previously-untested `t.Fatalf` path
- Add `tests/e2e/completions_test.go` with table-driven subtests for bash/zsh/fish completion output markers and an invalid-shell failure case

## Test Plan

<!-- How did you verify this works? Check the boxes. -->
- [x] Unit tests pass (`make test`) — 1977 passed, 26 packages
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2E tests pass (`make test-e2e`) — 300 passed
- [x] Coverage stays ≥ 97% (`make test-coverage`) — total: 97.0%

### Type-tailored checks ([test])
- [x] `TestLoadFixtureMissingFile`: `spy.fatalfCalled == true`, returned string is `""`, message contains `"LoadFixture testdata/does-not-exist.txt"`
- [x] `TestCompletionShells` subtests: bash → `"complete"`, zsh → `"#compdef rimba"`, fish → `"complete -c rimba"`
- [x] `TestCompletionInvalidShell`: `rimba completion fish2` exits non-zero
- [x] All existing callers of `LoadFixture` (pass `*testing.T`) still compile — structural interface satisfaction

## Issue

Closes #177
