### PR TITLE
[feat] honor global --json flag in log

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/output"
 	"github.com/lugassawan/rimba/internal/parallel"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/spinner"
@@ -25,6 +26,7 @@ type logEntry struct {
 	task       string
 	service    string
 	typeName   string
+	path       string
 	commitTime time.Time
 	subject    string
 	valid      bool
@@ -53,6 +55,9 @@ var logCmd = &cobra.Command{
 		candidates := git.FilterEntries(entries, mainBranch)
 
 		if len(candidates) == 0 {
+			if isJSON(cmd) {
+				return output.WriteJSON(cmd.OutOrStdout(), version, "log", make([]output.LogItem, 0))
+			}
 			fmt.Fprintln(cmd.OutOrStdout(), "No worktrees found.")
 			return nil
 		}
@@ -88,8 +93,15 @@ var logCmd = &cobra.Command{
 		}
 
 		if len(valid) == 0 {
+			if isJSON(cmd) {
+				return output.WriteJSON(cmd.OutOrStdout(), version, "log", make([]output.LogItem, 0))
+			}
 			fmt.Fprintln(cmd.OutOrStdout(), "No recent commits found.")
 			return nil
+		}
+
+		if isJSON(cmd) {
+			return writeLogJSON(cmd, valid)
 		}
 
 		noColor, _ := cmd.Flags().GetBool(flagNoColor)
@@ -118,13 +130,14 @@ func collectLogEntries(r git.Runner, candidates []git.WorktreeEntry, s *spinner.
 
 		ct, subject, err := git.LastCommitInfo(r, e.Branch)
 		if err != nil {
-			return logEntry{branch: e.Branch, task: task, service: svc, typeName: typeName}
+			return logEntry{branch: e.Branch, task: task, service: svc, typeName: typeName, path: e.Path}
 		}
 		return logEntry{
 			branch:     e.Branch,
 			task:       task,
 			service:    svc,
 			typeName:   typeName,
+			path:       e.Path,
 			commitTime: ct,
 			subject:    subject,
 			valid:      true,
@@ -189,4 +202,20 @@ func renderLogTable(out io.Writer, p *termcolor.Painter, entries []logEntry) {
 	}
 
 	tbl.Render(out)
+}
+
+func writeLogJSON(cmd *cobra.Command, entries []logEntry) error {
+	items := make([]output.LogItem, 0, len(entries))
+	for _, e := range entries {
+		items = append(items, output.LogItem{
+			Task:       e.task,
+			Service:    e.service,
+			Type:       e.typeName,
+			Branch:     e.branch,
+			Path:       e.path,
+			LastCommit: e.commitTime.UTC().Format(time.RFC3339),
+			Subject:    e.subject,
+		})
+	}
+	return output.WriteJSON(cmd.OutOrStdout(), version, "log", items)
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -56,7 +56,7 @@ var logCmd = &cobra.Command{
 
 		if len(candidates) == 0 {
 			if isJSON(cmd) {
-				return output.WriteJSON(cmd.OutOrStdout(), version, "log", make([]output.LogItem, 0))
+				return writeLogJSONEmpty(cmd)
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "No worktrees found.")
 			return nil
@@ -94,7 +94,7 @@ var logCmd = &cobra.Command{
 
 		if len(valid) == 0 {
 			if isJSON(cmd) {
-				return output.WriteJSON(cmd.OutOrStdout(), version, "log", make([]output.LogItem, 0))
+				return writeLogJSONEmpty(cmd)
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "No recent commits found.")
 			return nil
@@ -202,6 +202,10 @@ func renderLogTable(out io.Writer, p *termcolor.Painter, entries []logEntry) {
 	}
 
 	tbl.Render(out)
+}
+
+func writeLogJSONEmpty(cmd *cobra.Command) error {
+	return output.WriteJSON(cmd.OutOrStdout(), version, "log", make([]output.LogItem, 0))
 }
 
 func writeLogJSON(cmd *cobra.Command, entries []logEntry) error {

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -286,8 +286,8 @@ func TestLogJSON(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
 	}
-	if env.Command != "log" {
-		t.Errorf("command = %q, want %q", env.Command, "log")
+	if env.Command != cmdLog {
+		t.Errorf("command = %q, want %q", env.Command, cmdLog)
 	}
 
 	data, ok := env.Data.([]any)
@@ -315,6 +315,10 @@ func TestLogJSON(t *testing.T) {
 	}
 	if item["subject"] != "add login feature" {
 		t.Errorf("subject = %v, want %q", item["subject"], "add login feature")
+	}
+	lc, _ := item["last_commit"].(string)
+	if _, err := time.Parse(time.RFC3339, lc); err != nil {
+		t.Errorf("last_commit %q is not RFC3339: %v", lc, err)
 	}
 }
 
@@ -348,8 +352,8 @@ func TestLogJSONEmpty(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
 	}
-	if env.Command != "log" {
-		t.Errorf("command = %q, want %q", env.Command, "log")
+	if env.Command != cmdLog {
+		t.Errorf("command = %q, want %q", env.Command, cmdLog)
 	}
 
 	data, ok := env.Data.([]any)
@@ -358,5 +362,41 @@ func TestLogJSONEmpty(t *testing.T) {
 	}
 	if len(data) != 0 {
 		t.Errorf("expected empty data array, got %d items", len(data))
+	}
+}
+
+// TestLogJSONEmptyAfterFilter covers the post-filter JSON path (guard 2 in RunE):
+// worktrees exist but all entries are filtered out by --since.
+func TestLogJSONEmptyAfterFilter(t *testing.T) {
+	ts := strconv.FormatInt(time.Now().Add(-30*24*time.Hour).Unix(), 10)
+	restore := overrideNewRunner(logRunnerWithWorktree(func(_ string) (string, error) {
+		return ts + "\told commit", nil
+	}))
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	_ = cmd.Flags().Set(flagJSON, "true")
+	cmd.Flags().Int(flagLimit, 0, "")
+	cmd.Flags().String(flagSince, "", "")
+	_ = cmd.Flags().Set(flagSince, "1h")
+
+	if err := logCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("logCmd.RunE: %v", err)
+	}
+
+	var env output.Envelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if env.Command != cmdLog {
+		t.Errorf("command = %q, want %q", env.Command, cmdLog)
+	}
+
+	data, ok := env.Data.([]any)
+	if !ok {
+		t.Fatalf("data type = %T, want []any", env.Data)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected empty data array after filter, got %d items", len(data))
 	}
 }

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -83,6 +83,18 @@ func TestLogWithWorktrees(t *testing.T) {
 	}
 }
 
+// findLogItem searches a JSON data slice for the entry with the given task name.
+func findLogItem(t *testing.T, data []any, task string) map[string]any {
+	t.Helper()
+	for _, d := range data {
+		if m, ok := d.(map[string]any); ok && m["task"] == task {
+			return m
+		}
+	}
+	t.Fatalf("%q entry not found in JSON output", task)
+	return nil
+}
+
 func logRunnerWithWorktree(logResp func(branch string) (string, error)) *mockRunner {
 	return &mockRunner{
 		run: func(args ...string) (string, error) {
@@ -294,14 +306,10 @@ func TestLogJSON(t *testing.T) {
 	if !ok {
 		t.Fatalf("data type = %T, want []any", env.Data)
 	}
-	if len(data) != 1 {
-		t.Errorf("data length = %d, want 1", len(data))
+	if len(data) == 0 {
+		t.Fatal("expected at least one log entry")
 	}
-
-	item, ok := data[0].(map[string]any)
-	if !ok {
-		t.Fatalf("item type = %T, want map[string]any", data[0])
-	}
+	item := findLogItem(t, data, taskLogin)
 	for _, field := range []string{"task", "type", "branch", "path", "last_commit", "subject"} {
 		if _, exists := item[field]; !exists {
 			t.Errorf("item missing field %q", field)

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/lugassawan/rimba/internal/output"
 )
 
 func TestLogNoWorktrees(t *testing.T) {
@@ -260,5 +263,100 @@ func TestLogCommitInfoError(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "No recent commits found") {
 		t.Errorf("expected 'No recent commits found' when all entries fail, got: %q", buf.String())
+	}
+}
+
+func TestLogJSON(t *testing.T) {
+	ts := strconv.FormatInt(time.Now().Add(-2*time.Hour).Unix(), 10)
+	restore := overrideNewRunner(logRunnerWithWorktree(func(_ string) (string, error) {
+		return ts + "\tadd login feature", nil
+	}))
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	_ = cmd.Flags().Set(flagJSON, "true")
+	cmd.Flags().Int(flagLimit, 0, "")
+	cmd.Flags().String(flagSince, "", "")
+
+	if err := logCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("logCmd.RunE: %v", err)
+	}
+
+	var env output.Envelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if env.Command != "log" {
+		t.Errorf("command = %q, want %q", env.Command, "log")
+	}
+
+	data, ok := env.Data.([]any)
+	if !ok {
+		t.Fatalf("data type = %T, want []any", env.Data)
+	}
+	if len(data) != 1 {
+		t.Errorf("data length = %d, want 1", len(data))
+	}
+
+	item, ok := data[0].(map[string]any)
+	if !ok {
+		t.Fatalf("item type = %T, want map[string]any", data[0])
+	}
+	for _, field := range []string{"task", "type", "branch", "path", "last_commit", "subject"} {
+		if _, exists := item[field]; !exists {
+			t.Errorf("item missing field %q", field)
+		}
+	}
+	if item["task"] != taskLogin {
+		t.Errorf("task = %v, want %q", item["task"], taskLogin)
+	}
+	if item["path"] != pathWtFeatureLogin {
+		t.Errorf("path = %v, want %q", item["path"], pathWtFeatureLogin)
+	}
+	if item["subject"] != "add login feature" {
+		t.Errorf("subject = %v, want %q", item["subject"], "add login feature")
+	}
+}
+
+func TestLogJSONEmpty(t *testing.T) {
+	restore := overrideNewRunner(&mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case args[0] == cmdRevParse && args[1] == cmdShowToplevel:
+				return repoPath, nil
+			case args[0] == cmdSymbolicRef:
+				return refsRemotesOriginMain, nil
+			case args[0] == cmdWorktreeTest && args[1] == cmdList:
+				return wtRepo + headMainBlock, nil
+			}
+			return "", nil
+		},
+		runInDir: noopRunInDir,
+	})
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	_ = cmd.Flags().Set(flagJSON, "true")
+	cmd.Flags().Int(flagLimit, 0, "")
+	cmd.Flags().String(flagSince, "", "")
+
+	if err := logCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("logCmd.RunE: %v", err)
+	}
+
+	var env output.Envelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if env.Command != "log" {
+		t.Errorf("command = %q, want %q", env.Command, "log")
+	}
+
+	data, ok := env.Data.([]any)
+	if !ok {
+		t.Fatalf("data type = %T, want []any", env.Data)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected empty data array, got %d items", len(data))
 	}
 }

--- a/internal/output/types.go
+++ b/internal/output/types.go
@@ -83,3 +83,14 @@ type ExecResult struct {
 	Error     string `json:"error,omitempty"`
 	Cancelled bool   `json:"cancelled,omitempty"`
 }
+
+// LogItem represents a worktree's most-recent commit in JSON output.
+type LogItem struct {
+	Task       string `json:"task"`
+	Service    string `json:"service,omitempty"`
+	Type       string `json:"type"`
+	Branch     string `json:"branch"`
+	Path       string `json:"path"`
+	LastCommit string `json:"last_commit"`
+	Subject    string `json:"subject"`
+}

--- a/tests/e2e/json_test.go
+++ b/tests/e2e/json_test.go
@@ -148,17 +148,21 @@ func TestLogJSON(t *testing.T) {
 		t.Fatal("expected at least one log entry")
 	}
 
-	item, ok := data[0].(map[string]any)
-	if !ok {
-		t.Fatalf("item type = %T, want map[string]any", data[0])
+	var item map[string]any
+	for _, d := range data {
+		if m, ok := d.(map[string]any); ok && m["task"] == "log-json-task" {
+			item = m
+			break
+		}
 	}
+	if item == nil {
+		t.Fatal("log-json-task entry not found in JSON output")
+	}
+
 	for _, field := range []string{"task", "type", "branch", "path", "last_commit", "subject"} {
 		if _, exists := item[field]; !exists {
 			t.Errorf("item missing field %q", field)
 		}
-	}
-	if item["task"] != "log-json-task" {
-		t.Errorf("task = %v, want 'log-json-task'", item["task"])
 	}
 	if item["subject"] != "add log json work" {
 		t.Errorf("subject = %v, want 'add log json work'", item["subject"])

--- a/tests/e2e/json_test.go
+++ b/tests/e2e/json_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lugassawan/rimba/internal/deps"
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -161,6 +162,10 @@ func TestLogJSON(t *testing.T) {
 	}
 	if item["subject"] != "add log json work" {
 		t.Errorf("subject = %v, want 'add log json work'", item["subject"])
+	}
+	lc, _ := item["last_commit"].(string)
+	if _, err := time.Parse(time.RFC3339, lc); err != nil {
+		t.Errorf("last_commit %q is not RFC3339: %v", lc, err)
 	}
 
 	// No ANSI escape codes

--- a/tests/e2e/json_test.go
+++ b/tests/e2e/json_test.go
@@ -2,10 +2,13 @@ package e2e_test
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/deps"
+	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/testutil"
 )
 
 // parseEnvelope parses a JSON envelope from stdout and returns the data field.
@@ -109,6 +112,62 @@ func TestListJSONArchived(t *testing.T) {
 	}
 	if len(data) == 0 {
 		t.Error("expected at least one archived branch")
+	}
+}
+
+func TestLogJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo := setupInitializedRepo(t)
+	rimbaSuccess(t, repo, "add", "log-json-task")
+
+	// Make a commit in the worktree so log has something to show
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.BranchName(defaultPrefix, "log-json-task")
+	wtPath := resolver.WorktreePath(wtDir, branch)
+	testutil.CreateFile(t, wtPath, "work.txt", "some work")
+	testutil.GitCmd(t, wtPath, "add", ".")
+	testutil.GitCmd(t, wtPath, "commit", "-m", "add log json work")
+
+	r := rimbaSuccess(t, repo, "log", "--json")
+	env := parseEnvelope(t, r.Stdout)
+
+	if env["command"] != "log" {
+		t.Errorf("command = %v, want 'log'", env["command"])
+	}
+
+	data, ok := env["data"].([]any)
+	if !ok {
+		t.Fatalf("data type = %T, want []any", env["data"])
+	}
+	if len(data) == 0 {
+		t.Fatal("expected at least one log entry")
+	}
+
+	item, ok := data[0].(map[string]any)
+	if !ok {
+		t.Fatalf("item type = %T, want map[string]any", data[0])
+	}
+	for _, field := range []string{"task", "type", "branch", "path", "last_commit", "subject"} {
+		if _, exists := item[field]; !exists {
+			t.Errorf("item missing field %q", field)
+		}
+	}
+	if item["task"] != "log-json-task" {
+		t.Errorf("task = %v, want 'log-json-task'", item["task"])
+	}
+	if item["subject"] != "add log json work" {
+		t.Errorf("subject = %v, want 'add log json work'", item["subject"])
+	}
+
+	// No ANSI escape codes
+	assertNotContains(t, r.Stdout, "\033[")
+	// No spinner output on stderr
+	if r.Stderr != "" {
+		t.Errorf("expected empty stderr in JSON mode, got: %s", r.Stderr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `LogItem` DTO to `internal/output/types.go` with fields: `task`, `service` (omitempty), `type`, `branch`, `path`, `last_commit` (RFC3339 UTC), `subject` — mirroring `ListItem` conventions
- Thread `path` through `logEntry` struct from `git.WorktreeEntry.Path` (was missing, needed for JSON output)
- Add JSON guards at all three exit paths in `logCmd.RunE` (no worktrees, no commits after filters, happy path)
- Add `writeLogJSON` helper that maps `[]logEntry → []output.LogItem` and emits via `output.WriteJSON`
- `--since` / `--limit` filtering is applied before the JSON branch, so both flags are honoured in JSON mode
- Spinner already suppressed in JSON mode via existing `spinnerOpts(cmd)` — no change needed
- **Audit:** `status` and `list` already implement `--json` with passing tests. One asymmetry noted: `StatusItem` lacks `path` (present in `ListItem`/`ExecResult`/`LogItem`); left as-is — additive change deferred to avoid schema churn on an established shape

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)
- [x] New `TestLogJSON` unit test: happy path with field assertions (`task`, `type`, `branch`, `path`, `last_commit`, `subject`)
- [x] New `TestLogJSONEmpty` unit test: no-worktrees path emits `{"data":[]}`
- [x] New `TestLogJSON` e2e test: real git repo, ANSI-free stdout, empty stderr

## Issue

Closes #255