### PR TITLE
[fix] copy_files cannot escape worktree via symlinked dst component

### DIFF
--- a/internal/fileutil/copy.go
+++ b/internal/fileutil/copy.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const copyErrFmt = "copy %s: %w"
@@ -13,6 +14,10 @@ const copyErrFmt = "copy %s: %w"
 // Missing source entries are silently skipped. Returns the list of entries actually copied
 // and the list of nested symlink paths (relative to src) that were skipped without being copied.
 func CopyEntries(src, dst string, entries []string) (copied []string, skippedSymlinks []string, err error) {
+	dstRoot, err := resolveDstRoot(dst)
+	if err != nil {
+		return nil, nil, err
+	}
 	copied = make([]string, 0, len(entries))
 	for _, name := range entries {
 		srcPath, err := ContainedJoin(src, name)
@@ -24,7 +29,7 @@ func CopyEntries(src, dst string, entries []string) (copied []string, skippedSym
 			return copied, skippedSymlinks, fmt.Errorf(copyErrFmt, name, err)
 		}
 
-		ok, syms, copyErr := copyEntry(srcPath, dstPath, name)
+		ok, syms, copyErr := copyEntry(srcPath, dstPath, name, dstRoot)
 		if copyErr != nil {
 			return copied, skippedSymlinks, copyErr
 		}
@@ -58,7 +63,7 @@ func SkippedEntries(requested, copied []string) []string {
 }
 
 // copyEntry copies a single file or directory. Returns false if the source does not exist.
-func copyEntry(srcPath, dstPath, name string) (bool, []string, error) {
+func copyEntry(srcPath, dstPath, name, dstRoot string) (bool, []string, error) {
 	info, err := os.Stat(srcPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -68,25 +73,31 @@ func copyEntry(srcPath, dstPath, name string) (bool, []string, error) {
 	}
 
 	if info.IsDir() {
-		syms, err := copyDir(srcPath, dstPath)
+		syms, err := copyDir(srcPath, dstPath, dstRoot)
 		if err != nil {
 			return false, nil, fmt.Errorf(copyErrFmt, name, err)
 		}
 		return true, syms, nil
 	}
 
+	if err := assertContained(dstRoot, dstPath); err != nil {
+		return false, nil, fmt.Errorf(copyErrFmt, name, err)
+	}
 	if err := os.MkdirAll(filepath.Dir(dstPath), 0750); err != nil {
 		return false, nil, fmt.Errorf(copyErrFmt, name, err)
 	}
-	if err := copyFile(srcPath, dstPath); err != nil {
+	if err := copyFile(srcPath, dstPath, dstRoot); err != nil {
 		return false, nil, fmt.Errorf(copyErrFmt, name, err)
 	}
 	return true, nil, nil
 }
 
-func copyDir(src, dst string) ([]string, error) {
+func copyDir(src, dst, dstRoot string) ([]string, error) {
 	srcInfo, err := os.Stat(src)
 	if err != nil {
+		return nil, err
+	}
+	if err := assertContained(dstRoot, dst); err != nil {
 		return nil, err
 	}
 	if err := os.MkdirAll(dst, srcInfo.Mode().Perm()); err != nil {
@@ -98,7 +109,7 @@ func copyDir(src, dst string) ([]string, error) {
 	}
 	var skippedSymlinks []string
 	for _, entry := range entries {
-		syms, err := copyDirEntry(src, dst, entry)
+		syms, err := copyDirEntry(src, dst, dstRoot, entry)
 		if err != nil {
 			return nil, err
 		}
@@ -107,19 +118,22 @@ func copyDir(src, dst string) ([]string, error) {
 	return skippedSymlinks, nil
 }
 
-func copyDirEntry(src, dst string, entry os.DirEntry) ([]string, error) {
+func copyDirEntry(src, dst, dstRoot string, entry os.DirEntry) ([]string, error) {
 	if entry.Type()&os.ModeSymlink != 0 {
 		return []string{filepath.Join(src, entry.Name())}, nil
 	}
 	srcPath := filepath.Join(src, entry.Name())
 	dstPath := filepath.Join(dst, entry.Name())
 	if entry.IsDir() {
-		return copyDir(srcPath, dstPath)
+		return copyDir(srcPath, dstPath, dstRoot)
 	}
-	return nil, copyFile(srcPath, dstPath)
+	return nil, copyFile(srcPath, dstPath, dstRoot)
 }
 
-func copyFile(src, dst string) (retErr error) {
+func copyFile(src, dst, dstRoot string) (retErr error) {
+	if err := assertContained(dstRoot, dst); err != nil {
+		return err
+	}
 	in, err := os.Open(filepath.Clean(src))
 	if err != nil {
 		return err
@@ -131,7 +145,7 @@ func copyFile(src, dst string) (retErr error) {
 		return err
 	}
 
-	out, err := os.OpenFile(filepath.Clean(dst), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode()) //nolint:gosec // dst validated by ContainedJoin before copyEntry is called
+	out, err := os.OpenFile(filepath.Clean(dst), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode()) //nolint:gosec // dst validated by assertContained (symlink-resolved) before write
 	if err != nil {
 		return err
 	}
@@ -143,4 +157,52 @@ func copyFile(src, dst string) (retErr error) {
 
 	_, err = io.Copy(out, in)
 	return err
+}
+
+// resolveDstRoot resolves the symlink-canonical form of dst. If dst does not exist yet
+// (git worktree add has not run), "" is returned so assertContained becomes a no-op —
+// no symlinks can exist inside a non-existent directory. Non-ENOENT errors are surfaced.
+func resolveDstRoot(dst string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(dst)
+	if err == nil {
+		return resolved, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", fmt.Errorf("resolve dst %q: %w", dst, err)
+	}
+	return "", nil
+}
+
+// resolveExistingAncestor returns EvalSymlinks of the deepest existing ancestor of p.
+// Walks up one component at a time while EvalSymlinks reports path-not-exist. The walk
+// always terminates: filepath.Dir bottoms out at "/" which exists and resolves.
+func resolveExistingAncestor(p string) (string, error) {
+	for {
+		resolved, err := filepath.EvalSymlinks(p)
+		if err == nil {
+			return resolved, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		p = filepath.Dir(p)
+	}
+}
+
+// assertContained verifies that the deepest existing ancestor of path resolves inside root
+// (root must already be symlink-resolved). A symlinked directory component that redirects
+// a write outside the destination tree is rejected with ErrPathEscapes.
+// A blank root (dst did not exist at CopyEntries call time) is a no-op.
+func assertContained(root, path string) error {
+	if root == "" {
+		return nil
+	}
+	resolved, err := resolveExistingAncestor(path)
+	if err != nil {
+		return err
+	}
+	if resolved != root && !strings.HasPrefix(resolved, root+string(filepath.Separator)) {
+		return fmt.Errorf("path %q resolves outside %q via symlink: %w", path, root, ErrPathEscapes)
+	}
+	return nil
 }

--- a/internal/fileutil/copy_test.go
+++ b/internal/fileutil/copy_test.go
@@ -655,3 +655,144 @@ func TestCopyEntriesRecursiveCopyDirError(t *testing.T) {
 		t.Errorf(errContainsFmt, err, "copy "+dotConfig+":")
 	}
 }
+
+func TestCopyEntriesRejectsSymlinkedDstEscape(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	outside := t.TempDir()
+
+	if err := os.Symlink(outside, filepath.Join(dst, "sub")); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.MkdirAll(filepath.Join(src, "sub"), 0755)
+	_ = os.WriteFile(filepath.Join(src, "sub", "secret.txt"), []byte("secret"), 0644)
+
+	_, _, err := fileutil.CopyEntries(src, dst, []string{"sub/secret.txt"})
+	if err == nil {
+		t.Fatal("expected error when dst has top-level symlink pointing outside")
+	}
+	if !errors.Is(err, fileutil.ErrPathEscapes) {
+		t.Fatalf("error %v does not wrap fileutil.ErrPathEscapes", err)
+	}
+	if !strings.Contains(err.Error(), "resolves outside") {
+		t.Errorf("error %q should mention resolves outside", err.Error())
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "secret.txt")); !os.IsNotExist(statErr) {
+		t.Error("secret.txt must not have been written to outside")
+	}
+}
+
+func TestCopyEntriesRejectsNestedSymlinkEscape(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	outside := t.TempDir()
+
+	_ = os.MkdirAll(filepath.Join(src, "d", "deep"), 0755)
+	_ = os.WriteFile(filepath.Join(src, "d", "deep", "f.txt"), []byte("data"), 0644)
+
+	_ = os.MkdirAll(filepath.Join(dst, "d"), 0755)
+	if err := os.Symlink(outside, filepath.Join(dst, "d", "deep")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := fileutil.CopyEntries(src, dst, []string{"d"})
+	if err == nil {
+		t.Fatal("expected error when nested dir in dst is a symlink pointing outside")
+	}
+	if !errors.Is(err, fileutil.ErrPathEscapes) {
+		t.Fatalf("error %v does not wrap fileutil.ErrPathEscapes", err)
+	}
+	entries, _ := os.ReadDir(outside)
+	if len(entries) != 0 {
+		t.Errorf("outside dir should be empty after rejected copy, got %v", entries)
+	}
+}
+
+func TestCopyEntriesBenignSymlinkInsideDst(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	realDir := filepath.Join(dst, "real")
+	_ = os.MkdirAll(realDir, 0755)
+	if err := os.Symlink(realDir, filepath.Join(dst, "link")); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = os.MkdirAll(filepath.Join(src, "link"), 0755)
+	_ = os.WriteFile(filepath.Join(src, "link", "file.txt"), []byte("benign"), 0644)
+
+	copied, _, err := fileutil.CopyEntries(src, dst, []string{"link/file.txt"})
+	if err != nil {
+		t.Fatalf("in-dst symlink should not be rejected: %v", err)
+	}
+	if len(copied) != 1 {
+		t.Fatalf("expected 1 copied entry, got %d", len(copied))
+	}
+}
+
+func TestCopyEntriesNonExistentDst(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "missing")
+
+	_ = os.WriteFile(filepath.Join(src, ".env"), []byte("x"), 0644)
+	// Non-existent dst is allowed: no symlinks possible inside it, MkdirAll creates it.
+	copied, _, err := fileutil.CopyEntries(src, dst, []string{".env"})
+	if err != nil {
+		t.Fatalf("CopyEntries with non-existent dst should succeed: %v", err)
+	}
+	if len(copied) != 1 || copied[0] != ".env" {
+		t.Errorf("copied = %v, want [.env]", copied)
+	}
+}
+
+func TestCopyEntriesDstResolvePermissionError(t *testing.T) {
+	src := t.TempDir()
+	lockedParent := t.TempDir()
+
+	// Create dst inside a directory that will be locked.
+	dst := filepath.Join(lockedParent, "worktree")
+	if err := os.Mkdir(dst, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(lockedParent, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(lockedParent, 0755) })
+
+	_ = os.WriteFile(filepath.Join(src, ".env"), []byte("x"), 0644)
+
+	_, _, err := fileutil.CopyEntries(src, dst, []string{".env"})
+	if err == nil {
+		t.Skip("permission error on dst did not surface (likely running as root)")
+	}
+	if !strings.Contains(err.Error(), "resolve dst") {
+		t.Errorf("error %q should mention resolve dst", err.Error())
+	}
+	if errors.Is(err, fileutil.ErrPathEscapes) {
+		t.Error("dst permission error should not wrap ErrPathEscapes")
+	}
+}
+
+func TestCopyEntriesAncestorPermissionError(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	lockedSrc := filepath.Join(src, "locked")
+	_ = os.MkdirAll(lockedSrc, 0755)
+	_ = os.WriteFile(filepath.Join(lockedSrc, "secret.txt"), []byte("data"), 0644)
+
+	lockedDst := filepath.Join(dst, "locked")
+	_ = os.MkdirAll(lockedDst, 0755)
+	if err := os.Chmod(lockedDst, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(lockedDst, 0755) })
+
+	_, _, err := fileutil.CopyEntries(src, dst, []string{"locked/secret.txt"})
+	if err == nil {
+		t.Skip("permission error did not surface (likely running as root)")
+	}
+	if errors.Is(err, fileutil.ErrPathEscapes) {
+		t.Error("permission denied should not wrap ErrPathEscapes")
+	}
+}

--- a/internal/fileutil/copy_test.go
+++ b/internal/fileutil/copy_test.go
@@ -796,3 +796,27 @@ func TestCopyEntriesAncestorPermissionError(t *testing.T) {
 		t.Error("permission denied should not wrap ErrPathEscapes")
 	}
 }
+
+func TestCopyEntriesRejectsTopLevelDirSymlinkEscape(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+	outside := t.TempDir()
+
+	_ = os.Mkdir(filepath.Join(src, "mydir"), 0755)
+	_ = os.WriteFile(filepath.Join(src, "mydir", "f.txt"), []byte("data"), 0644)
+	if err := os.Symlink(outside, filepath.Join(dst, "mydir")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := fileutil.CopyEntries(src, dst, []string{"mydir"})
+	if err == nil {
+		t.Fatal("expected error when dst top-level entry is a symlink pointing outside")
+	}
+	if !errors.Is(err, fileutil.ErrPathEscapes) {
+		t.Fatalf("error %v does not wrap fileutil.ErrPathEscapes", err)
+	}
+	entries, _ := os.ReadDir(outside)
+	if len(entries) != 0 {
+		t.Errorf("outside dir should be empty after rejected copy, got %v", entries)
+	}
+}


### PR DESCRIPTION
## Summary
- `copy_files` (via `fileutil.CopyEntries`) now detects when a destination path component is a symlink pointing outside the worktree and rejects the write with `ErrPathEscapes`
- Added `resolveDstRoot`, `resolveExistingAncestor`, and `assertContained` helpers in `internal/fileutil/copy.go`; all three write syscalls (`MkdirAll` in `copyEntry`, `MkdirAll` in `copyDir`, `OpenFile` in `copyFile`) are now guarded
- `ContainedJoin` (lexical `..` guard) is unchanged; the new check adds symlink-resolution on top of it
- When `dst` doesn't exist at call time (tests with mocked runners, or pre-worktree-creation), the check is a no-op — in production `git worktree add` always creates `dst` before `CopyEntries` runs

## Test Plan
- [x] Unit tests pass (`make test`) — 1990 passed
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2E tests pass (`make test-e2e`) — 301 passed
- [x] Coverage at 97.0% (`make test-coverage`)
- New tests added: `TestCopyEntriesRejectsSymlinkedDstEscape`, `TestCopyEntriesRejectsNestedSymlinkEscape`, `TestCopyEntriesBenignSymlinkInsideDst`, `TestCopyEntriesNonExistentDst` (updated), `TestCopyEntriesDstResolvePermissionError`, `TestCopyEntriesAncestorPermissionError`

## Issue

Closes #254