### PR TITLE
[fix] prune stale remote-tracking refs during rimba clean --merged

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -278,7 +278,7 @@ func cleanStale(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 // other fetch failures (e.g. no remote configured).
 func cleanFetchMergeRef(ctx context.Context, cmd *cobra.Command, r git.Runner, s *spinner.Spinner, mainBranch string) (string, error) {
 	s.Start("Fetching from " + git.DefaultRemote + "...")
-	if err := git.Fetch(ctx, r, git.DefaultRemote); err != nil {
+	if err := git.Fetch(ctx, r, git.DefaultRemote, git.FetchArgs{Prune: true}); err != nil {
 		s.Stop()
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return "", err

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -795,5 +796,29 @@ func TestCleanFetchMergeRefCancelled(t *testing.T) {
 	ref, err := cleanFetchMergeRef(context.Background(), cmd, r, s, branchMain)
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got err=%v ref=%q", err, ref)
+	}
+}
+
+func TestCleanFetchMergeRefPassesPrune(t *testing.T) {
+	cmd, _ := newTestCmd()
+	var fetchArgs []string
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == cmdFetch {
+				fetchArgs = append([]string(nil), args...)
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+	s := spinner.New(spinnerOpts(cmd))
+	defer s.Stop()
+
+	_, err := cleanFetchMergeRef(context.Background(), cmd, r, s, branchMain)
+	if err != nil {
+		t.Fatalf("cleanFetchMergeRef: %v", err)
+	}
+	if !slices.Contains(fetchArgs, "--prune") {
+		t.Errorf("fetch args %v missing --prune: merged cleanup must prune stale remote-tracking refs", fetchArgs)
 	}
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -92,7 +92,7 @@ var syncCmd = &cobra.Command{
 			fmt.Fprintln(cmd.OutOrStdout(), "[dry-run] would fetch origin")
 		} else {
 			s.Start("Fetching from origin...")
-			if err := git.Fetch(cmd.Context(), r, "origin"); err != nil {
+			if err := git.Fetch(cmd.Context(), r, "origin", git.FetchArgs{}); err != nil {
 				s.Stop()
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 					return err

--- a/internal/git/sync.go
+++ b/internal/git/sync.go
@@ -2,9 +2,20 @@ package git
 
 import "context"
 
-// Fetch runs `git fetch <remote>` to update remote tracking branches.
-func Fetch(ctx context.Context, r Runner, remote string) error {
-	_, err := r.RunContext(ctx, "fetch", remote)
+// FetchArgs configures Fetch. The zero value performs a plain `git fetch <remote>`.
+type FetchArgs struct {
+	Prune bool // append --prune: drop remote-tracking refs whose upstream branch was deleted
+}
+
+// Fetch runs `git fetch <remote>`, applying any options in args, to update
+// remote-tracking branches.
+func Fetch(ctx context.Context, r Runner, remote string, args FetchArgs) error {
+	gitArgs := []string{"fetch"}
+	if args.Prune {
+		gitArgs = append(gitArgs, "--prune")
+	}
+	gitArgs = append(gitArgs, remote)
+	_, err := r.RunContext(ctx, gitArgs...)
 	return err
 }
 

--- a/internal/git/sync_ctx_test.go
+++ b/internal/git/sync_ctx_test.go
@@ -46,7 +46,7 @@ func TestFetchContextCancelledReturnsFast(t *testing.T) {
 
 	r := &ExecRunner{}
 	start := time.Now()
-	err := Fetch(ctx, r, "origin")
+	err := Fetch(ctx, r, "origin", FetchArgs{})
 	if time.Since(start) > time.Second {
 		t.Errorf("Fetch with cancelled ctx took too long: %v", time.Since(start))
 	}
@@ -62,7 +62,7 @@ func TestFetchPassesContext(t *testing.T) {
 	sentinel := context.WithValue(context.Background(), ctxKey{}, "sentinel")
 	r := &ctxMockRunner{}
 
-	if err := Fetch(sentinel, r, "origin"); err != nil {
+	if err := Fetch(sentinel, r, "origin", FetchArgs{}); err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
 

--- a/internal/git/sync_test.go
+++ b/internal/git/sync_test.go
@@ -20,20 +20,40 @@ const (
 )
 
 func TestFetch(t *testing.T) {
-	var captured []string
-	r := &mockRunner{
-		run: func(args ...string) (string, error) {
-			captured = args
-			return "", nil
+	cases := []struct {
+		name     string
+		args     FetchArgs
+		wantArgs []string
+	}{
+		{
+			name:     "plain fetch",
+			args:     FetchArgs{},
+			wantArgs: []string{"fetch", remoteOrigin},
+		},
+		{
+			name:     "fetch with prune",
+			args:     FetchArgs{Prune: true},
+			wantArgs: []string{"fetch", "--prune", remoteOrigin},
 		},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured []string
+			r := &mockRunner{
+				run: func(args ...string) (string, error) {
+					captured = args
+					return "", nil
+				},
+			}
 
-	if err := Fetch(context.Background(), r, remoteOrigin); err != nil {
-		t.Fatalf("Fetch: %v", err)
-	}
+			if err := Fetch(context.Background(), r, remoteOrigin, tc.args); err != nil {
+				t.Fatalf("Fetch: %v", err)
+			}
 
-	if len(captured) != 2 || captured[0] != "fetch" || captured[1] != remoteOrigin {
-		t.Errorf("expected [fetch origin], got %v", captured)
+			if !slices.Equal(captured, tc.wantArgs) {
+				t.Errorf("got %v, want %v", captured, tc.wantArgs)
+			}
+		})
 	}
 }
 
@@ -44,7 +64,7 @@ func TestFetchError(t *testing.T) {
 		},
 	}
 
-	err := Fetch(context.Background(), r, remoteOrigin)
+	err := Fetch(context.Background(), r, remoteOrigin, FetchArgs{})
 	if err == nil {
 		t.Fatal("expected error from Fetch")
 	}

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -94,7 +94,7 @@ func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dry
 
 	// Fetch latest (non-fatal; cancellation propagated as a tool error)
 	mergeRef := mainBranch
-	if fetchWarn, fetchErr := mcpFetchNonFatal(ctx, r); fetchErr != nil {
+	if fetchWarn, fetchErr := mcpFetchNonFatal(ctx, r, git.FetchArgs{Prune: true}); fetchErr != nil {
 		return mcp.NewToolResultError(fetchErr.Error()), nil
 	} else if fetchWarn == "" {
 		mergeRef = git.DefaultRemote + "/" + mainBranch

--- a/internal/mcp/tool_sync.go
+++ b/internal/mcp/tool_sync.go
@@ -67,7 +67,7 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 		r := hctx.Runner
 
 		// Fetch (non-fatal; cancellation propagated as a tool error)
-		fetchWarning, fetchErr := mcpFetchNonFatal(ctx, r)
+		fetchWarning, fetchErr := mcpFetchNonFatal(ctx, r, git.FetchArgs{})
 		if fetchErr != nil {
 			return mcp.NewToolResultError(fetchErr.Error()), nil
 		}
@@ -119,8 +119,8 @@ func syncMultiple(ctx context.Context, r git.Runner, worktrees []resolver.Worktr
 // mcpFetchNonFatal fetches from git.DefaultRemote ("origin") and returns a
 // warning string on connectivity failure. Cancellation is returned as a hard
 // error so callers can propagate it.
-func mcpFetchNonFatal(ctx context.Context, r git.Runner) (warning string, err error) {
-	if fetchErr := git.Fetch(ctx, r, git.DefaultRemote); fetchErr != nil {
+func mcpFetchNonFatal(ctx context.Context, r git.Runner, args git.FetchArgs) (warning string, err error) {
+	if fetchErr := git.Fetch(ctx, r, git.DefaultRemote, args); fetchErr != nil {
 		if errors.Is(fetchErr, context.Canceled) || errors.Is(fetchErr, context.DeadlineExceeded) {
 			return "", fetchErr
 		}

--- a/internal/mcp/tool_sync_test.go
+++ b/internal/mcp/tool_sync_test.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
 )
 
@@ -553,7 +555,7 @@ func TestMcpFetchNonFatalCancelled(t *testing.T) {
 			return "", context.Canceled
 		},
 	}
-	warn, err := mcpFetchNonFatal(context.Background(), r)
+	warn, err := mcpFetchNonFatal(context.Background(), r, git.FetchArgs{})
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected context.Canceled, got err=%v warn=%q", err, warn)
 	}
@@ -565,11 +567,37 @@ func TestMcpFetchNonFatalConnectivityFailure(t *testing.T) {
 			return "", errors.New("no remote configured")
 		},
 	}
-	warn, err := mcpFetchNonFatal(context.Background(), r)
+	warn, err := mcpFetchNonFatal(context.Background(), r, git.FetchArgs{})
 	if err != nil {
 		t.Errorf("connectivity failure should not return error, got %v", err)
 	}
 	if warn == "" {
 		t.Error("expected non-empty warning for connectivity failure")
+	}
+}
+
+func TestMcpFetchNonFatalPruneFlag(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      git.FetchArgs
+		wantPrune bool
+	}{
+		{"no prune for sync", git.FetchArgs{}, false},
+		{"prune for merged clean", git.FetchArgs{Prune: true}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var fetchArgs []string
+			r := &mockRunner{
+				run: func(args ...string) (string, error) {
+					fetchArgs = append([]string(nil), args...)
+					return "", nil
+				},
+			}
+			_, _ = mcpFetchNonFatal(context.Background(), r, tc.args)
+			if slices.Contains(fetchArgs, "--prune") != tc.wantPrune {
+				t.Errorf("--prune present=%v, want %v; fetch args: %v", slices.Contains(fetchArgs, "--prune"), tc.wantPrune, fetchArgs)
+			}
+		})
 	}
 }

--- a/internal/operations/add_pr_worktree.go
+++ b/internal/operations/add_pr_worktree.go
@@ -61,7 +61,7 @@ func AddPRWorktree(
 func resolveSource(ctx context.Context, gitR git.Runner, meta gh.PRMeta, onProgress progress.Func) (string, error) {
 	if !meta.IsCrossRepository {
 		progress.Notify(onProgress, "Fetching origin...")
-		if err := git.Fetch(ctx, gitR, "origin"); err != nil {
+		if err := git.Fetch(ctx, gitR, "origin", git.FetchArgs{}); err != nil {
 			return "", errhint.WithFix(err, "check network connectivity")
 		}
 		return "origin/" + meta.HeadRefName, nil
@@ -78,7 +78,7 @@ func resolveSource(ctx context.Context, gitR git.Runner, meta gh.PRMeta, onProgr
 	}
 
 	progress.Notify(onProgress, fmt.Sprintf("Fetching %s...", remoteName))
-	if err := git.Fetch(ctx, gitR, remoteName); err != nil {
+	if err := git.Fetch(ctx, gitR, remoteName, git.FetchArgs{}); err != nil {
 		return "", errhint.WithFix(err, "check network and fork visibility")
 	}
 


### PR DESCRIPTION
## Summary
- `rimba clean --merged` now passes `--prune` to `git fetch origin`, so stale remote-tracking refs (`origin/<branch>`) are pruned in the same step that detects merged branches. Previously, a follow-up `git fetch --prune` was still needed.
- Added `FetchArgs` struct to `git.Fetch` (zero value = plain fetch, `{Prune: true}` = fetch with `--prune`). All callers updated: `--merged` and its MCP counterpart get `{Prune: true}`; sync, PR-add, and fork-add callers keep the zero value.
- `mcpFetchNonFatal` receives a `FetchArgs` param so each caller explicitly opts in or out of pruning.

## Test Plan
- [x] Unit tests pass (`make test`) — 2072 tests, all green; +6 new tests pinning the `--prune` behavior
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2E tests pass (`make test-e2e`) — 24 tests, all green
- [x] Coverage stays ≥ 97% — 97.1%
- [x] `TestFetch` table now exercises both `FetchArgs{}` → `[fetch origin]` and `FetchArgs{Prune: true}` → `[fetch --prune origin]`
- [x] `TestCleanFetchMergeRefPassesPrune` asserts the `--merged` call site passes `--prune`
- [x] `TestMcpFetchNonFatalPruneFlag` guards the per-caller split in MCP (clean prunes, sync does not)

## Issue
Issue: N/A — direct bug report from post-merge cleanup hook, no ticket