### PR TITLE
[chore] Sign release checksums and emit an SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: anchore/sbom-action/download-syft@v0
-      - uses: sigstore/cosign-installer@v3
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      - uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
       - uses: goreleaser/goreleaser-action@v7
         with:
           args: release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -17,6 +18,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - uses: anchore/sbom-action/download-syft@v0
+      - uses: sigstore/cosign-installer@v3
       - uses: goreleaser/goreleaser-action@v7
         with:
           args: release --clean

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,21 @@ archives:
 checksum:
   name_template: checksums.txt
 
+sboms:
+  - artifacts: archive
+
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
 changelog:
   sort: asc
   abbrev: -1

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 - [Features](#features)
 - [Installation](#installation)
+  - [Verifying releases](#verifying-releases)
 - [Quick Start](#quick-start)
 - [Commands](#commands)
 - [Configuration](#configuration)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ make build
 # Binary is at ./bin/rimba
 ```
 
+### Verifying releases
+
+Each release publishes a `checksums.txt` signed with [cosign](https://github.com/sigstore/cosign) keyless signing (Sigstore OIDC via GitHub Actions). To verify a downloaded checksum file:
+
+```sh
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp 'https://github.com/lugassawan/rimba/.github/workflows/release.yml@refs/tags/v.*' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+```
+
+Each release archive also ships a companion `*.sbom.json` (SPDX format) on the GitHub Release page.
+
 ## Quick Start
 
 ```sh


### PR DESCRIPTION
## Summary
- Add `sboms:` block to `.goreleaser.yaml` — emits one SPDX-JSON SBOM per release archive via syft
- Add `signs:` block to `.goreleaser.yaml` — signs `checksums.txt` with cosign keyless (Sigstore OIDC), producing `checksums.txt.sig` + `checksums.txt.pem` logged to the Rekor transparency log
- Add `id-token: write` permission and install `anchore/sbom-action/download-syft@v0` + `sigstore/cosign-installer@v3` in `release.yml` so goreleaser can find both tools on PATH
- Add "Verifying releases" section to README with `cosign verify-blob` command and SBOM artifact note

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [ ] E2E tests pass (`make test-e2e`)

### Type-tailored checks ([chore])
- [x] `goreleaser check` — config is valid
- [x] `make fmt` — clean
- [ ] CI proof (post-merge, on next tag): release page lists `checksums.txt.sig`, `checksums.txt.pem`, and `*.sbom.json`; `cosign verify-blob` (README command) succeeds

## Issue

Closes #275
