### PR TITLE
test: cover worktree result presentation helpers

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/testutil"
 	"github.com/spf13/cobra"
 )
@@ -198,6 +199,33 @@ func TestAddWithSource(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "Created worktree") {
 		t.Errorf("output = %q, want 'Created worktree'", buf.String())
+	}
+}
+
+func TestPrintWorktreeResult(t *testing.T) {
+	cmd, buf := newTestCmd()
+	result := operations.AddResult{
+		Branch:          branchFeature,
+		Path:            pathWtFeatureLogin,
+		Copied:          []string{".env", "config/local.json"},
+		Skipped:         []string{"missing.env"},
+		SkippedSymlinks: []string{"linked-dir"},
+	}
+
+	printWorktreeResult(cmd, "Created worktree", result)
+
+	out := buf.String()
+	for _, want := range []string{
+		"Created worktree\n",
+		"  Branch: " + branchFeature + "\n",
+		"  Path:   " + pathWtFeatureLogin + "\n",
+		"  Copied: [.env config/local.json]\n",
+		"  Skipped (not found): [missing.env]\n",
+		"  Skipped (symlinks): [linked-dir]\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output = %q, want %q", out, want)
+		}
 	}
 }
 

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -567,6 +567,52 @@ func TestSyncAllDryRun(t *testing.T) {
 	}
 }
 
+func TestPrintSyncDryRun(t *testing.T) {
+	tests := []struct {
+		name     string
+		useMerge bool
+		push     bool
+		want     []string
+		notWant  []string
+	}{
+		{
+			name:    "rebase without push",
+			want:    []string{"[dry-run] would rebase " + branchFeature + " onto " + branchMain + "\n"},
+			notWant: []string{"would push"},
+		},
+		{
+			name:     "merge with push",
+			useMerge: true,
+			push:     true,
+			want: []string{
+				"[dry-run] would merge " + branchFeature + " onto " + branchMain + "\n",
+				"[dry-run] would push " + branchFeature + " to origin\n",
+			},
+			notWant: []string{"would rebase"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, buf := newTestCmd()
+
+			printSyncDryRun(cmd, branchFeature, branchMain, tt.useMerge, tt.push)
+
+			out := buf.String()
+			for _, want := range tt.want {
+				if !strings.Contains(out, want) {
+					t.Errorf("output = %q, want %q", out, want)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(out, notWant) {
+					t.Errorf("output = %q, must not contain %q", out, notWant)
+				}
+			}
+		})
+	}
+}
+
 func TestSyncWorktreeSkipWarningOnStderr(t *testing.T) {
 	var outBuf, errBuf bytes.Buffer
 	cmd := &cobra.Command{}


### PR DESCRIPTION
﻿## Summary
- Add focused tests for `printWorktreeResult` output.
- Add focused tests for `printSyncDryRun` output.
- Cover the presentation helper paths requested in #273 without changing production behavior.

## Test Plan
- [x] Unit tests pass (`go test ./cmd -run ''TestPrintWorktreeResult|TestPrintSyncDryRun'' -count=1`)
- [ ] Linter passes (`make lint`)
- [ ] E2E tests pass (`make test-e2e`)

Full `go test ./cmd -count=1` was attempted, but existing environment-sensitive tests failed on this Windows machine due to missing `gh`, MCP/init behavior, and path separator expectations unrelated to these helpers.

## Issue

Closes #273
