### PR TITLE
[test] Cover DepsConcurrency

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -759,3 +759,31 @@ func TestIsAutoDetectDeps(t *testing.T) {
 		})
 	}
 }
+
+func TestDepsConcurrency(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.Config
+		want int
+	}{
+		{
+			name: "nil deps",
+			cfg:  config.Config{WorktreeDir: "../wt", DefaultSource: testDefaultBranch},
+			want: 0,
+		},
+		{
+			name: "configured concurrency",
+			cfg:  config.Config{WorktreeDir: "../wt", DefaultSource: testDefaultBranch, Deps: &config.DepsConfig{Concurrency: 4}},
+			want: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.DepsConcurrency()
+			if got != tt.want {
+				t.Errorf("DepsConcurrency() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds table-driven coverage for `Config.DepsConcurrency()`.

The test covers both branches from #272:
- nil `Deps` returns `0`
- configured `Deps.Concurrency` returns that value

Tests:
- `go test ./internal/config -run 'Test(IsAutoDetectDeps|DepsConcurrency)' -count=1 -v`

I also tried `go test ./internal/config -count=1` on Windows. It fails in unrelated existing tests around Unix-style read-only directories and absolute paths, so I kept this PR scoped to the requested coverage gap.

Fixes #272