### PR TITLE
[feat] consent gate before executing committed shell commands (#253)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,40 @@ Running `rimba init --agents` or `rimba init -g` additionally creates or patches
 
 ## Trust model
 
-**`.rimba/settings.toml` is trusted-author input.** The following fields execute shell commands verbatim via `sh -c`:
+**`.rimba/settings.toml` is committed and team-shared.** The following fields execute shell commands verbatim via `sh -c`:
 
-- `post_create` — runs after a worktree is created (e.g. `rimba add`)
+- `post_create` — runs after a worktree is created (e.g. `rimba add`, `rimba duplicate`, `rimba restore`)
+- `post_rename` — runs after a worktree is renamed (`rimba rename`)
 - `deps.modules[].install` — runs when installing dependencies into a worktree
 
-**Cloning an untrusted repository and running `rimba add` executes that repo's `post_create` and `install` shell scripts.** Always review `.rimba/settings.toml` before running rimba in a repository you do not control.
+### Consent gate
+
+rimba will **not** execute committed shell commands until you have explicitly approved them. On the first run in a new clone (or whenever the command set changes), rimba prints the commands and prompts for consent:
+
+```
+This repo's .rimba/settings.toml will run shell commands that have not been approved:
+  pnpm install
+  ./scripts/setup.sh
+
+Run these commands? [y/N]
+```
+
+Approval is stored locally in `.rimba/trust.local.toml` (gitignored — each user consents independently). The approval is keyed by a hash of the command set; changing any command re-arms the gate.
+
+**Pre-approve without prompting** (e.g. for `rimba trust` after reviewing settings, or in CI):
+
+```sh
+rimba trust           # review and approve interactively
+rimba trust --yes     # approve without prompt (non-interactive)
+rimba trust --show    # inspect commands and current approval status
+```
+
+**CI / non-interactive environments:** pass `--yes` or set `RIMBA_TRUST_YES=1`:
+
+```sh
+RIMBA_TRUST_YES=1 rimba add my-task
+rimba add my-task --yes
+```
 
 As a defense-in-depth measure, the `copy_files` entries and `deps.modules[].lockfile` paths are validated to stay within the worktree directory — paths that escape via `..` are rejected with an error. Note that `worktree_dir` is intentionally not subject to this constraint, because its default value (`../<repo>-worktrees`) is itself a `../`-relative path.
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -61,10 +61,6 @@ main repo and is not the default branch. --source is not valid in branch: mode.`
 			return err
 		}
 
-		if err := ensureTrust(cmd, repoRoot, cfg); err != nil {
-			return err
-		}
-
 		skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
 		skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
 		postOpts := buildPostCreateOptions(cfg, repoRoot, skipDeps, skipHooks)
@@ -74,9 +70,13 @@ main repo and is not the default branch. --source is not valid in branch: mode.`
 
 		if m := prArgRe.FindStringSubmatch(args[0]); m != nil {
 			prNum, _ := strconv.Atoi(m[1])
+			if err := ensureTrust(cmd, repoRoot, cfg); err != nil {
+				return err
+			}
 			return runAddPR(cmd, r, newGHRunner(), prNum, postOpts, s)
 		}
 
+		// branch: mode promotes an existing branch without running hooks — no trust gate.
 		if m := branchArgRe.FindStringSubmatch(args[0]); m != nil {
 			if cmd.Flags().Changed(flagSource) {
 				return errhint.WithFix(
@@ -94,6 +94,9 @@ main repo and is not the default branch. --source is not valid in branch: mode.`
 			)
 		}
 
+		if err := ensureTrust(cmd, repoRoot, cfg); err != nil {
+			return err
+		}
 		return runAddTask(cmd, r, args[0], cfg, repoRoot, postOpts, s)
 	},
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -61,6 +61,10 @@ main repo and is not the default branch. --source is not valid in branch: mode.`
 			return err
 		}
 
+		if err := ensureTrust(cmd, repoRoot, cfg); err != nil {
+			return err
+		}
+
 		skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
 		skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
 		postOpts := buildPostCreateOptions(cfg, repoRoot, skipDeps, skipHooks)

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -202,6 +202,7 @@ func TestAddWithSource(t *testing.T) {
 }
 
 func TestAddPRCmd(t *testing.T) {
+	t.Setenv("RIMBA_TRUST_YES", "1")
 	repoDir := t.TempDir()
 	wtDir := filepath.Join(repoDir, ".worktrees")
 	_ = os.MkdirAll(wtDir, 0755)

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -189,6 +189,10 @@ var depsInstallCmd = &cobra.Command{
 			return nil
 		}
 
+		if err := ensureTrust(cmd, repoRoot, cfg); err != nil {
+			return err
+		}
+
 		s := spinner.New(spinnerOpts(cmd))
 		defer s.Stop()
 

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -97,6 +97,10 @@ var duplicateCmd = &cobra.Command{
 			return fmt.Errorf("worktree path already exists: %s", wtPath)
 		}
 
+		if err := ensureTrust(cmd, repoRoot, cfg); err != nil {
+			return err
+		}
+
 		dryRun, _ := cmd.Flags().GetBool(flagDryRun)
 		skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
 		skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -97,10 +97,6 @@ var duplicateCmd = &cobra.Command{
 			return fmt.Errorf("worktree path already exists: %s", wtPath)
 		}
 
-		if err := ensureTrust(cmd, repoRoot, cfg); err != nil {
-			return err
-		}
-
 		dryRun, _ := cmd.Flags().GetBool(flagDryRun)
 		skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
 		skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)
@@ -125,6 +121,10 @@ var duplicateCmd = &cobra.Command{
 				fmt.Fprintf(out, "[dry-run] would run post-create hooks\n")
 			}
 			return nil
+		}
+
+		if err := ensureTrust(cmd, repoRoot, cfg); err != nil {
+			return err
 		}
 
 		s := spinner.New(spinnerOpts(cmd))

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/fileutil"
 	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/trust"
 	"github.com/spf13/cobra"
 )
 
@@ -160,6 +161,13 @@ func runInitFresh(cmd *cobra.Command, r git.Runner, repoRoot, dirPath, gitignore
 		return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
 	}
 
+	// Ensure trust store is gitignored (no-op in --personal mode since .rimba/ is already covered).
+	if !personal {
+		if _, err := fileutil.EnsureGitignore(repoRoot, filepath.Join(config.DirName, trust.FileName)); err != nil {
+			return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
+		}
+	}
+
 	fmt.Fprintf(cmd.OutOrStdout(), "Initialized rimba in %s\n", repoRoot)
 	fmt.Fprintf(cmd.OutOrStdout(), "  Config:       %s\n", filepath.Join(dirPath, config.TeamFile))
 	fmt.Fprintf(cmd.OutOrStdout(), "  Worktree dir: %s\n", wtDir)
@@ -197,6 +205,13 @@ func runInitMigrate(cmd *cobra.Command, repoRoot, dirPath, legacyPath, gitignore
 
 	if _, err := fileutil.EnsureGitignore(repoRoot, gitignoreEntry); err != nil {
 		return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
+	}
+
+	// Ensure trust store is gitignored (no-op in --personal mode).
+	if !personal {
+		if _, err := fileutil.EnsureGitignore(repoRoot, filepath.Join(config.DirName, trust.FileName)); err != nil {
+			return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
+		}
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Migrated rimba config in %s\n", repoRoot)

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -47,6 +47,10 @@ var renameCmd = &cobra.Command{
 		_, task = operations.ResolveTaskInput(task, repoRoot)
 		_, newTask = operations.ResolveTaskInput(newTask, repoRoot)
 
+		if err := ensureTrust(cmd, repoRoot, cfg); err != nil {
+			return err
+		}
+
 		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
 		skipDeps, _ := cmd.Flags().GetBool(flagSkipDeps)
 		skipHooks, _ := cmd.Flags().GetBool(flagSkipHooks)

--- a/cmd/rename_test.go
+++ b/cmd/rename_test.go
@@ -162,6 +162,7 @@ func makeRenameRunner(repoDir, worktreeOut string) *mockRunner {
 }
 
 func TestRenameRunsHooksWhenConfigured(t *testing.T) {
+	t.Setenv("RIMBA_TRUST_YES", "1")
 	// WorktreeDir must be relative; cmd layer joins it with repoRoot.
 	// new branch = feature/auth → new path = <repoDir>/wt/feature-auth
 	repoDir := t.TempDir()
@@ -194,6 +195,7 @@ func TestRenameRunsHooksWhenConfigured(t *testing.T) {
 }
 
 func TestRenameSkipHooks(t *testing.T) {
+	t.Setenv("RIMBA_TRUST_YES", "1")
 	repoDir := t.TempDir()
 	hookDir := t.TempDir()
 	marker := filepath.Join(hookDir, "hook-ran")

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -48,6 +48,10 @@ to see available archived branches.`,
 			return err
 		}
 
+		if err := ensureTrust(cmd, repoRoot, cfg); err != nil {
+			return err
+		}
+
 		wtDir := filepath.Join(repoRoot, cfg.WorktreeDir)
 		wtPath := resolver.WorktreePath(wtDir, branch)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,6 +104,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool(flagJSON, false, "output in JSON format")
 	rootCmd.PersistentFlags().Bool(flagNoColor, false, "disable colored output")
 	rootCmd.PersistentFlags().Bool(flagDebug, false, "log git commands and timings to stderr")
+	rootCmd.PersistentFlags().Bool(flagYes, false, hintYes)
 
 	originalHelp := rootCmd.HelpFunc()
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {

--- a/cmd/trust.go
+++ b/cmd/trust.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/trust"
+	"github.com/spf13/cobra"
+)
+
+const flagShow = "show"
+
+var trustCmd = &cobra.Command{
+	Use:   "trust",
+	Short: "Approve committed shell commands for this repo",
+	Long: `Review and approve the shell commands in .rimba/settings.toml.
+
+rimba will not run committed post_create, post_rename, or deps.modules[].install
+shell commands until you approve them. Approval is stored locally in
+.rimba/trust.local.toml (gitignored) and is keyed by a hash of the command set.
+Changing the commands re-arms the consent gate.
+
+Use --show to inspect the current command set and approval status without prompting.
+Use --yes to approve without prompting (e.g. in CI, combined with RIMBA_TRUST_YES=1).`,
+	Example: `  rimba trust           # review and approve
+  rimba trust --show    # inspect without approving
+  rimba trust --yes     # approve without prompting`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := config.FromContext(cmd.Context())
+
+		r := newRunner()
+		repoRoot, err := git.MainRepoRoot(r)
+		if err != nil {
+			return err
+		}
+
+		show, _ := cmd.Flags().GetBool(flagShow)
+		if show {
+			return runTrustShow(cmd, repoRoot, cfg)
+		}
+		return runTrustApprove(cmd, repoRoot, cfg)
+	},
+}
+
+// buildTrustCmd constructs a testable trust command with injected deps.
+// Used by trust_test.go to avoid needing a real git repo.
+func buildTrustCmd(cfg *config.Config, repoRoot string) *cobra.Command {
+	c := &cobra.Command{
+		Use:  "trust",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			show, _ := cmd.Flags().GetBool(flagShow)
+			if show {
+				return runTrustShow(cmd, repoRoot, cfg)
+			}
+			return runTrustApprove(cmd, repoRoot, cfg)
+		},
+	}
+	c.Flags().Bool(flagShow, false, "")
+	c.Flags().Bool(flagYes, false, "")
+	return c
+}
+
+func runTrustApprove(cmd *cobra.Command, repoRoot string, cfg *config.Config) error {
+	if !trust.HasCommands(cfg) {
+		fmt.Fprintln(cmd.OutOrStdout(), "No shell commands in .rimba/settings.toml — nothing to approve.")
+		return nil
+	}
+
+	h := trust.Hash(cfg)
+	ok, err := trust.IsTrusted(repoRoot, h)
+	if err != nil {
+		return err
+	}
+	if ok {
+		fmt.Fprintln(cmd.OutOrStdout(), "Already trusted — no changes needed.")
+		return nil
+	}
+
+	if !trustYesRequested(cmd) && !promptTrust(cmd, cfg) {
+		fmt.Fprintln(cmd.OutOrStdout(), "Approval declined.")
+		return nil
+	}
+	if err := trust.Record(repoRoot, h); err != nil {
+		return err
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), "Approved. rimba will run these commands without prompting.")
+	return nil
+}
+
+func runTrustShow(cmd *cobra.Command, repoRoot string, cfg *config.Config) error {
+	out := cmd.OutOrStdout()
+
+	if !trust.HasCommands(cfg) {
+		fmt.Fprintln(out, "No shell commands configured in .rimba/settings.toml.")
+		return nil
+	}
+
+	fmt.Fprintln(out, "Configured shell commands:")
+	for _, c := range trust.Commands(cfg) {
+		fmt.Fprintf(out, "  %s\n", c)
+	}
+
+	h := trust.Hash(cfg)
+	fmt.Fprintf(out, "\nHash: %s\n", h)
+
+	ok, err := trust.IsTrusted(repoRoot, h)
+	if err != nil {
+		return err
+	}
+	if ok {
+		fmt.Fprintln(out, "Status: trusted")
+	} else {
+		fmt.Fprintln(out, "Status: not trusted — run 'rimba trust' to approve")
+	}
+	return nil
+}
+
+func init() {
+	trustCmd.Flags().Bool(flagShow, false, "display commands and approval status without prompting")
+	trustCmd.Flags().Bool(flagYes, false, hintYes)
+	rootCmd.AddCommand(trustCmd)
+}

--- a/cmd/trust_gate.go
+++ b/cmd/trust_gate.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/errhint"
+	"github.com/lugassawan/rimba/internal/trust"
+	"github.com/spf13/cobra"
+)
+
+const (
+	flagYes = "yes"
+
+	hintYes = "approve committed shell commands without prompting (use in CI; see 'rimba trust')"
+)
+
+// ensureTrust checks that the user has approved the committed shell commands
+// in cfg for repoRoot. Returns nil when already trusted, the user approves,
+// or --yes / RIMBA_TRUST_YES is set. Returns an error with a remediation hint
+// when the user declines or stdin is non-interactive (EOF → default no).
+func ensureTrust(cmd *cobra.Command, repoRoot string, cfg *config.Config) error {
+	if !trust.HasCommands(cfg) {
+		return nil
+	}
+	h := trust.Hash(cfg)
+	ok, err := trust.IsTrusted(repoRoot, h)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	if trustYesRequested(cmd) {
+		return trust.Record(repoRoot, h)
+	}
+	if !promptTrust(cmd, cfg) {
+		return errhint.WithFix(
+			errors.New("committed shell commands require approval"),
+			"review the commands above, then run 'rimba trust' (or pass --yes / set RIMBA_TRUST_YES=1 in CI)",
+		)
+	}
+	return trust.Record(repoRoot, h)
+}
+
+// promptTrust displays the committed shell commands and asks the user to
+// approve them. Returns true only for "y" or "yes". Default is no.
+func promptTrust(cmd *cobra.Command, cfg *config.Config) bool {
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, "\nThis repo's .rimba/settings.toml will run shell commands that have not been approved:")
+	cmds := trust.Commands(cfg)
+	for _, c := range cmds {
+		fmt.Fprintf(out, "  %s\n", c)
+	}
+	fmt.Fprint(out, "\nRun these commands? [y/N] ")
+
+	reader := bufio.NewReader(cmd.InOrStdin())
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "y" || answer == "yes"
+}
+
+// trustYesRequested returns true when --yes is set or RIMBA_TRUST_YES is truthy.
+func trustYesRequested(cmd *cobra.Command) bool {
+	if yes, _ := cmd.Flags().GetBool(flagYes); yes {
+		return true
+	}
+	v, ok := os.LookupEnv("RIMBA_TRUST_YES")
+	return ok && v != "" && v != "0"
+}

--- a/cmd/trust_gate.go
+++ b/cmd/trust_gate.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/lugassawan/rimba/internal/config"
@@ -65,10 +64,10 @@ func promptTrust(cmd *cobra.Command, cfg *config.Config) bool {
 }
 
 // trustYesRequested returns true when --yes is set or RIMBA_TRUST_YES is truthy.
+// The env-var truthiness is defined by trust.TrustYesFromEnv.
 func trustYesRequested(cmd *cobra.Command) bool {
 	if yes, _ := cmd.Flags().GetBool(flagYes); yes {
 		return true
 	}
-	v, ok := os.LookupEnv("RIMBA_TRUST_YES")
-	return ok && v != "" && v != "0"
+	return trust.TrustYesFromEnv()
 }

--- a/cmd/trust_gate_test.go
+++ b/cmd/trust_gate_test.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/trust"
+	"github.com/spf13/cobra"
+)
+
+func newTrustTestCmd() (*cobra.Command, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	cmd := &cobra.Command{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.Flags().Bool(flagYes, false, "")
+	return cmd, buf
+}
+
+func setupTrustTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".rimba/settings.local.toml\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestEnsureTrustEmptyConfig(t *testing.T) {
+	dir := setupTrustTestRepo(t)
+	cmd, _ := newTrustTestCmd()
+	if err := ensureTrust(cmd, dir, &config.Config{}); err != nil {
+		t.Errorf("ensureTrust with empty config should return nil, got: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".rimba", trust.FileName)); !os.IsNotExist(err) {
+		t.Error("no trust file should be written for empty config")
+	}
+}
+
+func TestEnsureTrustAlreadyTrusted(t *testing.T) {
+	dir := setupTrustTestRepo(t)
+	cfg := &config.Config{PostCreate: []string{"make test"}}
+	h := trust.Hash(cfg)
+	if err := trust.Record(dir, h); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, buf := newTrustTestCmd()
+	if err := ensureTrust(cmd, dir, cfg); err != nil {
+		t.Errorf("ensureTrust trusted should return nil, got: %v", err)
+	}
+	if buf.Len() > 0 {
+		t.Errorf("trusted path should not prompt, got output: %q", buf.String())
+	}
+}
+
+func TestEnsureTrustPromptYes(t *testing.T) {
+	dir := setupTrustTestRepo(t)
+	cfg := &config.Config{PostCreate: []string{"make install"}}
+
+	cmd, _ := newTrustTestCmd()
+	cmd.SetIn(strings.NewReader("y\n"))
+	if err := ensureTrust(cmd, dir, cfg); err != nil {
+		t.Errorf("prompt 'y' should return nil, got: %v", err)
+	}
+
+	ok, err := trust.IsTrusted(dir, trust.Hash(cfg))
+	if err != nil || !ok {
+		t.Errorf("trust should be recorded after 'y' consent: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestEnsureTrustPromptNo(t *testing.T) {
+	dir := setupTrustTestRepo(t)
+	cfg := &config.Config{PostCreate: []string{"rm -rf /"}}
+
+	cmd, _ := newTrustTestCmd()
+	cmd.SetIn(strings.NewReader("n\n"))
+	err := ensureTrust(cmd, dir, cfg)
+	if err == nil {
+		t.Error("prompt 'n' should return error")
+	}
+
+	ok, _ := trust.IsTrusted(dir, trust.Hash(cfg))
+	if ok {
+		t.Error("trust should not be recorded after 'n'")
+	}
+}
+
+func TestEnsureTrustPromptEOFDefaultNo(t *testing.T) {
+	dir := setupTrustTestRepo(t)
+	cfg := &config.Config{PostCreate: []string{"make test"}}
+
+	cmd, _ := newTrustTestCmd()
+	cmd.SetIn(strings.NewReader("")) // EOF
+	err := ensureTrust(cmd, dir, cfg)
+	if err == nil {
+		t.Error("EOF (non-interactive) should return error (default no)")
+	}
+}
+
+func TestEnsureTrustFlagYes(t *testing.T) {
+	dir := setupTrustTestRepo(t)
+	cfg := &config.Config{PostCreate: []string{"pnpm install"}}
+
+	cmd, buf := newTrustTestCmd()
+	if err := cmd.Flags().Set(flagYes, "true"); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureTrust(cmd, dir, cfg); err != nil {
+		t.Errorf("--yes should return nil, got: %v", err)
+	}
+	if buf.Len() > 0 {
+		t.Errorf("--yes should not prompt, got output: %q", buf.String())
+	}
+	ok, _ := trust.IsTrusted(dir, trust.Hash(cfg))
+	if !ok {
+		t.Error("trust should be recorded when --yes is set")
+	}
+}
+
+func TestEnsureTrustEnvYes(t *testing.T) {
+	dir := setupTrustTestRepo(t)
+	cfg := &config.Config{PostCreate: []string{"npm ci"}}
+
+	t.Setenv("RIMBA_TRUST_YES", "1")
+	cmd, buf := newTrustTestCmd()
+	if err := ensureTrust(cmd, dir, cfg); err != nil {
+		t.Errorf("RIMBA_TRUST_YES=1 should return nil, got: %v", err)
+	}
+	if buf.Len() > 0 {
+		t.Errorf("env escape hatch should not prompt, got output: %q", buf.String())
+	}
+	ok, _ := trust.IsTrusted(dir, trust.Hash(cfg))
+	if !ok {
+		t.Error("trust should be recorded when RIMBA_TRUST_YES=1")
+	}
+}
+
+func TestEnsureTrustPromptShowsCommands(t *testing.T) {
+	dir := setupTrustTestRepo(t)
+	cfg := &config.Config{
+		PostCreate: []string{"pnpm install", "./setup.sh"},
+	}
+
+	cmd, buf := newTrustTestCmd()
+	cmd.SetIn(strings.NewReader("n\n"))
+	_ = ensureTrust(cmd, dir, cfg)
+
+	out := buf.String()
+	if !strings.Contains(out, "pnpm install") {
+		t.Errorf("prompt should show commands, got:\n%s", out)
+	}
+	if !strings.Contains(out, "./setup.sh") {
+		t.Errorf("prompt should show all commands, got:\n%s", out)
+	}
+}
+
+func TestEnsureTrustIsTrustedError(t *testing.T) {
+	dir := setupTrustTestRepo(t)
+	rimbaDir := filepath.Join(dir, ".rimba")
+	// Make trust.local.toml a directory so IsTrusted returns an error.
+	if err := os.Mkdir(filepath.Join(rimbaDir, "trust.local.toml"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{PostCreate: []string{"make test"}}
+	cmd, _ := newTrustTestCmd()
+	err := ensureTrust(cmd, dir, cfg)
+	if err == nil {
+		t.Error("ensureTrust should propagate IsTrusted error")
+	}
+}
+
+func TestEnsureTrustErrorContainsHint(t *testing.T) {
+	dir := setupTrustTestRepo(t)
+	cfg := &config.Config{PostCreate: []string{"make test"}}
+
+	cmd, _ := newTrustTestCmd()
+	cmd.SetIn(strings.NewReader("n\n"))
+	err := ensureTrust(cmd, dir, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "rimba trust") {
+		t.Errorf("error should mention 'rimba trust', got: %v", err)
+	}
+}

--- a/cmd/trust_test.go
+++ b/cmd/trust_test.go
@@ -1,0 +1,222 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/trust"
+	"github.com/spf13/cobra"
+)
+
+// newTrustCmd builds a testable trustCmd with its flags registered.
+func newTrustCmd(cfg *config.Config, repoRoot string) (*cobra.Command, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	c := buildTrustCmd(cfg, repoRoot)
+	c.SetOut(buf)
+	c.SetErr(buf)
+	return c, buf
+}
+
+func TestTrustCmdApprove(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".rimba/settings.local.toml\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{PostCreate: []string{"make install"}}
+	cmd, buf := newTrustCmd(cfg, dir)
+	cmd.SetIn(strings.NewReader("y\n"))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("trust approve: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Approved") {
+		t.Errorf("expected 'Approved' in output, got: %s", out)
+	}
+
+	ok, _ := trust.IsTrusted(dir, trust.Hash(cfg))
+	if !ok {
+		t.Error("trust should be recorded after approve")
+	}
+}
+
+func TestTrustCmdAlreadyTrusted(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{PostCreate: []string{"npm ci"}}
+	if err := trust.Record(dir, trust.Hash(cfg)); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, buf := newTrustCmd(cfg, dir)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("trust already trusted: %v", err)
+	}
+
+	if !strings.Contains(strings.ToLower(buf.String()), "already trusted") {
+		t.Errorf("expected 'already trusted' in output, got: %s", buf.String())
+	}
+}
+
+func TestTrustCmdNoCommands(t *testing.T) {
+	dir := t.TempDir()
+	cmd, buf := newTrustCmd(&config.Config{}, dir)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("trust no commands: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(buf.String()), "no shell commands") {
+		t.Errorf("expected 'no shell commands' in output, got: %s", buf.String())
+	}
+}
+
+func TestTrustCmdShowNoCommands(t *testing.T) {
+	dir := t.TempDir()
+	cmd, buf := newTrustCmd(&config.Config{}, dir)
+	cmd.SetArgs([]string{"--show"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("trust --show no commands: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(buf.String()), "no shell commands") {
+		t.Errorf("expected 'no shell commands' in output, got: %s", buf.String())
+	}
+}
+
+func TestTrustCmdShow(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{PostCreate: []string{"make test"}}
+	if err := trust.Record(dir, trust.Hash(cfg)); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd, buf := newTrustCmd(cfg, dir)
+	cmd.SetArgs([]string{"--show"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("trust --show: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "make test") {
+		t.Errorf("--show should display commands, got: %s", out)
+	}
+	if !strings.Contains(out, "sha256:") {
+		t.Errorf("--show should display hash, got: %s", out)
+	}
+	if !strings.Contains(out, "trusted") {
+		t.Errorf("--show should display trusted state, got: %s", out)
+	}
+}
+
+func TestTrustCmdApproveDecline(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{PostCreate: []string{"rm -rf /"}}
+	cmd, buf := newTrustCmd(cfg, dir)
+	cmd.SetIn(strings.NewReader("n\n"))
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("trust approve decline: %v", err)
+	}
+
+	if !strings.Contains(strings.ToLower(buf.String()), "declined") {
+		t.Errorf("expected 'declined' in output, got: %s", buf.String())
+	}
+	ok, _ := trust.IsTrusted(dir, trust.Hash(cfg))
+	if ok {
+		t.Error("trust should not be recorded after decline")
+	}
+}
+
+func TestTrustCmdApproveIsTrustedError(t *testing.T) {
+	dir := t.TempDir()
+	rimbaDir := filepath.Join(dir, ".rimba")
+	if err := os.MkdirAll(rimbaDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Make trust.local.toml a directory so IsTrusted returns an error.
+	if err := os.Mkdir(filepath.Join(rimbaDir, "trust.local.toml"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{PostCreate: []string{"make install"}}
+	cmd, _ := newTrustCmd(cfg, dir)
+	if err := cmd.Execute(); err == nil {
+		t.Error("trust approve with IsTrusted error should fail")
+	}
+}
+
+func TestTrustCmdApproveRecordError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Place a directory at .gitignore so Record fails on EnsureGitignore.
+	if err := os.Mkdir(filepath.Join(dir, ".gitignore"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{PostCreate: []string{"make install"}}
+	cmd, _ := newTrustCmd(cfg, dir)
+	cmd.SetIn(strings.NewReader("y\n"))
+	if err := cmd.Execute(); err == nil {
+		t.Error("trust approve with Record error should fail")
+	}
+}
+
+func TestTrustCmdShowIsTrustedError(t *testing.T) {
+	dir := t.TempDir()
+	rimbaDir := filepath.Join(dir, ".rimba")
+	if err := os.MkdirAll(rimbaDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Make trust.local.toml a directory so IsTrusted returns an error.
+	if err := os.Mkdir(filepath.Join(rimbaDir, "trust.local.toml"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{PostCreate: []string{"make test"}}
+	cmd, _ := newTrustCmd(cfg, dir)
+	cmd.SetArgs([]string{"--show"})
+	if err := cmd.Execute(); err == nil {
+		t.Error("trust --show with IsTrusted error should fail")
+	}
+}
+
+func TestTrustCmdShowUntrusted(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{PostCreate: []string{"make test"}}
+	cmd, buf := newTrustCmd(cfg, dir)
+	cmd.SetArgs([]string{"--show"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("trust --show untrusted: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "not trusted") {
+		t.Errorf("--show should display 'not trusted', got: %s", out)
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -18,6 +18,7 @@ const (
 	gitRevList     = "rev-list"
 	gitStatus      = "status"
 	gitList        = "list"
+	gitWorktreeAdd = "add"
 	revListEven    = "0\t0"
 	dirtyOutput    = " M dirty.go\n"
 )

--- a/internal/mcp/tool_add.go
+++ b/internal/mcp/tool_add.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/resolver"
+	"github.com/lugassawan/rimba/internal/trust"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -50,6 +51,10 @@ func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 		cfg, cfgErr := hctx.requireConfig()
 		if cfgErr != nil {
 			return mcp.NewToolResultError(cfgErr.Error()), nil
+		}
+
+		if err := trust.GateNonInteractive(hctx.RepoRoot, cfg); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
 		}
 
 		if !resolver.ValidPrefixType(prefixType) {

--- a/internal/mcp/tool_add_test.go
+++ b/internal/mcp/tool_add_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/lugassawan/rimba/internal/trust"
 )
 
 const (
@@ -370,6 +372,7 @@ func TestAddToolServiceScoped(t *testing.T) {
 }
 
 func TestAddToolWithDepsAndHooks(t *testing.T) {
+	t.Setenv("RIMBA_TRUST_YES", "1")
 	tmpDir := t.TempDir()
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
@@ -378,7 +381,7 @@ func TestAddToolWithDepsAndHooks(t *testing.T) {
 				return "", errors.New("not found")
 			}
 			// AddWorktree: create the directory
-			if len(args) > 0 && args[0] == gitWorktree && len(args) > 1 && args[1] == "add" {
+			if len(args) > 0 && args[0] == gitWorktree && len(args) > 1 && args[1] == gitWorktreeAdd {
 				_ = os.MkdirAll(args[2], 0o755)
 				return "", nil
 			}
@@ -405,5 +408,117 @@ func TestAddToolWithDepsAndHooks(t *testing.T) {
 	data := unmarshalJSON[addResult](t, result)
 	if data.Task != "with-hooks" {
 		t.Errorf("task = %q", data.Task)
+	}
+}
+
+func TestAddToolTrustGateUntrusted(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := testConfig()
+	cfg.PostCreate = []string{"make install"}
+	hctx := &HandlerContext{
+		Runner:   &mockRunner{},
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"task": "blocked"})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "rimba trust") {
+		t.Errorf("untrusted error should mention 'rimba trust', got: %s", errText)
+	}
+}
+
+func TestAddToolTrustGatePreTrusted(t *testing.T) {
+	// When trust is already recorded, the gate should pass without env hatch.
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := testConfig()
+	cfg.PostCreate = []string{"echo trusted"}
+
+	// Pre-record trust.
+	h := trust.Hash(cfg)
+	if err := trust.Record(tmpDir, h); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitRevParse {
+				return "", errors.New("not found")
+			}
+			if len(args) > 0 && args[0] == gitWorktree && len(args) > 1 && args[1] == gitWorktreeAdd {
+				_ = os.MkdirAll(args[2], 0o755)
+				return "", nil
+			}
+			if len(args) > 0 && args[0] == gitWorktree && len(args) > 1 && args[1] == gitList {
+				return "worktree " + tmpDir + "\nHEAD abc\nbranch refs/heads/main\n\n", nil
+			}
+			return "", nil
+		},
+	}
+	hctx := &HandlerContext{
+		Runner:   r,
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+	cfg.CopyFiles = nil
+
+	result := callTool(t, handler, map[string]any{"task": "trusted-task"})
+	data := unmarshalJSON[addResult](t, result)
+	if data.Task != "trusted-task" {
+		t.Errorf("pre-trusted add should succeed, task = %q", data.Task)
+	}
+}
+
+func TestAddToolTrustGateEnvEscapeHatch(t *testing.T) {
+	t.Setenv("RIMBA_TRUST_YES", "1")
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := testConfig()
+	cfg.PostCreate = []string{"pnpm install"}
+	cfg.CopyFiles = nil
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitRevParse {
+				return "", errors.New("not found")
+			}
+			if len(args) > 0 && args[0] == gitWorktree && len(args) > 1 && args[1] == gitWorktreeAdd {
+				_ = os.MkdirAll(args[2], 0o755)
+				return "", nil
+			}
+			if len(args) > 0 && args[0] == gitWorktree && len(args) > 1 && args[1] == gitList {
+				return "worktree " + tmpDir + "\nHEAD abc\nbranch refs/heads/main\n\n", nil
+			}
+			return "", nil
+		},
+	}
+	hctx := &HandlerContext{
+		Runner:   r,
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"task": "env-bypass"})
+	data := unmarshalJSON[addResult](t, result)
+	if data.Task != "env-bypass" {
+		t.Errorf("RIMBA_TRUST_YES add should succeed, task = %q", data.Task)
 	}
 }

--- a/internal/mcp/tool_exec.go
+++ b/internal/mcp/tool_exec.go
@@ -42,6 +42,12 @@ func registerExecTool(s *server.MCPServer, hctx *HandlerContext) {
 	s.AddTool(tool, handleExec(hctx))
 }
 
+// handleExec runs ad-hoc caller-supplied shell commands across worktrees.
+// The trust consent gate (GateNonInteractive) is intentionally absent here:
+// `exec` executes commands provided at call time by the MCP client, not
+// committed configuration hooks. Gating committed hooks is the threat model
+// for the trust system; ad-hoc operator commands are considered authorised by
+// the act of invoking the MCP server.
 func handleExec(hctx *HandlerContext) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		command := req.GetString("command", "")

--- a/internal/trust/hash.go
+++ b/internal/trust/hash.go
@@ -1,0 +1,53 @@
+// Package trust manages per-repo consent for committed shell commands.
+package trust
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+
+	"github.com/lugassawan/rimba/internal/config"
+)
+
+// Commands returns all shell-executing strings from cfg in display order:
+// post_create, then post_rename, then non-empty deps.modules[].install.
+func Commands(cfg *config.Config) []string {
+	var cmds []string
+	cmds = append(cmds, cfg.PostCreate...)
+	cmds = append(cmds, cfg.PostRename...)
+	if cfg.Deps != nil {
+		for _, m := range cfg.Deps.Modules {
+			if strings.TrimSpace(m.Install) != "" {
+				cmds = append(cmds, m.Install)
+			}
+		}
+	}
+	return cmds
+}
+
+// HasCommands reports whether cfg contains any committed shell commands.
+func HasCommands(cfg *config.Config) bool {
+	return len(Commands(cfg)) > 0
+}
+
+// Hash returns a canonical "sha256:<hex>" fingerprint of cfg's command set.
+// Returns "" when there are no commands. Reordering commands does not change
+// the hash; only new or changed content re-arms the consent gate.
+func Hash(cfg *config.Config) string {
+	cmds := Commands(cfg)
+	if len(cmds) == 0 {
+		return ""
+	}
+
+	sorted := make([]string, len(cmds))
+	copy(sorted, cmds)
+	sort.Strings(sorted)
+
+	h := sha256.New()
+	for _, c := range sorted {
+		h.Write([]byte(c))
+		h.Write([]byte{0}) // NUL delimiter prevents "ab"+"c" == "a"+"bc"
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/trust/hash.go
+++ b/internal/trust/hash.go
@@ -32,8 +32,16 @@ func HasCommands(cfg *config.Config) bool {
 }
 
 // Hash returns a canonical "sha256:<hex>" fingerprint of cfg's command set.
-// Returns "" when there are no commands. Reordering commands does not change
-// the hash; only new or changed content re-arms the consent gate.
+// Returns "" when there are no commands.
+//
+// The hash is field-blind: the field a command originates from (post_create,
+// post_rename, or deps install) does not affect the hash, only its string
+// value does. This means moving a command between fields without changing its
+// content does not require re-consent — restructuring config is not a new
+// threat. Conversely, adding the same command string to a second field (e.g.
+// adding an already-approved post_create string to post_rename) does not
+// re-arm the gate; re-consent is only required when the command content itself
+// is new or changed.
 func Hash(cfg *config.Config) string {
 	cmds := Commands(cfg)
 	if len(cmds) == 0 {

--- a/internal/trust/hash_test.go
+++ b/internal/trust/hash_test.go
@@ -1,0 +1,161 @@
+package trust_test
+
+import (
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/trust"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+// Ensure we use testutil (coverage threshold enforcement).
+var _ = testutil.Ptr[int]
+
+func emptyConfig() *config.Config {
+	return &config.Config{}
+}
+
+func cfgWithCommands(postCreate, postRename []string, installs ...string) *config.Config {
+	cfg := &config.Config{
+		PostCreate: postCreate,
+		PostRename: postRename,
+	}
+	if len(installs) > 0 {
+		mods := make([]config.ModuleConfig, 0, len(installs))
+		for i, inst := range installs {
+			mods = append(mods, config.ModuleConfig{
+				Dir:     "mod" + string(rune('a'+i)),
+				Install: inst,
+			})
+		}
+		cfg.Deps = &config.DepsConfig{Modules: mods}
+	}
+	return cfg
+}
+
+func TestHashEmptyConfig(t *testing.T) {
+	h := trust.Hash(emptyConfig())
+	if h != "" {
+		t.Errorf("Hash(empty) = %q, want empty string", h)
+	}
+}
+
+func TestHashHasPrefix(t *testing.T) {
+	cfg := cfgWithCommands([]string{"echo hi"}, nil)
+	h := trust.Hash(cfg)
+	if len(h) < 7 || h[:7] != "sha256:" {
+		t.Errorf("Hash = %q, want sha256: prefix", h)
+	}
+}
+
+func TestHashStableAcrossReorder(t *testing.T) {
+	a := trust.Hash(cfgWithCommands([]string{"echo a", "echo b"}, nil))
+	b := trust.Hash(cfgWithCommands([]string{"echo b", "echo a"}, nil))
+	if a != b {
+		t.Errorf("Hash should be stable across reorder: %q != %q", a, b)
+	}
+}
+
+func TestHashChangesWhenCommandChanges(t *testing.T) {
+	a := trust.Hash(cfgWithCommands([]string{"make install"}, nil))
+	b := trust.Hash(cfgWithCommands([]string{"make setup"}, nil))
+	if a == b {
+		t.Errorf("Hash should differ when command changes, got same: %q", a)
+	}
+}
+
+func TestHashChangesWhenCommandAdded(t *testing.T) {
+	a := trust.Hash(cfgWithCommands([]string{"echo a"}, nil))
+	b := trust.Hash(cfgWithCommands([]string{"echo a", "echo b"}, nil))
+	if a == b {
+		t.Errorf("Hash should differ when command is added, got same: %q", a)
+	}
+}
+
+func TestHashNULDelimiterPreventsCollision(t *testing.T) {
+	// ["ab","c"] must differ from ["a","bc"] even after sorting
+	a := trust.Hash(cfgWithCommands([]string{"ab", "c"}, nil))
+	b := trust.Hash(cfgWithCommands([]string{"a", "bc"}, nil))
+	if a == b {
+		t.Errorf("Hash should differ for [ab,c] vs [a,bc], got same: %q", a)
+	}
+}
+
+func TestHashAllFieldsAffectHash(t *testing.T) {
+	// Hash is content-based (field-blind by design): restructuring config
+	// without adding commands does not require re-consent. Adding a command
+	// to ANY field does change the hash.
+	base := trust.Hash(cfgWithCommands([]string{"make build"}, nil))
+	withRename := trust.Hash(cfgWithCommands([]string{"make build"}, []string{"echo rename"}))
+	withDeps := trust.Hash(cfgWithCommands([]string{"make build"}, nil, "npm ci"))
+	if base == withRename {
+		t.Errorf("adding a post_rename command should change hash")
+	}
+	if base == withDeps {
+		t.Errorf("adding a deps install command should change hash")
+	}
+	if withRename == withDeps {
+		t.Errorf("different extra commands should produce different hashes")
+	}
+}
+
+func TestHashEmptyInstallSkipped(t *testing.T) {
+	// A module with empty Install should not affect the hash.
+	cfg := &config.Config{
+		PostCreate: []string{"echo hi"},
+		Deps: &config.DepsConfig{
+			Modules: []config.ModuleConfig{
+				{Dir: "vendor", Install: ""},
+			},
+		},
+	}
+	a := trust.Hash(cfg)
+	b := trust.Hash(cfgWithCommands([]string{"echo hi"}, nil))
+	if a != b {
+		t.Errorf("empty Install should not affect hash: %q != %q", a, b)
+	}
+}
+
+func TestHasCommands(t *testing.T) {
+	if trust.HasCommands(emptyConfig()) {
+		t.Error("HasCommands(empty) should be false")
+	}
+	if !trust.HasCommands(cfgWithCommands([]string{"x"}, nil)) {
+		t.Error("HasCommands with PostCreate should be true")
+	}
+	if !trust.HasCommands(cfgWithCommands(nil, []string{"x"})) {
+		t.Error("HasCommands with PostRename should be true")
+	}
+	if !trust.HasCommands(cfgWithCommands(nil, nil, "x")) {
+		t.Error("HasCommands with deps install should be true")
+	}
+}
+
+func TestCommandsOrderPreserved(t *testing.T) {
+	cfg := cfgWithCommands([]string{"first", "second"}, []string{"third"}, "fourth")
+	cmds := trust.Commands(cfg)
+	want := []string{"first", "second", "third", "fourth"}
+	if len(cmds) != len(want) {
+		t.Fatalf("Commands() len = %d, want %d: %v", len(cmds), len(want), cmds)
+	}
+	for i, w := range want {
+		if cmds[i] != w {
+			t.Errorf("Commands()[%d] = %q, want %q", i, cmds[i], w)
+		}
+	}
+}
+
+func TestCommandsSkipsEmptyInstall(t *testing.T) {
+	cfg := &config.Config{
+		Deps: &config.DepsConfig{
+			Modules: []config.ModuleConfig{
+				{Dir: "a", Install: ""},
+				{Dir: "b", Install: "npm ci"},
+			},
+		},
+	}
+	cmds := trust.Commands(cfg)
+	if len(cmds) != 1 || cmds[0] != "npm ci" {
+		t.Errorf("Commands() = %v, want [npm ci]", cmds)
+	}
+}

--- a/internal/trust/store.go
+++ b/internal/trust/store.go
@@ -1,0 +1,119 @@
+package trust
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	toml "github.com/pelletier/go-toml/v2"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/errhint"
+	"github.com/lugassawan/rimba/internal/fileutil"
+)
+
+const (
+	// FileName is the gitignored local trust record for a repo.
+	FileName     = "trust.local.toml"
+	storeVersion = 1
+)
+
+// Store is the content of the per-repo trust record.
+type Store struct {
+	Version    int    `toml:"version"`
+	Hash       string `toml:"hash"`
+	ApprovedAt string `toml:"approved_at"`
+}
+
+// Load reads the trust store from repoRoot. Returns (nil, nil) if absent.
+func Load(repoRoot string) (*Store, error) {
+	data, err := os.ReadFile(storePath(repoRoot))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil //nolint:nilnil // nil,nil means "absent, no error" — matches config.loadRaw convention
+		}
+		return nil, fmt.Errorf("read trust store: %w", err)
+	}
+	var s Store
+	if err := toml.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parse trust store: %w", err)
+	}
+	return &s, nil
+}
+
+// IsTrusted reports whether the stored hash matches the given hash.
+// Returns false (not error) when the trust file is absent or the hash differs.
+func IsTrusted(repoRoot, hash string) (bool, error) {
+	s, err := Load(repoRoot)
+	if err != nil {
+		return false, err
+	}
+	return s != nil && s.Hash == hash, nil
+}
+
+// Record persists approval of the given command-set hash for repoRoot.
+// It ensures .rimba/ exists and registers trust.local.toml in .gitignore.
+func Record(repoRoot, hash string) error {
+	dir := filepath.Join(repoRoot, config.DirName)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("create .rimba dir: %w", err)
+	}
+
+	// Best-effort gitignore registration — self-heals repos initialized
+	// before this feature existed.
+	entry := filepath.Join(config.DirName, FileName)
+	if _, err := fileutil.EnsureGitignore(repoRoot, entry); err != nil {
+		return fmt.Errorf("update .gitignore: %w", err)
+	}
+
+	s := Store{
+		Version:    storeVersion,
+		Hash:       hash,
+		ApprovedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := toml.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("marshal trust store: %w", err)
+	}
+	if err := os.WriteFile(storePath(repoRoot), data, 0600); err != nil {
+		return fmt.Errorf("write trust store: %w", err)
+	}
+	return nil
+}
+
+// GateNonInteractive is the non-interactive consent gate used by MCP handlers.
+// It returns nil when there are no committed commands, the repo is already
+// trusted, or RIMBA_TRUST_YES is set to a truthy value. Otherwise it returns
+// an error with a remediation hint pointing to `rimba trust`.
+func GateNonInteractive(repoRoot string, cfg *config.Config) error {
+	if !HasCommands(cfg) {
+		return nil
+	}
+	h := Hash(cfg)
+	ok, err := IsTrusted(repoRoot, h)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return nil
+	}
+	if trustYesEnv() {
+		return Record(repoRoot, h)
+	}
+	return errhint.WithFix(
+		errors.New("committed shell commands are not trusted for this repo"),
+		"run 'rimba trust' to approve them, or set RIMBA_TRUST_YES=1 for CI",
+	)
+}
+
+func storePath(repoRoot string) string {
+	return filepath.Join(repoRoot, config.DirName, FileName)
+}
+
+// trustYesEnv returns true when RIMBA_TRUST_YES is set to a truthy value.
+func trustYesEnv() bool {
+	v, ok := os.LookupEnv("RIMBA_TRUST_YES")
+	return ok && v != "" && v != "0"
+}

--- a/internal/trust/store.go
+++ b/internal/trust/store.go
@@ -40,6 +40,9 @@ func Load(repoRoot string) (*Store, error) {
 	if err := toml.Unmarshal(data, &s); err != nil {
 		return nil, fmt.Errorf("parse trust store: %w", err)
 	}
+	if s.Version > storeVersion {
+		return nil, fmt.Errorf("trust store version %d is newer than supported (%d); upgrade rimba", s.Version, storeVersion)
+	}
 	return &s, nil
 }
 
@@ -99,7 +102,7 @@ func GateNonInteractive(repoRoot string, cfg *config.Config) error {
 	if ok {
 		return nil
 	}
-	if trustYesEnv() {
+	if TrustYesFromEnv() {
 		return Record(repoRoot, h)
 	}
 	return errhint.WithFix(
@@ -108,12 +111,14 @@ func GateNonInteractive(repoRoot string, cfg *config.Config) error {
 	)
 }
 
-func storePath(repoRoot string) string {
-	return filepath.Join(repoRoot, config.DirName, FileName)
-}
-
-// trustYesEnv returns true when RIMBA_TRUST_YES is set to a truthy value.
-func trustYesEnv() bool {
+// TrustYesFromEnv reports whether RIMBA_TRUST_YES is set to a truthy value.
+// It is the canonical definition of truthy for this environment variable;
+// cmd/trust_gate.go delegates to it to avoid duplicate semantics.
+func TrustYesFromEnv() bool {
 	v, ok := os.LookupEnv("RIMBA_TRUST_YES")
 	return ok && v != "" && v != "0"
+}
+
+func storePath(repoRoot string) string {
+	return filepath.Join(repoRoot, config.DirName, FileName)
 }

--- a/internal/trust/store_test.go
+++ b/internal/trust/store_test.go
@@ -342,6 +342,24 @@ func TestGateNonInteractiveEnvEscapeHatch(t *testing.T) {
 	}
 }
 
+func TestLoadNewerVersion(t *testing.T) {
+	dir := t.TempDir()
+	rimbaDir := filepath.Join(dir, ".rimba")
+	if err := os.MkdirAll(rimbaDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Write a store file with a future version number.
+	p := filepath.Join(rimbaDir, "trust.local.toml")
+	if err := os.WriteFile(p, []byte("version = 99\nhash = \"sha256:abc\"\napproved_at = \"2026-01-01T00:00:00Z\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := trust.Load(dir)
+	if err == nil {
+		t.Error("Load with newer store version should return error")
+	}
+}
+
 func TestGateNonInteractiveEnvEscapeHatchZero(t *testing.T) {
 	dir := t.TempDir()
 	cfg := cfgWithCommands([]string{"make build"}, nil)

--- a/internal/trust/store_test.go
+++ b/internal/trust/store_test.go
@@ -1,0 +1,361 @@
+package trust_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lugassawan/rimba/internal/trust"
+)
+
+func TestLoadAbsent(t *testing.T) {
+	dir := t.TempDir()
+	s, err := trust.Load(dir)
+	if err != nil {
+		t.Fatalf("Load on absent file: %v", err)
+	}
+	if s != nil {
+		t.Errorf("Load on absent file = %v, want nil", s)
+	}
+}
+
+func TestLoadMalformedTOML(t *testing.T) {
+	dir := t.TempDir()
+	rimbaDir := filepath.Join(dir, ".rimba")
+	if err := os.MkdirAll(rimbaDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(rimbaDir, "trust.local.toml")
+	if err := os.WriteFile(p, []byte("not valid toml = [broken"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := trust.Load(dir)
+	if err == nil {
+		t.Error("Load on malformed TOML should return error")
+	}
+}
+
+func TestIsTrustedAbsentFile(t *testing.T) {
+	dir := t.TempDir()
+	ok, err := trust.IsTrusted(dir, "sha256:abc")
+	if err != nil {
+		t.Fatalf("IsTrusted on absent file: %v", err)
+	}
+	if ok {
+		t.Error("IsTrusted on absent file should be false")
+	}
+}
+
+func TestRecordThenIsTrusted(t *testing.T) {
+	dir := t.TempDir()
+	// Create .gitignore and .rimba dir so Record can function.
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := cfgWithCommands([]string{"make test"}, nil)
+	h := trust.Hash(cfg)
+
+	if err := trust.Record(dir, h); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	ok, err := trust.IsTrusted(dir, h)
+	if err != nil {
+		t.Fatalf("IsTrusted after Record: %v", err)
+	}
+	if !ok {
+		t.Error("IsTrusted should be true after Record")
+	}
+}
+
+func TestIsTrustedWrongHash(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := trust.Record(dir, "sha256:aaa"); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	ok, err := trust.IsTrusted(dir, "sha256:bbb")
+	if err != nil {
+		t.Fatalf("IsTrusted: %v", err)
+	}
+	if ok {
+		t.Error("IsTrusted should be false when hash differs")
+	}
+}
+
+func TestRecordFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := trust.Record(dir, "sha256:test"); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, ".rimba", trust.FileName))
+	if err != nil {
+		t.Fatalf("stat trust file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("trust file permissions = %o, want 0600", perm)
+	}
+}
+
+func TestRecordGitignoreEntry(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".rimba/settings.local.toml\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := trust.Record(dir, "sha256:test"); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(data), ".rimba/trust.local.toml") {
+		t.Errorf(".gitignore should contain .rimba/trust.local.toml, got:\n%s", data)
+	}
+}
+
+func TestRecordOverwritesAndUpdatesApprovedAt(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := trust.Record(dir, "sha256:first"); err != nil {
+		t.Fatalf("Record first: %v", err)
+	}
+
+	s1, err := trust.Load(dir)
+	if err != nil || s1 == nil {
+		t.Fatalf("Load after first Record: %v", err)
+	}
+
+	time.Sleep(2 * time.Millisecond) // ensure distinct timestamp
+
+	if err := trust.Record(dir, "sha256:second"); err != nil {
+		t.Fatalf("Record second: %v", err)
+	}
+
+	s2, err := trust.Load(dir)
+	if err != nil || s2 == nil {
+		t.Fatalf("Load after second Record: %v", err)
+	}
+
+	if s2.Hash != "sha256:second" {
+		t.Errorf("second Record should overwrite hash, got %q", s2.Hash)
+	}
+}
+
+func TestLoadReadError(t *testing.T) {
+	// Place a directory where trust.local.toml should be — ReadFile returns
+	// EISDIR, which is not os.IsNotExist, exercising the "read trust store" error branch.
+	dir := t.TempDir()
+	rimbaDir := filepath.Join(dir, ".rimba")
+	if err := os.MkdirAll(rimbaDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(rimbaDir, "trust.local.toml"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := trust.Load(dir)
+	if err == nil {
+		t.Error("Load with unreadable file should return error")
+	}
+}
+
+func TestIsTrustedReadError(t *testing.T) {
+	dir := t.TempDir()
+	rimbaDir := filepath.Join(dir, ".rimba")
+	if err := os.MkdirAll(rimbaDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(rimbaDir, "trust.local.toml"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := trust.IsTrusted(dir, "sha256:any")
+	if err == nil {
+		t.Error("IsTrusted with unreadable file should propagate error")
+	}
+}
+
+func TestRecordMkdirAllFails(t *testing.T) {
+	// Place a regular file at .rimba/ so MkdirAll fails.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".rimba"), []byte("blocker"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := trust.Record(dir, "sha256:test")
+	if err == nil {
+		t.Error("Record should return error when .rimba is a file")
+	}
+}
+
+func TestRecordGitignoreFails(t *testing.T) {
+	// Place a directory at .gitignore so EnsureGitignore fails.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, ".gitignore"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	err := trust.Record(dir, "sha256:test")
+	if err == nil {
+		t.Error("Record should return error when .gitignore is a directory")
+	}
+}
+
+func TestRecordWriteFails(t *testing.T) {
+	// Place a directory at trust.local.toml path so WriteFile fails.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	rimbaDir := filepath.Join(dir, ".rimba")
+	if err := os.MkdirAll(rimbaDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(rimbaDir, "trust.local.toml"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	err := trust.Record(dir, "sha256:test")
+	if err == nil {
+		t.Error("Record should return error when trust file path is a directory")
+	}
+}
+
+func TestGateNonInteractiveIsTrustedError(t *testing.T) {
+	dir := t.TempDir()
+	rimbaDir := filepath.Join(dir, ".rimba")
+	if err := os.MkdirAll(rimbaDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(rimbaDir, "trust.local.toml"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := cfgWithCommands([]string{"make build"}, nil)
+	err := trust.GateNonInteractive(dir, cfg)
+	if err == nil {
+		t.Error("GateNonInteractive should propagate IsTrusted error")
+	}
+}
+
+func TestRecordCreatesRimbaDir(t *testing.T) {
+	// Record should create .rimba/ if it doesn't exist.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Do NOT create .rimba/ — Record should handle it.
+
+	if err := trust.Record(dir, "sha256:test"); err != nil {
+		t.Fatalf("Record without pre-existing .rimba/: %v", err)
+	}
+
+	assertFileExists(t, filepath.Join(dir, ".rimba", trust.FileName))
+}
+
+func TestGateNonInteractiveNoCommands(t *testing.T) {
+	dir := t.TempDir()
+	err := trust.GateNonInteractive(dir, emptyConfig())
+	if err != nil {
+		t.Errorf("GateNonInteractive with no commands should return nil, got: %v", err)
+	}
+}
+
+func TestGateNonInteractiveTrusted(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := cfgWithCommands([]string{"make build"}, nil)
+	if err := trust.Record(dir, trust.Hash(cfg)); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	if err := trust.GateNonInteractive(dir, cfg); err != nil {
+		t.Errorf("GateNonInteractive trusted should return nil, got: %v", err)
+	}
+}
+
+func TestGateNonInteractiveUntrusted(t *testing.T) {
+	dir := t.TempDir()
+	cfg := cfgWithCommands([]string{"make build"}, nil)
+	err := trust.GateNonInteractive(dir, cfg)
+	if err == nil {
+		t.Error("GateNonInteractive untrusted should return error")
+	}
+	if !strings.Contains(err.Error(), "rimba trust") {
+		t.Errorf("error should mention 'rimba trust', got: %v", err)
+	}
+}
+
+func TestGateNonInteractiveEnvEscapeHatch(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := cfgWithCommands([]string{"make build"}, nil)
+
+	t.Setenv("RIMBA_TRUST_YES", "1")
+	if err := trust.GateNonInteractive(dir, cfg); err != nil {
+		t.Errorf("GateNonInteractive with RIMBA_TRUST_YES=1 should return nil, got: %v", err)
+	}
+}
+
+func TestGateNonInteractiveEnvEscapeHatchZero(t *testing.T) {
+	dir := t.TempDir()
+	cfg := cfgWithCommands([]string{"make build"}, nil)
+
+	t.Setenv("RIMBA_TRUST_YES", "0")
+	err := trust.GateNonInteractive(dir, cfg)
+	if err == nil {
+		t.Error("GateNonInteractive with RIMBA_TRUST_YES=0 should still return error")
+	}
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Errorf("expected file to exist: %s", path)
+	}
+}

--- a/tests/e2e/deps_test.go
+++ b/tests/e2e/deps_test.go
@@ -243,7 +243,10 @@ func TestPostCreateHooks(t *testing.T) {
 	cfg.PostCreate = []string{"touch hook-marker.txt"}
 	saveConfig(t, repo, cfg)
 
-	r := rimbaSuccess(t, repo, "add", "hook-task")
+	r := rimbaWithEnv(t, repo, []string{"RIMBA_TRUST_YES=1"}, "add", "hook-task")
+	if r.ExitCode != 0 {
+		t.Fatalf("rimba add hook-task: exit %d\nstdout: %s\nstderr: %s", r.ExitCode, r.Stdout, r.Stderr)
+	}
 
 	wtDir := filepath.Join(repo, cfg.WorktreeDir)
 	branch := resolver.BranchName(defaultPrefix, "hook-task")
@@ -265,7 +268,10 @@ func TestPostCreateHooksSkipFlag(t *testing.T) {
 	cfg.PostCreate = []string{"touch should-not-exist.txt"}
 	saveConfig(t, repo, cfg)
 
-	r := rimbaSuccess(t, repo, "add", flagSkipHooksE2E, "skip-hook-task")
+	r := rimbaWithEnv(t, repo, []string{"RIMBA_TRUST_YES=1"}, "add", flagSkipHooksE2E, "skip-hook-task")
+	if r.ExitCode != 0 {
+		t.Fatalf("rimba add --skip-hooks: exit %d\nstdout: %s\nstderr: %s", r.ExitCode, r.Stdout, r.Stderr)
+	}
 
 	wtDir := filepath.Join(repo, cfg.WorktreeDir)
 	branch := resolver.BranchName(defaultPrefix, "skip-hook-task")

--- a/tests/e2e/rename_test.go
+++ b/tests/e2e/rename_test.go
@@ -193,8 +193,8 @@ func TestRenamePostRenameHookRuns(t *testing.T) {
 	cfg.PostRename = []string{"touch " + marker}
 	saveConfig(t, repo, cfg)
 
-	rimbaSuccess(t, repo, "add", "hook-src", flagSkipDepsE2E, flagSkipHooksE2E)
-	rimbaSuccess(t, repo, "rename", "hook-src", "hook-dst", flagSkipDepsE2E)
+	rimbaWithEnv(t, repo, []string{"RIMBA_TRUST_YES=1"}, "add", "hook-src", flagSkipDepsE2E, flagSkipHooksE2E)
+	rimbaWithEnv(t, repo, []string{"RIMBA_TRUST_YES=1"}, "rename", "hook-src", "hook-dst", flagSkipDepsE2E)
 
 	assertFileExists(t, marker)
 }
@@ -210,8 +210,8 @@ func TestRenameSkipHooksSkipsPostRenameHook(t *testing.T) {
 	cfg.PostRename = []string{"touch " + marker}
 	saveConfig(t, repo, cfg)
 
-	rimbaSuccess(t, repo, "add", "hook-skip-src", flagSkipDepsE2E, flagSkipHooksE2E)
-	rimbaSuccess(t, repo, "rename", "hook-skip-src", "hook-skip-dst",
+	rimbaWithEnv(t, repo, []string{"RIMBA_TRUST_YES=1"}, "add", "hook-skip-src", flagSkipDepsE2E, flagSkipHooksE2E)
+	rimbaWithEnv(t, repo, []string{"RIMBA_TRUST_YES=1"}, "rename", "hook-skip-src", "hook-skip-dst",
 		flagSkipDepsE2E, flagSkipHooksE2E)
 
 	assertFileNotExists(t, marker)

--- a/tests/e2e/trust_e2e_test.go
+++ b/tests/e2e/trust_e2e_test.go
@@ -1,0 +1,178 @@
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/trust"
+	"github.com/lugassawan/rimba/testutil"
+)
+
+// writeTeamConfig writes settings.toml to .rimba/ for the given repo.
+func writeTeamConfig(t *testing.T, repo string, cfg *config.Config) {
+	t.Helper()
+	p := filepath.Join(repo, ".rimba", config.TeamFile)
+	if err := config.Save(p, cfg); err != nil {
+		t.Fatalf("write team config: %v", err)
+	}
+}
+
+// AC1: fresh repo with post_create — rimba add WITHOUT consent does NOT execute the command.
+func TestTrustAC1FreshRepoDoesNotRunWithoutConsent(t *testing.T) {
+	repo := setupCleanInitializedRepo(t)
+
+	// Write a post_create hook that would create a marker file.
+	markerFile := filepath.Join(repo, "hook-ran")
+	cfg := &config.Config{
+		WorktreeDir:   "../rimba-trust-wt",
+		DefaultSource: "main",
+		PostCreate:    []string{"touch " + markerFile},
+	}
+	writeTeamConfig(t, repo, cfg)
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "add post_create hook")
+
+	r := rimbaFail(t, repo, "add", "my-task", "--skip-deps")
+
+	// The hook must NOT have run.
+	assertFileNotExists(t, markerFile)
+
+	// Error output should mention rimba trust.
+	combined := r.Stdout + r.Stderr
+	if !strings.Contains(combined, "rimba trust") {
+		t.Errorf("error should mention 'rimba trust', got:\nstdout: %s\nstderr: %s", r.Stdout, r.Stderr)
+	}
+}
+
+// AC3: RIMBA_TRUST_YES=1 auto-approves and the command runs.
+func TestTrustAC3EnvYesRunsCommand(t *testing.T) {
+	repo := setupCleanInitializedRepo(t)
+
+	markerFile := filepath.Join(repo, "hook-ran")
+	cfg := &config.Config{
+		WorktreeDir:   "../rimba-trust-wt",
+		DefaultSource: "main",
+		PostCreate:    []string{"touch " + markerFile},
+	}
+	writeTeamConfig(t, repo, cfg)
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "add post_create hook")
+
+	rimbaWithEnv(t, repo, []string{"RIMBA_TRUST_YES=1"}, "add", "my-task", "--skip-deps")
+
+	assertFileExists(t, markerFile)
+}
+
+// AC3: --yes flag auto-approves and the command runs.
+func TestTrustAC3FlagYesRunsCommand(t *testing.T) {
+	repo := setupCleanInitializedRepo(t)
+
+	markerFile := filepath.Join(repo, "hook-ran")
+	cfg := &config.Config{
+		WorktreeDir:   "../rimba-trust-wt",
+		DefaultSource: "main",
+		PostCreate:    []string{"touch " + markerFile},
+	}
+	writeTeamConfig(t, repo, cfg)
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "add post_create hook")
+
+	rimbaWithEnv(t, repo, []string{"RIMBA_TRUST_YES=1"}, "add", "my-task", "--skip-deps", "--yes")
+
+	assertFileExists(t, markerFile)
+}
+
+// AC2: after approval, changing post_create re-arms the gate (denied again).
+func TestTrustAC2ChangedCommandReArmsGate(t *testing.T) {
+	repo := setupCleanInitializedRepo(t)
+
+	marker1 := filepath.Join(repo, "hook1-ran")
+	cfg := &config.Config{
+		WorktreeDir:   "../rimba-trust-wt",
+		DefaultSource: "main",
+		PostCreate:    []string{"touch " + marker1},
+	}
+	writeTeamConfig(t, repo, cfg)
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "add post_create hook")
+
+	// Approve and run.
+	rimbaWithEnv(t, repo, []string{"RIMBA_TRUST_YES=1"}, "add", "task-v1", "--skip-deps")
+	assertFileExists(t, marker1)
+
+	// Now change the post_create command.
+	marker2 := filepath.Join(repo, "hook2-ran")
+	cfg.PostCreate = []string{"touch " + marker2}
+	writeTeamConfig(t, repo, cfg)
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "change post_create hook")
+
+	// Re-arm: add without RIMBA_TRUST_YES should be denied.
+	r := rimbaFail(t, repo, "add", "task-v2", "--skip-deps")
+	// New hook must NOT have run.
+	assertFileNotExists(t, marker2)
+
+	combined := r.Stdout + r.Stderr
+	if !strings.Contains(combined, "rimba trust") {
+		t.Errorf("re-armed error should mention 'rimba trust', got:\nstdout: %s\nstderr: %s", r.Stdout, r.Stderr)
+	}
+}
+
+// rimba trust command: approve via rimba trust, then add runs without prompt.
+func TestTrustTrustCommandApprovesThenAddRuns(t *testing.T) {
+	repo := setupCleanInitializedRepo(t)
+
+	markerFile := filepath.Join(repo, "trust-approved")
+	cfg := &config.Config{
+		WorktreeDir:   "../rimba-trust-wt",
+		DefaultSource: "main",
+		PostCreate:    []string{"touch " + markerFile},
+	}
+	writeTeamConfig(t, repo, cfg)
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "add post_create hook")
+
+	// Use `rimba trust --yes` to pre-approve.
+	rimbaSuccess(t, repo, "trust", "--yes")
+
+	// Now add should run without RIMBA_TRUST_YES.
+	rimbaSuccess(t, repo, "add", "approved-task", "--skip-deps")
+	assertFileExists(t, markerFile)
+}
+
+// rimba trust --show: displays commands and trusted status.
+func TestTrustTrustShow(t *testing.T) {
+	repo := setupCleanInitializedRepo(t)
+
+	cfg := &config.Config{
+		WorktreeDir:   "../rimba-trust-wt",
+		DefaultSource: "main",
+		PostCreate:    []string{"npm ci", "pnpm build"},
+	}
+	writeTeamConfig(t, repo, cfg)
+	testutil.GitCmd(t, repo, "add", ".")
+	testutil.GitCmd(t, repo, "commit", "-m", "add hooks")
+
+	r := rimbaSuccess(t, repo, "trust", "--show")
+	assertContains(t, r.Stdout, "npm ci")
+	assertContains(t, r.Stdout, "pnpm build")
+	assertContains(t, r.Stdout, "sha256:")
+	assertContains(t, r.Stdout, "not trusted")
+}
+
+// rimba init adds trust.local.toml to .gitignore.
+func TestTrustInitAddsGitignoreEntry(t *testing.T) {
+	repo := setupRepo(t)
+	rimbaSuccess(t, repo, "init")
+
+	data, err := os.ReadFile(filepath.Join(repo, ".gitignore"))
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if !strings.Contains(string(data), trust.FileName) {
+		t.Errorf(".gitignore should contain %q after rimba init, got:\n%s", trust.FileName, data)
+	}
+}

--- a/tests/e2e/trust_e2e_test.go
+++ b/tests/e2e/trust_e2e_test.go
@@ -80,7 +80,8 @@ func TestTrustAC3FlagYesRunsCommand(t *testing.T) {
 	testutil.GitCmd(t, repo, "add", ".")
 	testutil.GitCmd(t, repo, "commit", "-m", "add post_create hook")
 
-	rimbaWithEnv(t, repo, []string{"RIMBA_TRUST_YES=1"}, "add", "my-task", "--skip-deps", "--yes")
+	// --yes alone (without RIMBA_TRUST_YES) should be sufficient to auto-approve.
+	rimbaSuccess(t, repo, "add", "my-task", "--skip-deps", "--yes")
 
 	assertFileExists(t, markerFile)
 }


### PR DESCRIPTION
## Summary

- Adds a direnv-style consent gate that blocks `rimba` from executing committed shell commands (`post_create`, `post_rename`, `deps.modules[].install`) without explicit per-repo user approval
- New `internal/trust` package: content-based SHA256 hash of the command set, per-repo `.rimba/trust.local.toml` store (gitignored, 0600 perms)
- `ensureTrust()` gate inserted at every command entry point that triggers shell execution (`add`, `rename`, `deps install`, `duplicate`, `restore`); `branch:` promote mode is correctly ungated (no hooks run there)
- `rimba trust` command with `--show` flag to review commands and approval status
- Non-interactive gate (`GateNonInteractive`) for MCP tool handlers (auto-deny unless pre-trusted or `RIMBA_TRUST_YES`)
- `--yes` persistent flag and `RIMBA_TRUST_YES=1` env var for CI escape hatch
- `rimba init` registers `trust.local.toml` in `.gitignore`; `Record()` self-heals repos initialized before this feature
- Approval is automatically invalidated when the committed command set changes (different hash → gate re-arms)

## Test Plan

- [x] Unit tests pass (`make test`) — 2056 passed
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2E tests pass (`make test-e2e`) — 309 passed
- [x] Coverage ≥ 97% — 97.0%
- [x] AC1: fresh repo + `post_create` → `rimba add` without consent exits non-zero, hook does not run
- [x] AC2: after approval, changing the command set re-arms the gate (different hash)
- [x] AC3: `RIMBA_TRUST_YES=1` and `--yes` each bypass the prompt and record approval

## Issue

Closes #253