### PR TITLE
[chore] bump golang.org/x/text from v0.14.0 to v0.38.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,5 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/text v0.38.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
+golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary

- Bumps the indirect dependency `golang.org/x/text` from `v0.14.0` to `v0.38.0` — well past the `v0.21.0` floor requested in #282
- The module is pulled transitively via `github.com/santhosh-tekuri/jsonschema/v6` → `mark3labs/mcp-go`; the vendored packages cover localization only (`feature/plural`, `language`, `message`, `message/catalog`)
- CVE note: CVE-2024-45338 is attributed to `golang.org/x/net/html`, not `x/text`, and `x/net` is not a rimba dependency. The bump is performed as requested for hygiene and to keep govulncheck clean

## Test Plan

- [x] `go build ./...` passes
- [x] `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./...` passes
- [x] `go test ./...` — 2083 tests pass across 27 packages
- [x] `go vet ./...` — no issues
- [x] `govulncheck ./...` — no vulnerabilities found

Closes #282