### PR TITLE
[test] Cover git helper failure paths

### DIFF
--- a/testutil/githelper.go
+++ b/testutil/githelper.go
@@ -4,18 +4,29 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"testing"
 )
+
+type testRepoT interface {
+	Helper()
+	Fatalf(format string, args ...any)
+	TempDir() string
+}
+
+type testFatalT interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
 
 // NewTestRepo creates a temporary git repository with an initial commit.
 // Returns the path to the repo. The repo is cleaned up when the test finishes.
-func NewTestRepo(t *testing.T) string {
+func NewTestRepo(t testRepoT) string {
 	t.Helper()
 
 	dir := t.TempDir()
 	repo := filepath.Join(dir, "test-repo")
 	if err := os.MkdirAll(repo, 0755); err != nil {
 		t.Fatalf("mkdir: %v", err)
+		return ""
 	}
 
 	cmds := [][]string{
@@ -29,6 +40,7 @@ func NewTestRepo(t *testing.T) string {
 		cmd.Dir = repo
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("cmd %v: %s: %v", args, out, err)
+			return ""
 		}
 	}
 
@@ -36,6 +48,7 @@ func NewTestRepo(t *testing.T) string {
 	readmePath := filepath.Join(repo, "README.md")
 	if err := os.WriteFile(readmePath, []byte("# Test\n"), 0644); err != nil {
 		t.Fatalf("write: %v", err)
+		return ""
 	}
 
 	cmds = [][]string{
@@ -48,6 +61,7 @@ func NewTestRepo(t *testing.T) string {
 		cmd.Dir = repo
 		if out, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("cmd %v: %s: %v", args, out, err)
+			return ""
 		}
 	}
 
@@ -55,22 +69,24 @@ func NewTestRepo(t *testing.T) string {
 }
 
 // CreateFile creates a file in the given directory with the given content.
-func CreateFile(t *testing.T, dir, name, content string) {
+func CreateFile(t testFatalT, dir, name, content string) {
 	t.Helper()
 	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
+		return
 	}
 }
 
 // GitCmd runs a git command in the given directory.
-func GitCmd(t *testing.T, dir string, args ...string) string {
+func GitCmd(t testFatalT, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v: %s: %v", args, out, err)
+		return ""
 	}
 	return string(out)
 }

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -13,6 +13,7 @@ import (
 type fixtureTSpy struct {
 	fatalfCalled bool
 	fatalfMsg    string
+	tempDir      string
 }
 
 func (s *fixtureTSpy) Helper() {}
@@ -20,6 +21,20 @@ func (s *fixtureTSpy) Helper() {}
 func (s *fixtureTSpy) Fatalf(format string, args ...any) {
 	s.fatalfCalled = true
 	s.fatalfMsg = fmt.Sprintf(format, args...)
+}
+
+func (s *fixtureTSpy) TempDir() string {
+	return s.tempDir
+}
+
+func assertFatalContains(t *testing.T, spy *fixtureTSpy, want string) {
+	t.Helper()
+	if !spy.fatalfCalled {
+		t.Fatal("expected Fatalf to be called")
+	}
+	if !strings.Contains(spy.fatalfMsg, want) {
+		t.Fatalf("expected message to contain %q, got %q", want, spy.fatalfMsg)
+	}
 }
 
 func TestPtr(t *testing.T) {
@@ -30,7 +45,7 @@ func TestPtr(t *testing.T) {
 }
 
 func TestLoadFixture(t *testing.T) {
-	got := testutil.LoadFixture(t, "testdata/fixture.txt")
+	got := strings.ReplaceAll(testutil.LoadFixture(t, "testdata/fixture.txt"), "\r\n", "\n")
 	if got != "hello fixture\n" {
 		t.Fatalf("LoadFixture = %q, want %q", got, "hello fixture\n")
 	}
@@ -40,6 +55,72 @@ func TestNewTestRepo(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	if _, err := os.Stat(filepath.Join(repo, ".git")); err != nil {
 		t.Fatalf("expected .git dir in repo %s: %v", repo, err)
+	}
+}
+
+func TestNewTestRepoFatalBranches(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) *fixtureTSpy
+		wantMsg string
+	}{
+		{
+			name: "mkdir failure",
+			setup: func(t *testing.T) *fixtureTSpy {
+				t.Helper()
+				blocked := filepath.Join(t.TempDir(), "blocked")
+				if err := os.WriteFile(blocked, []byte("file"), 0644); err != nil {
+					t.Fatalf("write blocker: %v", err)
+				}
+				return &fixtureTSpy{tempDir: blocked}
+			},
+			wantMsg: "mkdir:",
+		},
+		{
+			name: "git init failure",
+			setup: func(t *testing.T) *fixtureTSpy {
+				t.Helper()
+				t.Setenv("PATH", "")
+				return &fixtureTSpy{tempDir: t.TempDir()}
+			},
+			wantMsg: "cmd [git init -b main]",
+		},
+		{
+			name: "readme write failure",
+			setup: func(t *testing.T) *fixtureTSpy {
+				t.Helper()
+				dir := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(dir, "test-repo", "README.md"), 0755); err != nil {
+					t.Fatalf("mkdir readme blocker: %v", err)
+				}
+				return &fixtureTSpy{tempDir: dir}
+			},
+			wantMsg: "write:",
+		},
+		{
+			name: "git add failure",
+			setup: func(t *testing.T) *fixtureTSpy {
+				t.Helper()
+				indexDir := filepath.Join(t.TempDir(), "index")
+				if err := os.MkdirAll(indexDir, 0755); err != nil {
+					t.Fatalf("mkdir index blocker: %v", err)
+				}
+				t.Setenv("GIT_INDEX_FILE", indexDir)
+				return &fixtureTSpy{tempDir: t.TempDir()}
+			},
+			wantMsg: "cmd [git add .]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Helper()
+			spy := tt.setup(t)
+			if got := testutil.NewTestRepo(spy); got != "" {
+				t.Fatalf("NewTestRepo returned %q, want empty path on failure", got)
+			}
+			assertFatalContains(t, spy, tt.wantMsg)
+		})
 	}
 }
 
@@ -55,18 +136,19 @@ func TestCreateFile(t *testing.T) {
 	}
 }
 
+func TestCreateFileFailure(t *testing.T) {
+	spy := &fixtureTSpy{}
+	testutil.CreateFile(spy, t.TempDir(), filepath.Join("missing", "hello.txt"), "world")
+	assertFatalContains(t, spy, "write ")
+}
+
 func TestLoadFixtureMissingFile(t *testing.T) {
 	spy := &fixtureTSpy{}
 	got := testutil.LoadFixture(spy, "testdata/does-not-exist.txt")
-	if !spy.fatalfCalled {
-		t.Fatal("expected Fatalf to be called for missing fixture")
-	}
 	if got != "" {
 		t.Fatalf("expected empty string on error, got %q", got)
 	}
-	if !strings.Contains(spy.fatalfMsg, "LoadFixture testdata/does-not-exist.txt") {
-		t.Fatalf("expected message to contain %q, got %q", "LoadFixture testdata/does-not-exist.txt", spy.fatalfMsg)
-	}
+	assertFatalContains(t, spy, "LoadFixture testdata/does-not-exist.txt")
 }
 
 func TestGitCmd(t *testing.T) {
@@ -75,4 +157,14 @@ func TestGitCmd(t *testing.T) {
 	if !strings.Contains(out, "initial commit") {
 		t.Fatalf("git log = %q, want 'initial commit'", out)
 	}
+}
+
+func TestGitCmdFailure(t *testing.T) {
+	repo := testutil.NewTestRepo(t)
+	spy := &fixtureTSpy{}
+	got := testutil.GitCmd(spy, repo, "not-a-real-subcommand")
+	if got != "" {
+		t.Fatalf("GitCmd returned %q, want empty output on failure", got)
+	}
+	assertFatalContains(t, spy, "git [not-a-real-subcommand]")
 }


### PR DESCRIPTION
Fixes #279. Adds focused coverage for githelper failure branches using the existing Fatalf spy pattern. Checks: go test ./testutil -cover; go test ./testutil -count=1; git diff --check. Full go test ./... was attempted but fails on this Windows environment in unrelated Unix-tool/permission tests.