### PR TITLE
[fix] Handle same-name worktree rename

### DIFF
--- a/internal/operations/rename.go
+++ b/internal/operations/rename.go
@@ -27,6 +27,9 @@ func RenameWorktree(r git.Runner, wt resolver.WorktreeInfo, newTask, wtDir strin
 	}
 
 	newBranch := resolver.FullBranchName(svc, matchedPrefix, newTask)
+	if newBranch == wt.Branch {
+		return RenameResult{}, fmt.Errorf("new name is the same as the current name: %q", newTask)
+	}
 
 	if git.BranchExists(r, newBranch) {
 		return RenameResult{}, errhint.WithFix(

--- a/internal/operations/rename_test.go
+++ b/internal/operations/rename_test.go
@@ -72,6 +72,38 @@ func TestRenameWorktreeBranchExists(t *testing.T) {
 	}
 }
 
+func TestRenameWorktreeSameName(t *testing.T) {
+	calls := 0
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			calls++
+			return "", nil
+		},
+		runInDir: func(dir string, args ...string) (string, error) {
+			calls++
+			return "", nil
+		},
+	}
+
+	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
+	_, err := RenameWorktree(r, wt, "login", wtDir, false)
+	if err == nil {
+		t.Fatal("expected error for same-name rename")
+	}
+	if !strings.Contains(err.Error(), "same as the current name") {
+		t.Errorf("error = %q, want same-name message", err.Error())
+	}
+	if strings.Contains(err.Error(), "git branch -D") {
+		t.Errorf("error = %q, must not include destructive branch delete hint", err.Error())
+	}
+	if strings.Contains(err.Error(), "To fix:") {
+		t.Errorf("error = %q, must not include a recovery hint", err.Error())
+	}
+	if calls != 0 {
+		t.Fatalf("expected no git calls for same-name rename, got %d", calls)
+	}
+}
+
 func TestRenameWorktreeMoveFails(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {


### PR DESCRIPTION
Fixes #220.

`rename` now catches the no-op case before checking whether the target branch exists. That keeps `rimba rename auth auth` from returning the generic "branch already exists" error and avoids showing the `git branch -D` recovery hint for the current branch.

Tested on Windows:
```sh
go test ./internal/operations -run TestRenameWorktreeSameName -count=1 -v
go test ./internal/operations -run TestRenameWorktree -count=1 -v
```

I also tried `go test ./internal/operations -count=1`, but this local Windows environment fails existing tests that need symlink privileges and `sh` for hook execution.