### PR TITLE
[fix] Avoid ambiguous bare task resolution

### DIFF
--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -116,15 +116,18 @@ func FindBranchForTask(service, task string, worktrees []WorktreeInfo, prefixes 
 		return wt, true
 	}
 
-	if wt, ok := findExact(task, worktrees); ok {
-		return wt, true
-	}
-
 	if service == "" {
 		matches := FindAllBranchesForTask(task, worktrees, prefixes)
 		if len(matches) == 1 {
 			return matches[0], true
 		}
+		if len(matches) > 1 {
+			return WorktreeInfo{}, false
+		}
+	}
+
+	if wt, ok := findExact(task, worktrees); ok {
+		return wt, true
 	}
 
 	return WorktreeInfo{}, false

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -320,6 +320,18 @@ func TestFindBranchForTaskWithService(t *testing.T) {
 		}
 	})
 
+	t.Run("bare branch collision with service matches is ambiguous", func(t *testing.T) {
+		colliding := []resolver.WorktreeInfo{
+			{Path: "/wt/login", Branch: taskLogin},
+			{Path: "/wt/auth-api-feature-login", Branch: "auth-api/" + featurePrefix + taskLogin},
+			{Path: "/wt/web-app-feature-login", Branch: "web-app/" + featurePrefix + taskLogin},
+		}
+		_, ok := resolver.FindBranchForTask("", taskLogin, colliding, prefixes)
+		if ok {
+			t.Fatal("expected no match due to bare branch collision with service-scoped matches")
+		}
+	})
+
 	t.Run("bare task with single monorepo match", func(t *testing.T) {
 		singleMono := []resolver.WorktreeInfo{
 			{Path: "/wt/auth-api-feature-login", Branch: "auth-api/" + featurePrefix + taskLogin},


### PR DESCRIPTION
## Summary
- check task-normalized branch matches before the exact bare-branch fallback
- return no resolver match when a bare branch collides with service-scoped task matches
- add a regression test for the collision case

Fixes #266

## Tests
- go test ./internal/resolver -run TestFindBranchForTask|TestFindAllBranchesForTask -count=1

Note: `go test ./internal/resolver` currently fails on Windows in existing `TestWorktreePath`, which expects POSIX separators.