### PR TITLE
[fix] Force stable locale for git commands

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -24,6 +25,7 @@ type ExecRunner struct {
 // RunInDirContext is the single execution primitive: all other methods delegate here.
 func (r *ExecRunner) RunInDirContext(ctx context.Context, dir string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = stableGitEnv(os.Environ())
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -34,6 +36,23 @@ func (r *ExecRunner) RunInDirContext(ctx context.Context, dir string, args ...st
 		return result, fmt.Errorf("git %s: %s: %w", strings.Join(args, " "), result, err)
 	}
 	return result, nil
+}
+
+func stableGitEnv(environ []string) []string {
+	env := make([]string, 0, len(environ)+2)
+	for _, entry := range environ {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			env = append(env, entry)
+			continue
+		}
+		if strings.EqualFold(key, "LANG") || strings.EqualFold(key, "LC_ALL") {
+			continue
+		}
+		env = append(env, entry)
+	}
+
+	return append(env, "LANG=C", "LC_ALL=C")
 }
 
 func (r *ExecRunner) RunContext(ctx context.Context, args ...string) (string, error) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -41,11 +41,7 @@ func (r *ExecRunner) RunInDirContext(ctx context.Context, dir string, args ...st
 func stableGitEnv(environ []string) []string {
 	env := make([]string, 0, len(environ)+2)
 	for _, entry := range environ {
-		key, _, ok := strings.Cut(entry, "=")
-		if !ok {
-			env = append(env, entry)
-			continue
-		}
+		key, _, _ := strings.Cut(entry, "=")
 		if strings.EqualFold(key, "LANG") || strings.EqualFold(key, "LC_ALL") {
 			continue
 		}

--- a/internal/git/git_ctx_test.go
+++ b/internal/git/git_ctx_test.go
@@ -47,7 +47,6 @@ func TestRunContextDelegatesToRunInDirContext(t *testing.T) {
 func TestStableGitEnvForcesCLocale(t *testing.T) {
 	env := stableGitEnv([]string{
 		"PATH=/usr/bin",
-		"NO_EQUALS",
 		"LANG=fr_FR.UTF-8",
 		"LC_ALL=de_DE.UTF-8",
 		"OTHER=value",
@@ -62,7 +61,7 @@ func TestStableGitEnvForcesCLocale(t *testing.T) {
 		}
 	}
 
-	for _, want := range []string{"PATH=/usr/bin", "NO_EQUALS", "OTHER=value", "LANG=C", "LC_ALL=C"} {
+	for _, want := range []string{"PATH=/usr/bin", "OTHER=value", "LANG=C", "LC_ALL=C"} {
 		if !hasEnv(env, want) {
 			t.Fatalf("expected %q in %v", want, env)
 		}

--- a/internal/git/git_ctx_test.go
+++ b/internal/git/git_ctx_test.go
@@ -42,3 +42,36 @@ func TestRunContextDelegatesToRunInDirContext(t *testing.T) {
 		t.Errorf("expected git version output, got: %q", out)
 	}
 }
+
+func TestStableGitEnvForcesCLocale(t *testing.T) {
+	env := stableGitEnv([]string{
+		"PATH=/usr/bin",
+		"LANG=fr_FR.UTF-8",
+		"LC_ALL=de_DE.UTF-8",
+		"OTHER=value",
+	})
+
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "LANG=") && entry != "LANG=C" {
+			t.Fatalf("unexpected LANG entry %q in %v", entry, env)
+		}
+		if strings.HasPrefix(entry, "LC_ALL=") && entry != "LC_ALL=C" {
+			t.Fatalf("unexpected LC_ALL entry %q in %v", entry, env)
+		}
+	}
+
+	for _, want := range []string{"PATH=/usr/bin", "OTHER=value", "LANG=C", "LC_ALL=C"} {
+		if !hasEnv(env, want) {
+			t.Fatalf("expected %q in %v", want, env)
+		}
+	}
+}
+
+func hasEnv(env []string, want string) bool {
+	for _, entry := range env {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/git/git_ctx_test.go
+++ b/internal/git/git_ctx_test.go
@@ -47,6 +47,7 @@ func TestRunContextDelegatesToRunInDirContext(t *testing.T) {
 func TestStableGitEnvForcesCLocale(t *testing.T) {
 	env := stableGitEnv([]string{
 		"PATH=/usr/bin",
+		"NO_EQUALS",
 		"LANG=fr_FR.UTF-8",
 		"LC_ALL=de_DE.UTF-8",
 		"OTHER=value",
@@ -61,7 +62,7 @@ func TestStableGitEnvForcesCLocale(t *testing.T) {
 		}
 	}
 
-	for _, want := range []string{"PATH=/usr/bin", "OTHER=value", "LANG=C", "LC_ALL=C"} {
+	for _, want := range []string{"PATH=/usr/bin", "NO_EQUALS", "OTHER=value", "LANG=C", "LC_ALL=C"} {
 		if !hasEnv(env, want) {
 			t.Fatalf("expected %q in %v", want, env)
 		}

--- a/internal/git/git_ctx_test.go
+++ b/internal/git/git_ctx_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -68,10 +69,5 @@ func TestStableGitEnvForcesCLocale(t *testing.T) {
 }
 
 func hasEnv(env []string, want string) bool {
-	for _, entry := range env {
-		if entry == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(env, want)
 }


### PR DESCRIPTION
Fixes #251.

ExecRunner was inheriting the caller's locale, but branch cleanup treats a few already-gone git errors as success by matching git's English output. A translated git message can miss those checks and turn cleanup into a hard error.

This strips inherited LANG and LC_ALL values for git subprocesses and sets both to C so git output stays stable.

Tested on Windows:
```sh
go test ./internal/git -run "TestStableGitEnvForcesCLocale|TestRun" -count=1 -v
go test ./internal/git -run "Test(Run|StableGitEnv|DeleteBranch|DeleteRemoteBranch)" -count=1 -v
```