### PR TITLE
[feat] consolidate .rimba/*.local.toml gitignore entries under a single glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ This repo's .rimba/settings.toml will run shell commands that have not been appr
 Run these commands? [y/N]
 ```
 
-Approval is stored locally in `.rimba/trust.local.toml` (gitignored — each user consents independently). The approval is keyed by a hash of the command set; changing any command re-arms the gate.
+Approval is stored locally in `.rimba/trust.local.toml` (covered by the `.rimba/*.local.toml` gitignore glob — each user consents independently). The approval is keyed by a hash of the command set; changing any command re-arms the gate.
 
 **Pre-approve without prompting** (e.g. for `rimba trust` after reviewing settings, or in CI):
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -287,11 +287,9 @@ func printSection(cmd *cobra.Command, title string, tier installTier, results []
 	}
 }
 
-// ensureLocalIgnore writes the gitignore entry for local config files.
-// In personal mode it ignores the whole .rimba/ dir; otherwise it consolidates
-// all *.local.toml files under a single glob via trust.EnsureLocalGlobIgnored.
-// gitignoreEntry is only used in personal mode; in non-personal mode
-// trust.EnsureLocalGlobIgnored always derives the glob from config.LocalGlob.
+// ensureLocalIgnore updates .gitignore for local config files.
+// Personal mode ignores the whole .rimba/ dir; non-personal mode writes the
+// *.local.toml glob. gitignoreEntry is only used in the personal branch.
 func ensureLocalIgnore(repoRoot, gitignoreEntry string, personal bool) (bool, error) {
 	if personal {
 		return fileutil.EnsureGitignore(repoRoot, gitignoreEntry)
@@ -299,11 +297,8 @@ func ensureLocalIgnore(repoRoot, gitignoreEntry string, personal bool) (bool, er
 	return trust.EnsureLocalGlobIgnored(repoRoot)
 }
 
-// reconcileExistingIgnore runs on re-init of an already-initialized repo.
-// It migrates per-file gitignore entries to the consolidated glob and prints
-// a message only when the glob line was newly added.
-// NOTE: switching from non-personal to personal mode (--personal on re-init) is
-// not handled here; users must manually add .rimba/ to .gitignore if desired.
+// reconcileExistingIgnore migrates per-file .gitignore entries to the glob on
+// re-init. Switching from non-personal to personal mode is not handled here.
 func reconcileExistingIgnore(cmd *cobra.Command, repoRoot string, personal bool) error {
 	if personal {
 		return nil

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -290,6 +290,8 @@ func printSection(cmd *cobra.Command, title string, tier installTier, results []
 // ensureLocalIgnore writes the gitignore entry for local config files.
 // In personal mode it ignores the whole .rimba/ dir; otherwise it consolidates
 // all *.local.toml files under a single glob via trust.EnsureLocalGlobIgnored.
+// gitignoreEntry is only used in personal mode; in non-personal mode
+// trust.EnsureLocalGlobIgnored always derives the glob from config.LocalGlob.
 func ensureLocalIgnore(repoRoot, gitignoreEntry string, personal bool) (bool, error) {
 	if personal {
 		return fileutil.EnsureGitignore(repoRoot, gitignoreEntry)
@@ -300,6 +302,8 @@ func ensureLocalIgnore(repoRoot, gitignoreEntry string, personal bool) (bool, er
 // reconcileExistingIgnore runs on re-init of an already-initialized repo.
 // It migrates per-file gitignore entries to the consolidated glob and prints
 // a message only when the glob line was newly added.
+// NOTE: switching from non-personal to personal mode (--personal on re-init) is
+// not handled here; users must manually add .rimba/ to .gitignore if desired.
 func reconcileExistingIgnore(cmd *cobra.Command, repoRoot string, personal bool) error {
 	if personal {
 		return nil

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -83,10 +83,10 @@ register MCP — it only updates agent files. Registration is idempotent.`,
 
 		dirPath := filepath.Join(repoRoot, config.DirName)
 		legacyPath := filepath.Join(repoRoot, config.FileName)
-		localEntry := filepath.Join(config.DirName, config.LocalFile)
+		globEntry := filepath.Join(config.DirName, config.LocalGlob)
 		dirEntry := config.DirName + "/"
 
-		gitignoreEntry := localEntry
+		gitignoreEntry := globEntry
 		if personal {
 			gitignoreEntry = dirEntry
 		}
@@ -95,6 +95,9 @@ register MCP — it only updates agent files. Registration is idempotent.`,
 		case dirExists(dirPath):
 			// .rimba/ directory already exists
 			fmt.Fprintf(cmd.OutOrStdout(), "Config %s already exists, skipping config creation\n", dirPath)
+			if err := reconcileExistingIgnore(cmd, repoRoot, personal); err != nil {
+				return err
+			}
 
 		case fileExists(legacyPath):
 			if err := runInitMigrate(cmd, repoRoot, dirPath, legacyPath, gitignoreEntry, personal); err != nil {
@@ -156,16 +159,9 @@ func runInitFresh(cmd *cobra.Command, r git.Runner, repoRoot, dirPath, gitignore
 		)
 	}
 
-	added, err := fileutil.EnsureGitignore(repoRoot, gitignoreEntry)
+	added, err := ensureLocalIgnore(repoRoot, gitignoreEntry, personal)
 	if err != nil {
 		return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
-	}
-
-	// Ensure trust store is gitignored (no-op in --personal mode since .rimba/ is already covered).
-	if !personal {
-		if _, err := fileutil.EnsureGitignore(repoRoot, filepath.Join(config.DirName, trust.FileName)); err != nil {
-			return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
-		}
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Initialized rimba in %s\n", repoRoot)
@@ -203,15 +199,8 @@ func runInitMigrate(cmd *cobra.Command, repoRoot, dirPath, legacyPath, gitignore
 
 	_, _ = fileutil.RemoveGitignoreEntry(repoRoot, config.FileName)
 
-	if _, err := fileutil.EnsureGitignore(repoRoot, gitignoreEntry); err != nil {
+	if _, err := ensureLocalIgnore(repoRoot, gitignoreEntry, personal); err != nil {
 		return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
-	}
-
-	// Ensure trust store is gitignored (no-op in --personal mode).
-	if !personal {
-		if _, err := fileutil.EnsureGitignore(repoRoot, filepath.Join(config.DirName, trust.FileName)); err != nil {
-			return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
-		}
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Migrated rimba config in %s\n", repoRoot)
@@ -296,6 +285,33 @@ func printSection(cmd *cobra.Command, title string, tier installTier, results []
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "    %s (%s)\n", p, r.Action)
 	}
+}
+
+// ensureLocalIgnore writes the gitignore entry for local config files.
+// In personal mode it ignores the whole .rimba/ dir; otherwise it consolidates
+// all *.local.toml files under a single glob via trust.EnsureLocalGlobIgnored.
+func ensureLocalIgnore(repoRoot, gitignoreEntry string, personal bool) (bool, error) {
+	if personal {
+		return fileutil.EnsureGitignore(repoRoot, gitignoreEntry)
+	}
+	return trust.EnsureLocalGlobIgnored(repoRoot)
+}
+
+// reconcileExistingIgnore runs on re-init of an already-initialized repo.
+// It migrates per-file gitignore entries to the consolidated glob and prints
+// a message only when the glob line was newly added.
+func reconcileExistingIgnore(cmd *cobra.Command, repoRoot string, personal bool) error {
+	if personal {
+		return nil
+	}
+	added, err := trust.EnsureLocalGlobIgnored(repoRoot)
+	if err != nil {
+		return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
+	}
+	if added {
+		fmt.Fprintf(cmd.OutOrStdout(), "  Gitignore:    %s added to .gitignore\n", filepath.Join(config.DirName, config.LocalGlob))
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -10,7 +10,6 @@ import (
 	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/fileutil"
 	"github.com/lugassawan/rimba/internal/git"
-	"github.com/lugassawan/rimba/internal/trust"
 	"github.com/spf13/cobra"
 )
 
@@ -294,7 +293,7 @@ func ensureLocalIgnore(repoRoot, gitignoreEntry string, personal bool) (bool, er
 	if personal {
 		return fileutil.EnsureGitignore(repoRoot, gitignoreEntry)
 	}
-	return trust.EnsureLocalGlobIgnored(repoRoot)
+	return fileutil.EnsureLocalGlobIgnored(repoRoot)
 }
 
 // reconcileExistingIgnore migrates per-file .gitignore entries to the glob on
@@ -303,7 +302,7 @@ func reconcileExistingIgnore(cmd *cobra.Command, repoRoot string, personal bool)
 	if personal {
 		return nil
 	}
-	added, err := trust.EnsureLocalGlobIgnored(repoRoot)
+	added, err := fileutil.EnsureLocalGlobIgnored(repoRoot)
 	if err != nil {
 		return errhint.WithFix(fmt.Errorf("failed to update .gitignore: %w", err), gitignoreHint)
 	}

--- a/cmd/init_personal_test.go
+++ b/cmd/init_personal_test.go
@@ -45,7 +45,7 @@ func TestInitPersonalFreshInit(t *testing.T) {
 		t.Error("settings.local.toml should not be created in personal mode")
 	}
 
-	// Verify .gitignore has .rimba/ not .rimba/settings.local.toml
+	// Verify .gitignore has .rimba/ not per-file or glob entries
 	data, err := os.ReadFile(filepath.Join(repoDir, ".gitignore"))
 	if err != nil {
 		t.Fatal(err)
@@ -58,6 +58,10 @@ func TestInitPersonalFreshInit(t *testing.T) {
 	localEntry := filepath.Join(config.DirName, config.LocalFile)
 	if strings.Contains(content, localEntry) {
 		t.Errorf(".gitignore should not contain %q in personal mode, got:\n%s", localEntry, content)
+	}
+	globEntry := filepath.Join(config.DirName, config.LocalGlob)
+	if strings.Contains(content, globEntry) {
+		t.Errorf(".gitignore should not contain glob %q in personal mode, got:\n%s", globEntry, content)
 	}
 }
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -112,9 +112,9 @@ func TestInitMigrationFromLegacy(t *testing.T) {
 	if strings.Contains(content, config.FileName) {
 		t.Error(".gitignore should not contain legacy entry after migration")
 	}
-	localEntry := filepath.Join(config.DirName, config.LocalFile)
-	if !strings.Contains(content, localEntry) {
-		t.Errorf(".gitignore should contain %q, got:\n%s", localEntry, content)
+	globEntry := filepath.Join(config.DirName, config.LocalGlob)
+	if !strings.Contains(content, globEntry) {
+		t.Errorf(".gitignore should contain %q, got:\n%s", globEntry, content)
 	}
 }
 
@@ -343,8 +343,8 @@ func TestInitMigrateConflictingDir(t *testing.T) {
 func TestInitFreshGitignoreAlreadyPresent(t *testing.T) {
 	repoDir := t.TempDir()
 
-	// Pre-seed .gitignore with the entry that rimba would add
-	gitignoreEntry := filepath.Join(config.DirName, config.LocalFile)
+	// Pre-seed .gitignore with the glob entry that rimba now writes
+	gitignoreEntry := filepath.Join(config.DirName, config.LocalGlob)
 	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte(gitignoreEntry+"\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -366,5 +366,50 @@ func TestInitFreshGitignoreAlreadyPresent(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "already in .gitignore") {
 		t.Errorf("output should say 'already in .gitignore', got:\n%s", out)
+	}
+}
+
+func TestInitReInitMigratesPerFileEntries(t *testing.T) {
+	repoDir := t.TempDir()
+
+	// Pre-create .rimba/ (already initialized) with per-file gitignore entries
+	rimbaDir := filepath.Join(repoDir, config.DirName)
+	if err := os.MkdirAll(rimbaDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	perFileEntries := filepath.Join(config.DirName, config.LocalFile) + "\n" +
+		filepath.Join(config.DirName, "trust.local.toml") + "\n"
+	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte(perFileEntries), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := repoRootRunner(repoDir, func(_ ...string) (string, error) { return "", nil })
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	if err := initCmd.RunE(cmd, nil); err != nil {
+		t.Fatalf("initCmd.RunE on re-init: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "already exists") {
+		t.Errorf("output should mention 'already exists', got:\n%s", out)
+	}
+
+	data, err := os.ReadFile(filepath.Join(repoDir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	globEntry := filepath.Join(config.DirName, config.LocalGlob)
+	if !strings.Contains(content, globEntry) {
+		t.Errorf(".gitignore should contain %q after re-init, got:\n%s", globEntry, content)
+	}
+	if strings.Contains(content, filepath.Join(config.DirName, config.LocalFile)) {
+		t.Errorf(".gitignore should not contain per-file settings.local.toml after re-init, got:\n%s", content)
+	}
+	if strings.Contains(content, filepath.Join(config.DirName, "trust.local.toml")) {
+		t.Errorf(".gitignore should not contain per-file trust.local.toml after re-init, got:\n%s", content)
 	}
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -378,7 +378,7 @@ func TestInitReInitMigratesPerFileEntries(t *testing.T) {
 		t.Fatal(err)
 	}
 	perFileEntries := filepath.Join(config.DirName, config.LocalFile) + "\n" +
-		filepath.Join(config.DirName, "trust.local.toml") + "\n"
+		filepath.Join(config.DirName, config.TrustFile) + "\n"
 	if err := os.WriteFile(filepath.Join(repoDir, ".gitignore"), []byte(perFileEntries), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -409,7 +409,7 @@ func TestInitReInitMigratesPerFileEntries(t *testing.T) {
 	if strings.Contains(content, filepath.Join(config.DirName, config.LocalFile)) {
 		t.Errorf(".gitignore should not contain per-file settings.local.toml after re-init, got:\n%s", content)
 	}
-	if strings.Contains(content, filepath.Join(config.DirName, "trust.local.toml")) {
+	if strings.Contains(content, filepath.Join(config.DirName, config.TrustFile)) {
 		t.Errorf(".gitignore should not contain per-file trust.local.toml after re-init, got:\n%s", content)
 	}
 }

--- a/cmd/trust_test.go
+++ b/cmd/trust_test.go
@@ -23,6 +23,7 @@ func newTrustCmd(cfg *config.Config, repoRoot string) (*cobra.Command, *bytes.Bu
 
 func TestTrustCmdApprove(t *testing.T) {
 	dir := t.TempDir()
+	// Pre-seed with per-file entry to verify consolidation on approve.
 	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".rimba/settings.local.toml\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -46,6 +47,16 @@ func TestTrustCmdApprove(t *testing.T) {
 	ok, _ := trust.IsTrusted(dir, trust.Hash(cfg))
 	if !ok {
 		t.Error("trust should be recorded after approve")
+	}
+
+	// Verify gitignore was consolidated to glob.
+	data, _ := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	content := string(data)
+	if !strings.Contains(content, ".rimba/*.local.toml") {
+		t.Errorf(".gitignore should contain glob after approve, got:\n%s", content)
+	}
+	if strings.Contains(content, ".rimba/settings.local.toml") {
+		t.Errorf(".gitignore should not contain per-file entry after approve, got:\n%s", content)
 	}
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -53,7 +53,7 @@ rimba init --agents --uninstall   # Remove project-team agent files and MCP regi
 | `-g`, `--global` | Install agent files at user level (`~/`) — works outside a git repo |
 | `--local` | Install agent files gitignored (personal overrides; requires `--agents`) |
 | `--uninstall` | Remove agent files and MCP registration (requires `-g` or `--agents`) |
-| `--personal` | Gitignore the entire `.rimba/` directory instead of just the local config file |
+| `--personal` | Gitignore the entire `.rimba/` directory instead of the `.rimba/*.local.toml` glob |
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@
 `rimba init` creates a `.rimba/` directory in the repo root with two config files:
 
 - **`settings.toml`** — team-shared configuration (commit this to git)
-- **`settings.local.toml`** — personal overrides (gitignored, per-developer)
+- **`settings.local.toml`** — personal overrides (gitignored via `.rimba/*.local.toml`, per-developer)
 
 Local settings override team settings. Fields omitted from the local file inherit from the team file. All fields are optional — sensible defaults are applied automatically.
 
@@ -65,7 +65,7 @@ rimba init
 # Migrated rimba config in /path/to/repo
 #   Moved:     .rimba.toml → .rimba/settings.toml
 #   Created:   .rimba/settings.local.toml
-#   Gitignore: updated (.rimba.toml → .rimba/settings.local.toml)
+#   Gitignore: updated (.rimba.toml → .rimba/*.local.toml)
 ```
 
 ## Field Reference

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ const (
 	DirName   = ".rimba"
 	TeamFile  = "settings.toml"
 	LocalFile = "settings.local.toml"
+	LocalGlob = "*.local.toml" // gitignore glob for personal *.local.toml overrides
 )
 
 type Config struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ const (
 	DirName   = ".rimba"
 	TeamFile  = "settings.toml"
 	LocalFile = "settings.local.toml"
+	TrustFile = "trust.local.toml"
 	LocalGlob = "*.local.toml" // gitignore glob for personal *.local.toml overrides
 )
 

--- a/internal/fileutil/gitignore.go
+++ b/internal/fileutil/gitignore.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/lugassawan/rimba/internal/config"
 )
 
 // EnsureGitignore ensures that entry is present as a line in the .gitignore
@@ -68,6 +70,21 @@ func HasGitignoreEntry(repoRoot, entry string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// EnsureLocalGlobIgnored consolidates *.local.toml overrides under a single
+// .rimba/*.local.toml gitignore glob, removing any pre-existing per-file entries.
+// No-op when .rimba/ is already ignored (--personal repos).
+// Returns whether the glob line was newly added.
+func EnsureLocalGlobIgnored(repoRoot string) (added bool, err error) {
+	hasDir, err := HasGitignoreEntry(repoRoot, config.DirName+"/")
+	if err != nil || hasDir {
+		return false, err
+	}
+	// Best-effort cleanup: the glob below covers both files even if removal fails.
+	_, _ = RemoveGitignoreEntry(repoRoot, filepath.Join(config.DirName, config.LocalFile))
+	_, _ = RemoveGitignoreEntry(repoRoot, filepath.Join(config.DirName, config.TrustFile))
+	return EnsureGitignore(repoRoot, filepath.Join(config.DirName, config.LocalGlob))
 }
 
 // RemoveGitignoreEntry removes entry from the .gitignore file at repoRoot.

--- a/internal/fileutil/gitignore.go
+++ b/internal/fileutil/gitignore.go
@@ -51,6 +51,25 @@ func EnsureGitignore(repoRoot string, entry string) (added bool, retErr error) {
 	return true, nil
 }
 
+// HasGitignoreEntry reports whether entry is present as a trimmed line in the
+// .gitignore file at repoRoot. Returns false (not error) when the file is absent.
+func HasGitignoreEntry(repoRoot, entry string) (bool, error) {
+	path := filepath.Join(repoRoot, ".gitignore")
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if strings.TrimSpace(line) == entry {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // RemoveGitignoreEntry removes entry from the .gitignore file at repoRoot.
 // Returns true if the entry was removed, false if the file doesn't exist or
 // the entry was not present.

--- a/internal/fileutil/gitignore_test.go
+++ b/internal/fileutil/gitignore_test.go
@@ -304,6 +304,23 @@ func TestEnsureLocalGlobIgnoredMigration(t *testing.T) {
 	}
 }
 
+func TestEnsureLocalGlobIgnoredNoGitignore(t *testing.T) {
+	dir := t.TempDir()
+
+	added, err := EnsureLocalGlobIgnored(dir)
+	if err != nil {
+		t.Fatalf(errUnexpected, err)
+	}
+	if !added {
+		t.Error("expected added=true for fresh repo with no .gitignore")
+	}
+	content := readFile(t, filepath.Join(dir, gitignoreFile))
+	glob := config.DirName + "/" + config.LocalGlob
+	if !strings.Contains(content, glob) {
+		t.Errorf("expected glob %q in new .gitignore, got:\n%s", glob, content)
+	}
+}
+
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/internal/fileutil/gitignore_test.go
+++ b/internal/fileutil/gitignore_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/lugassawan/rimba/internal/config"
 )
 
 const (
@@ -253,6 +255,52 @@ func TestHasGitignoreEntryNotPresent(t *testing.T) {
 	}
 	if present {
 		t.Fatal("expected present=false when entry is not in .gitignore")
+	}
+}
+
+func TestEnsureLocalGlobIgnoredPersonalMode(t *testing.T) {
+	dir := t.TempDir()
+	original := ".rimba/\n"
+	writeFile(t, filepath.Join(dir, gitignoreFile), original)
+
+	added, err := EnsureLocalGlobIgnored(dir)
+	if err != nil {
+		t.Fatalf(errUnexpected, err)
+	}
+	if added {
+		t.Error("expected added=false in personal mode (.rimba/ already ignored)")
+	}
+	if got := readFile(t, filepath.Join(dir, gitignoreFile)); got != original {
+		t.Errorf(".gitignore should be unchanged in personal mode, got:\n%s", got)
+	}
+}
+
+func TestEnsureLocalGlobIgnoredMigration(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, gitignoreFile),
+		"node_modules\n.rimba/settings.local.toml\n.rimba/trust.local.toml\n")
+
+	added, err := EnsureLocalGlobIgnored(dir)
+	if err != nil {
+		t.Fatalf(errUnexpected, err)
+	}
+	if !added {
+		t.Error("expected added=true when glob was not yet present")
+	}
+
+	content := readFile(t, filepath.Join(dir, gitignoreFile))
+	glob := config.DirName + "/" + config.LocalGlob
+	if !strings.Contains(content, glob) {
+		t.Errorf(".gitignore should contain %q, got:\n%s", glob, content)
+	}
+	if strings.Contains(content, ".rimba/settings.local.toml") {
+		t.Errorf(".gitignore should not contain per-file settings entry, got:\n%s", content)
+	}
+	if strings.Contains(content, ".rimba/trust.local.toml") {
+		t.Errorf(".gitignore should not contain per-file trust entry, got:\n%s", content)
+	}
+	if !strings.Contains(content, "node_modules") {
+		t.Errorf(".gitignore should preserve other entries, got:\n%s", content)
 	}
 }
 

--- a/internal/fileutil/gitignore_test.go
+++ b/internal/fileutil/gitignore_test.go
@@ -218,6 +218,44 @@ func TestRemoveGitignoreEntryWriteError(t *testing.T) {
 	}
 }
 
+func TestHasGitignoreEntryNoFile(t *testing.T) {
+	dir := t.TempDir()
+
+	present, err := HasGitignoreEntry(dir, testEntry)
+	if err != nil {
+		t.Fatalf(errUnexpected, err)
+	}
+	if present {
+		t.Fatal("expected present=false when .gitignore does not exist")
+	}
+}
+
+func TestHasGitignoreEntryPresent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, gitignoreFile), otherEntryLine+testEntry+"\n")
+
+	present, err := HasGitignoreEntry(dir, testEntry)
+	if err != nil {
+		t.Fatalf(errUnexpected, err)
+	}
+	if !present {
+		t.Fatal("expected present=true when entry is in .gitignore")
+	}
+}
+
+func TestHasGitignoreEntryNotPresent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, gitignoreFile), otherEntryLine)
+
+	present, err := HasGitignoreEntry(dir, testEntry)
+	if err != nil {
+		t.Fatalf(errUnexpected, err)
+	}
+	if present {
+		t.Fatal("expected present=false when entry is not in .gitignore")
+	}
+}
+
 func readFile(t *testing.T, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/internal/trust/store.go
+++ b/internal/trust/store.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// FileName is the gitignored local trust record for a repo.
-	FileName     = "trust.local.toml"
+	FileName     = config.TrustFile
 	storeVersion = 1
 )
 

--- a/internal/trust/store.go
+++ b/internal/trust/store.go
@@ -66,9 +66,7 @@ func EnsureLocalGlobIgnored(repoRoot string) (added bool, err error) {
 	if err != nil || hasDir {
 		return false, err
 	}
-	// Removal of legacy per-file entries is best-effort: even if removal fails,
-	// the glob appended below still covers both files, so gitignore correctness is
-	// preserved — the only residue is a redundant line that git ignores via the glob.
+	// Best-effort cleanup: the glob below covers both files even if removal fails.
 	_, _ = fileutil.RemoveGitignoreEntry(repoRoot, filepath.Join(config.DirName, config.LocalFile))
 	_, _ = fileutil.RemoveGitignoreEntry(repoRoot, filepath.Join(config.DirName, FileName))
 	return fileutil.EnsureGitignore(repoRoot, filepath.Join(config.DirName, config.LocalGlob))

--- a/internal/trust/store.go
+++ b/internal/trust/store.go
@@ -66,6 +66,9 @@ func EnsureLocalGlobIgnored(repoRoot string) (added bool, err error) {
 	if err != nil || hasDir {
 		return false, err
 	}
+	// Removal of legacy per-file entries is best-effort: even if removal fails,
+	// the glob appended below still covers both files, so gitignore correctness is
+	// preserved — the only residue is a redundant line that git ignores via the glob.
 	_, _ = fileutil.RemoveGitignoreEntry(repoRoot, filepath.Join(config.DirName, config.LocalFile))
 	_, _ = fileutil.RemoveGitignoreEntry(repoRoot, filepath.Join(config.DirName, FileName))
 	return fileutil.EnsureGitignore(repoRoot, filepath.Join(config.DirName, config.LocalGlob))

--- a/internal/trust/store.go
+++ b/internal/trust/store.go
@@ -56,22 +56,6 @@ func IsTrusted(repoRoot, hash string) (bool, error) {
 	return s != nil && s.Hash == hash, nil
 }
 
-// EnsureLocalGlobIgnored consolidates the personal *.local.toml overrides
-// (settings.local.toml, trust.local.toml) under a single .rimba/*.local.toml
-// gitignore glob: it removes any pre-existing specific entries and adds the glob.
-// No-op when the whole .rimba/ directory is already ignored (--personal repos).
-// Returns whether the glob line was newly added.
-func EnsureLocalGlobIgnored(repoRoot string) (added bool, err error) {
-	hasDir, err := fileutil.HasGitignoreEntry(repoRoot, config.DirName+"/")
-	if err != nil || hasDir {
-		return false, err
-	}
-	// Best-effort cleanup: the glob below covers both files even if removal fails.
-	_, _ = fileutil.RemoveGitignoreEntry(repoRoot, filepath.Join(config.DirName, config.LocalFile))
-	_, _ = fileutil.RemoveGitignoreEntry(repoRoot, filepath.Join(config.DirName, FileName))
-	return fileutil.EnsureGitignore(repoRoot, filepath.Join(config.DirName, config.LocalGlob))
-}
-
 // Record persists approval of the given command-set hash for repoRoot.
 // It ensures .rimba/ exists and consolidates *.local.toml under a single
 // .rimba/*.local.toml gitignore glob, self-healing repos initialized before
@@ -82,7 +66,7 @@ func Record(repoRoot, hash string) error {
 		return fmt.Errorf("create .rimba dir: %w", err)
 	}
 
-	if _, err := EnsureLocalGlobIgnored(repoRoot); err != nil {
+	if _, err := fileutil.EnsureLocalGlobIgnored(repoRoot); err != nil {
 		return fmt.Errorf("update .gitignore: %w", err)
 	}
 

--- a/internal/trust/store.go
+++ b/internal/trust/store.go
@@ -56,18 +56,32 @@ func IsTrusted(repoRoot, hash string) (bool, error) {
 	return s != nil && s.Hash == hash, nil
 }
 
+// EnsureLocalGlobIgnored consolidates the personal *.local.toml overrides
+// (settings.local.toml, trust.local.toml) under a single .rimba/*.local.toml
+// gitignore glob: it removes any pre-existing specific entries and adds the glob.
+// No-op when the whole .rimba/ directory is already ignored (--personal repos).
+// Returns whether the glob line was newly added.
+func EnsureLocalGlobIgnored(repoRoot string) (added bool, err error) {
+	hasDir, err := fileutil.HasGitignoreEntry(repoRoot, config.DirName+"/")
+	if err != nil || hasDir {
+		return false, err
+	}
+	_, _ = fileutil.RemoveGitignoreEntry(repoRoot, filepath.Join(config.DirName, config.LocalFile))
+	_, _ = fileutil.RemoveGitignoreEntry(repoRoot, filepath.Join(config.DirName, FileName))
+	return fileutil.EnsureGitignore(repoRoot, filepath.Join(config.DirName, config.LocalGlob))
+}
+
 // Record persists approval of the given command-set hash for repoRoot.
-// It ensures .rimba/ exists and registers trust.local.toml in .gitignore.
+// It ensures .rimba/ exists and consolidates *.local.toml under a single
+// .rimba/*.local.toml gitignore glob, self-healing repos initialized before
+// this feature existed.
 func Record(repoRoot, hash string) error {
 	dir := filepath.Join(repoRoot, config.DirName)
 	if err := os.MkdirAll(dir, 0750); err != nil {
 		return fmt.Errorf("create .rimba dir: %w", err)
 	}
 
-	// Best-effort gitignore registration — self-heals repos initialized
-	// before this feature existed.
-	entry := filepath.Join(config.DirName, FileName)
-	if _, err := fileutil.EnsureGitignore(repoRoot, entry); err != nil {
+	if _, err := EnsureLocalGlobIgnored(repoRoot); err != nil {
 		return fmt.Errorf("update .gitignore: %w", err)
 	}
 

--- a/internal/trust/store_test.go
+++ b/internal/trust/store_test.go
@@ -151,66 +151,6 @@ func TestRecordGitignoreEntry(t *testing.T) {
 	}
 }
 
-func TestEnsureLocalGlobIgnoredPersonalMode(t *testing.T) {
-	// When .rimba/ is in .gitignore (personal mode), EnsureLocalGlobIgnored is a no-op.
-	dir := t.TempDir()
-	original := ".rimba/\n"
-	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(original), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	added, err := trust.EnsureLocalGlobIgnored(dir)
-	if err != nil {
-		t.Fatalf("EnsureLocalGlobIgnored: %v", err)
-	}
-	if added {
-		t.Error("expected added=false in personal mode (.rimba/ already ignored)")
-	}
-
-	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != original {
-		t.Errorf(".gitignore should be unchanged in personal mode, got:\n%s", data)
-	}
-}
-
-func TestEnsureLocalGlobIgnoredMigration(t *testing.T) {
-	// Pre-existing per-file entries are removed and replaced by the glob.
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("node_modules\n.rimba/settings.local.toml\n.rimba/trust.local.toml\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	added, err := trust.EnsureLocalGlobIgnored(dir)
-	if err != nil {
-		t.Fatalf("EnsureLocalGlobIgnored: %v", err)
-	}
-	if !added {
-		t.Error("expected added=true when glob was not yet present")
-	}
-
-	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	content := string(data)
-	glob := config.DirName + "/" + config.LocalGlob
-	if !strings.Contains(content, glob) {
-		t.Errorf(".gitignore should contain %q, got:\n%s", glob, content)
-	}
-	if strings.Contains(content, ".rimba/settings.local.toml") {
-		t.Errorf(".gitignore should not contain per-file entry, got:\n%s", content)
-	}
-	if strings.Contains(content, ".rimba/trust.local.toml") {
-		t.Errorf(".gitignore should not contain per-file entry, got:\n%s", content)
-	}
-	if !strings.Contains(content, "node_modules") {
-		t.Errorf(".gitignore should preserve other entries, got:\n%s", content)
-	}
-}
-
 func TestRecordOverwritesAndUpdatesApprovedAt(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), nil, 0644); err != nil {

--- a/internal/trust/store_test.go
+++ b/internal/trust/store_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/trust"
 )
 
@@ -121,7 +122,8 @@ func TestRecordFilePermissions(t *testing.T) {
 
 func TestRecordGitignoreEntry(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".rimba/settings.local.toml\n"), 0644); err != nil {
+	// Simulate an existing repo that has both per-file entries.
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(".rimba/settings.local.toml\n.rimba/trust.local.toml\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(filepath.Join(dir, ".rimba"), 0750); err != nil {
@@ -136,8 +138,76 @@ func TestRecordGitignoreEntry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read .gitignore: %v", err)
 	}
-	if !strings.Contains(string(data), ".rimba/trust.local.toml") {
-		t.Errorf(".gitignore should contain .rimba/trust.local.toml, got:\n%s", data)
+	content := string(data)
+	glob := config.DirName + "/" + config.LocalGlob
+	if !strings.Contains(content, glob) {
+		t.Errorf(".gitignore should contain %q, got:\n%s", glob, content)
+	}
+	if strings.Contains(content, ".rimba/settings.local.toml") {
+		t.Errorf(".gitignore should not contain per-file settings.local.toml after consolidation, got:\n%s", content)
+	}
+	if strings.Contains(content, ".rimba/trust.local.toml") {
+		t.Errorf(".gitignore should not contain per-file trust.local.toml after consolidation, got:\n%s", content)
+	}
+}
+
+func TestEnsureLocalGlobIgnoredPersonalMode(t *testing.T) {
+	// When .rimba/ is in .gitignore (personal mode), EnsureLocalGlobIgnored is a no-op.
+	dir := t.TempDir()
+	original := ".rimba/\n"
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := trust.EnsureLocalGlobIgnored(dir)
+	if err != nil {
+		t.Fatalf("EnsureLocalGlobIgnored: %v", err)
+	}
+	if added {
+		t.Error("expected added=false in personal mode (.rimba/ already ignored)")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != original {
+		t.Errorf(".gitignore should be unchanged in personal mode, got:\n%s", data)
+	}
+}
+
+func TestEnsureLocalGlobIgnoredMigration(t *testing.T) {
+	// Pre-existing per-file entries are removed and replaced by the glob.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("node_modules\n.rimba/settings.local.toml\n.rimba/trust.local.toml\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := trust.EnsureLocalGlobIgnored(dir)
+	if err != nil {
+		t.Fatalf("EnsureLocalGlobIgnored: %v", err)
+	}
+	if !added {
+		t.Error("expected added=true when glob was not yet present")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	glob := config.DirName + "/" + config.LocalGlob
+	if !strings.Contains(content, glob) {
+		t.Errorf(".gitignore should contain %q, got:\n%s", glob, content)
+	}
+	if strings.Contains(content, ".rimba/settings.local.toml") {
+		t.Errorf(".gitignore should not contain per-file entry, got:\n%s", content)
+	}
+	if strings.Contains(content, ".rimba/trust.local.toml") {
+		t.Errorf(".gitignore should not contain per-file entry, got:\n%s", content)
+	}
+	if !strings.Contains(content, "node_modules") {
+		t.Errorf(".gitignore should preserve other entries, got:\n%s", content)
 	}
 }
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -22,6 +22,7 @@ const (
 	configDir     = ".rimba"
 	teamFile      = "settings.toml"
 	localFile     = "settings.local.toml"
+	localGlob     = "*.local.toml" // gitignore glob — matches LocalGlob in config
 	gitignoreFile = ".gitignore"
 
 	// Output messages asserted in tests.

--- a/tests/e2e/init_test.go
+++ b/tests/e2e/init_test.go
@@ -26,10 +26,10 @@ func TestInitCreatesConfigAndDir(t *testing.T) {
 	wtDir := filepath.Join(repo, config.DefaultWorktreeDir(filepath.Base(repo)))
 	assertFileExists(t, wtDir)
 
-	// .gitignore is created with .rimba/settings.local.toml
+	// .gitignore is created with .rimba/*.local.toml
 	assertFileExists(t, filepath.Join(repo, gitignoreFile))
-	localEntry := filepath.Join(configDir, localFile)
-	assertGitignoreContains(t, repo, localEntry)
+	globEntry := filepath.Join(configDir, localGlob)
+	assertGitignoreContains(t, repo, globEntry)
 }
 
 func TestInitConfigDefaults(t *testing.T) {
@@ -91,10 +91,10 @@ func TestInitAddsToGitignore(t *testing.T) {
 		t.Fatalf("failed to write %s: %v", gitignoreFile, err)
 	}
 
-	localEntry := filepath.Join(configDir, localFile)
+	globEntry := filepath.Join(configDir, localGlob)
 	r := rimbaSuccess(t, repo, "init")
-	assertContains(t, r.Stdout, localEntry+" added to .gitignore")
-	assertGitignoreContains(t, repo, localEntry)
+	assertContains(t, r.Stdout, globEntry+" added to .gitignore")
+	assertGitignoreContains(t, repo, globEntry)
 
 	// Original content is preserved
 	data, err := os.ReadFile(filepath.Join(repo, gitignoreFile))
@@ -112,9 +112,9 @@ func TestInitGitignoreIdempotent(t *testing.T) {
 	}
 
 	repo := setupRepo(t)
-	localEntry := filepath.Join(configDir, localFile)
-	// Pre-create .gitignore already containing the entry
-	if err := os.WriteFile(filepath.Join(repo, gitignoreFile), []byte(localEntry+"\n"), 0644); err != nil {
+	globEntry := filepath.Join(configDir, localGlob)
+	// Pre-create .gitignore already containing the glob entry
+	if err := os.WriteFile(filepath.Join(repo, gitignoreFile), []byte(globEntry+"\n"), 0644); err != nil {
 		t.Fatalf("failed to write %s: %v", gitignoreFile, err)
 	}
 
@@ -126,8 +126,8 @@ func TestInitGitignoreIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read %s: %v", gitignoreFile, err)
 	}
-	if strings.Count(string(data), localEntry) != 1 {
-		t.Errorf("expected exactly one %s entry, got:\n%s", localEntry, string(data))
+	if strings.Count(string(data), globEntry) != 1 {
+		t.Errorf("expected exactly one %s entry, got:\n%s", globEntry, string(data))
 	}
 }
 
@@ -177,8 +177,8 @@ func TestInitMigratesLegacyConfig(t *testing.T) {
 	if strings.Contains(content, configFile) {
 		t.Error(".gitignore should not contain legacy entry after migration")
 	}
-	localEntry := filepath.Join(configDir, localFile)
-	assertGitignoreContains(t, repo, localEntry)
+	globEntry := filepath.Join(configDir, localGlob)
+	assertGitignoreContains(t, repo, globEntry)
 }
 
 func TestInitFailsOutsideGitRepo(t *testing.T) {
@@ -324,11 +324,13 @@ func TestInitPersonalFreshInit(t *testing.T) {
 	assertFileExists(t, filepath.Join(repo, configDir, teamFile))
 	assertFileNotExists(t, filepath.Join(repo, configDir, localFile))
 
-	// .gitignore has .rimba/ not .rimba/settings.local.toml
+	// .gitignore has .rimba/ not per-file or glob entries
 	dirEntry := configDir + "/"
 	assertGitignoreContains(t, repo, dirEntry)
 	localEntry := filepath.Join(configDir, localFile)
 	assertGitignoreNotContains(t, repo, localEntry)
+	globEntry := filepath.Join(configDir, localGlob)
+	assertGitignoreNotContains(t, repo, globEntry)
 }
 
 func TestInitPersonalMigration(t *testing.T) {
@@ -367,7 +369,7 @@ func TestInitPersonalMigration(t *testing.T) {
 		t.Errorf("DefaultSource = %q, want %q", cfg.DefaultSource, branchMain)
 	}
 
-	// Verify .gitignore updated with .rimba/ not legacy entry
+	// Verify .gitignore updated with .rimba/ not legacy or per-file entries
 	data, err := os.ReadFile(filepath.Join(repo, gitignoreFile))
 	if err != nil {
 		t.Fatal(err)
@@ -380,6 +382,8 @@ func TestInitPersonalMigration(t *testing.T) {
 	assertGitignoreContains(t, repo, dirEntry)
 	localEntry := filepath.Join(configDir, localFile)
 	assertGitignoreNotContains(t, repo, localEntry)
+	globEntry := filepath.Join(configDir, localGlob)
+	assertGitignoreNotContains(t, repo, globEntry)
 }
 
 // assertGitignoreContains verifies that .gitignore in the repo contains the given entry.

--- a/tests/e2e/trust_e2e_test.go
+++ b/tests/e2e/trust_e2e_test.go
@@ -1,7 +1,6 @@
 package e2e_test
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -164,16 +163,14 @@ func TestTrustTrustShow(t *testing.T) {
 	assertContains(t, r.Stdout, "not trusted")
 }
 
-// rimba init adds trust.local.toml to .gitignore.
+// rimba init adds .rimba/*.local.toml glob to .gitignore (covers both
+// settings.local.toml and trust.local.toml under a single entry).
 func TestTrustInitAddsGitignoreEntry(t *testing.T) {
 	repo := setupRepo(t)
 	rimbaSuccess(t, repo, "init")
 
-	data, err := os.ReadFile(filepath.Join(repo, ".gitignore"))
-	if err != nil {
-		t.Fatalf("read .gitignore: %v", err)
-	}
-	if !strings.Contains(string(data), trust.FileName) {
-		t.Errorf(".gitignore should contain %q after rimba init, got:\n%s", trust.FileName, data)
-	}
+	globEntry := filepath.Join(configDir, localGlob)
+	assertGitignoreContains(t, repo, globEntry)
+	// Specific trust.local.toml entry must NOT be added (the glob covers it).
+	assertGitignoreNotContains(t, repo, filepath.Join(configDir, trust.FileName))
 }


### PR DESCRIPTION
## Summary
- Replace per-file `.rimba/settings.local.toml` and `.rimba/trust.local.toml` gitignore entries with a single `.rimba/*.local.toml` glob, so any current or future `*.local.toml` file under `.rimba/` is ignored without further `.gitignore` churn
- Add `trust.EnsureLocalGlobIgnored` which removes pre-existing per-file entries and adds the glob (no-op for `--personal` repos where `.rimba/` is already ignored)
- Re-running `rimba init` on an existing repo now reconciles per-file entries to the consolidated glob
- `trust.Record` also self-heals on approval, migrating repos initialized before this change

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)
- [x] Coverage ≥97% (`make test-coverage` → 97.0%)
- [x] New `HasGitignoreEntry` + `EnsureLocalGlobIgnored` tests added
- [x] Re-init migration test: seeds `.gitignore` with per-file entries, asserts they're replaced by one glob line after `rimba init`

## Issue

Issue: N/A — direct feature request, no ticket