### PR TITLE
[test] Cover presentation helper output

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/testutil"
 	"github.com/spf13/cobra"
 )
@@ -53,6 +54,32 @@ func makeWorktreeGitRunner(repoDir string) *mockRunner {
 			return "", nil
 		},
 		runInDir: noopRunInDir,
+	}
+}
+
+func TestPrintWorktreeResultCopySkipBranches(t *testing.T) {
+	cmd, buf := newTestCmd()
+
+	printWorktreeResult(cmd, "Created worktree", operations.AddResult{
+		Branch:          "feature/presentation",
+		Path:            "/repo/.rimba/worktrees/presentation",
+		Copied:          []string{".env", ".tool-versions"},
+		Skipped:         []string{".missing"},
+		SkippedSymlinks: []string{".config/link"},
+	})
+
+	got := buf.String()
+	for _, want := range []string{
+		"Created worktree\n",
+		"  Branch: feature/presentation\n",
+		"  Path:   /repo/.rimba/worktrees/presentation\n",
+		"  Copied: [.env .tool-versions]\n",
+		"  Skipped (not found): [.missing]\n",
+		"  Skipped (symlinks): [.config/link]\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q:\n%s", want, got)
+		}
 	}
 }
 

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -38,6 +38,18 @@ func testSyncWorktrees() []resolver.WorktreeInfo {
 	}
 }
 
+func TestPrintSyncDryRunMerge(t *testing.T) {
+	cmd, buf := newTestCmd()
+
+	printSyncDryRun(cmd, "feature/login", "main", true, true)
+
+	want := "[dry-run] would merge feature/login onto main\n" +
+		"[dry-run] would push feature/login to origin\n"
+	if got := buf.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
 func TestSyncOneSuccess(t *testing.T) {
 	worktrees := testSyncWorktrees()
 


### PR DESCRIPTION
Closes #273.

Adds direct output tests for:
- `printWorktreeResult` copied, missing, and symlink-skipped rows
- `printSyncDryRun` merge dry-run output

Checks:
- `gofmt -w cmd/add_test.go cmd/sync_test.go`
- `git diff --check`

Note: I could not run `go test` locally because this host has Go 1.25.1 while `go.mod` requires Go 1.26.4, and automatic toolchain switching hung in the sandbox.