### PR TITLE
[fix] Require config for MCP cleanup tools

### DIFF
--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -38,6 +38,11 @@ func handleClean(hctx *HandlerContext) server.ToolHandlerFunc {
 			return mcp.NewToolResultError("mode is required"), nil
 		}
 
+		cfg, cfgErr := hctx.requireConfig()
+		if cfgErr != nil {
+			return mcp.NewToolResultError(cfgErr.Error()), nil
+		}
+
 		dryRun := req.GetBool("dry_run", false)
 		force := req.GetBool("force", false)
 		staleDays := req.GetInt("stale_days", 14)
@@ -48,9 +53,9 @@ func handleClean(hctx *HandlerContext) server.ToolHandlerFunc {
 		case "prune":
 			return mcpCleanPrune(ctx, r, dryRun)
 		case "merged":
-			return mcpCleanMerged(ctx, r, hctx, dryRun, force)
+			return mcpCleanMerged(ctx, r, cfg.DefaultSource, dryRun, force)
 		case "stale":
-			return mcpCleanStale(ctx, r, hctx, dryRun, staleDays, force)
+			return mcpCleanStale(ctx, r, cfg.DefaultSource, dryRun, staleDays, force)
 		default:
 			return mcp.NewToolResultError(fmt.Sprintf("invalid mode %q; use prune, merged, or stale", mode)), nil
 		}
@@ -86,8 +91,8 @@ func mcpCleanPrune(ctx context.Context, r git.Runner, dryRun bool) (*mcp.CallToo
 	})
 }
 
-func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dryRun bool, force bool) (*mcp.CallToolResult, error) {
-	mainBranch, err := operations.ResolveMainBranch(ctx, r, configDefault(hctx))
+func mcpCleanMerged(ctx context.Context, r git.Runner, defaultSource string, dryRun bool, force bool) (*mcp.CallToolResult, error) {
+	mainBranch, err := operations.ResolveMainBranch(ctx, r, defaultSource)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -137,8 +142,8 @@ func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dry
 	})
 }
 
-func mcpCleanStale(ctx context.Context, r git.Runner, hctx *HandlerContext, dryRun bool, staleDays int, force bool) (*mcp.CallToolResult, error) {
-	mainBranch, err := operations.ResolveMainBranch(ctx, r, configDefault(hctx))
+func mcpCleanStale(ctx context.Context, r git.Runner, defaultSource string, dryRun bool, staleDays int, force bool) (*mcp.CallToolResult, error) {
+	mainBranch, err := operations.ResolveMainBranch(ctx, r, defaultSource)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}

--- a/internal/mcp/tool_clean_test.go
+++ b/internal/mcp/tool_clean_test.go
@@ -132,6 +132,22 @@ func TestCleanToolRequiresMode(t *testing.T) {
 	}
 }
 
+func TestCleanToolRequiresConfig(t *testing.T) {
+	hctx := &HandlerContext{
+		Runner:   &mockRunner{},
+		Config:   nil,
+		RepoRoot: "/repo",
+		Version:  "test",
+	}
+	handler := handleClean(hctx)
+
+	result := callTool(t, handler, map[string]any{"mode": modePrune})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, errConfigRequired.Error()) {
+		t.Errorf("expected config required error, got: %s", errText)
+	}
+}
+
 func TestCleanToolInvalidMode(t *testing.T) {
 	hctx := testContext(&mockRunner{})
 	handler := handleClean(hctx)
@@ -450,28 +466,9 @@ func TestCleanToolStaleListWorktreesError(t *testing.T) {
 	}
 }
 
-func TestCleanToolMergedNoConfig(t *testing.T) {
-	// When config is nil, resolveMainBranch falls back to git.DefaultBranch
-	r := &mockRunner{
-		run: func(args ...string) (string, error) {
-			// symbolic-ref for DefaultBranch detection
-			if len(args) >= 1 && args[0] == gitSymbolicRef {
-				return refsOriginMain, nil
-			}
-			if len(args) > 0 && args[0] == gitFetch {
-				return "", nil
-			}
-			if len(args) >= 2 && args[0] == gitBranch && args[1] == gitMerged {
-				return "", nil
-			}
-			porcelain := worktreePorcelain(
-				struct{ path, branch string }{"/repo", "main"},
-			)
-			return porcelain, nil
-		},
-	}
+func TestCleanToolMergedRequiresConfig(t *testing.T) {
 	hctx := &HandlerContext{
-		Runner:   r,
+		Runner:   &mockRunner{},
 		Config:   nil,
 		RepoRoot: "/repo",
 		Version:  "test",
@@ -479,9 +476,9 @@ func TestCleanToolMergedNoConfig(t *testing.T) {
 	handler := handleClean(hctx)
 
 	result := callTool(t, handler, map[string]any{"mode": modeMerged})
-	data := unmarshalJSON[cleanResult](t, result)
-	if data.Mode != modeMerged {
-		t.Errorf("mode = %q, want %q", data.Mode, modeMerged)
+	errText := resultError(t, result)
+	if !strings.Contains(errText, errConfigRequired.Error()) {
+		t.Errorf("expected config required error, got: %s", errText)
 	}
 }
 

--- a/internal/mcp/tool_remove.go
+++ b/internal/mcp/tool_remove.go
@@ -32,6 +32,10 @@ func handleRemove(hctx *HandlerContext) server.ToolHandlerFunc {
 			return mcp.NewToolResultError("task is required"), nil
 		}
 
+		if _, cfgErr := hctx.requireConfig(); cfgErr != nil {
+			return mcp.NewToolResultError(cfgErr.Error()), nil
+		}
+
 		service, task := operations.ResolveTaskInput(task, hctx.RepoRoot)
 
 		keepBranch := req.GetBool("keep_branch", false)

--- a/internal/mcp/tool_remove_test.go
+++ b/internal/mcp/tool_remove_test.go
@@ -19,6 +19,22 @@ func TestRemoveToolRequiresTask(t *testing.T) {
 	}
 }
 
+func TestRemoveToolRequiresConfig(t *testing.T) {
+	hctx := &HandlerContext{
+		Runner:   &mockRunner{},
+		Config:   nil,
+		RepoRoot: "/repo",
+		Version:  "test",
+	}
+	handler := handleRemove(hctx)
+
+	result := callTool(t, handler, map[string]any{"task": "login"})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, errConfigRequired.Error()) {
+		t.Errorf("expected config required error, got: %s", errText)
+	}
+}
+
 func TestRemoveToolNotFound(t *testing.T) {
 	porcelain := worktreePorcelain(
 		struct{ path, branch string }{"/repo", "main"},

--- a/internal/mcp/tool_status.go
+++ b/internal/mcp/tool_status.go
@@ -35,7 +35,12 @@ func handleStatus(hctx *HandlerContext) server.ToolHandlerFunc {
 		staleDays := req.GetInt("stale_days", 14)
 		r := hctx.Runner
 
-		mainBranch, err := operations.ResolveMainBranch(ctx, r, configDefault(hctx))
+		cfg, cfgErr := hctx.requireConfig()
+		if cfgErr != nil {
+			return mcp.NewToolResultError(cfgErr.Error()), nil
+		}
+
+		mainBranch, err := operations.ResolveMainBranch(ctx, r, cfg.DefaultSource)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}

--- a/internal/mcp/tool_status_test.go
+++ b/internal/mcp/tool_status_test.go
@@ -108,36 +108,19 @@ func TestStatusToolResolvesMainBranch(t *testing.T) {
 	}
 }
 
-func TestStatusToolNoConfig(t *testing.T) {
-	r := &mockRunner{
-		run: func(args ...string) (string, error) {
-			if len(args) > 0 && args[0] == gitSymbolicRef {
-				return refsOriginMain, nil
-			}
-			if len(args) > 0 && args[0] == gitWorktree {
-				return worktreePorcelain(
-					struct{ path, branch string }{"/repo", "main"},
-				), nil
-			}
-			return "", nil
-		},
-	}
+func TestStatusToolRequiresConfig(t *testing.T) {
 	hctx := &HandlerContext{
-		Runner:   r,
+		Runner:   &mockRunner{},
 		Config:   nil,
 		RepoRoot: "/repo",
 		Version:  "test",
 	}
 	handler := handleStatus(hctx)
 
-	// Status should work without config (uses git detection)
 	result := callTool(t, handler, nil)
-	if result.IsError {
-		errMsg := resultError(t, result)
-		// Only fail if the error is about config — git detection errors are acceptable
-		if strings.Contains(errMsg, "not initialized") {
-			t.Errorf("status should work without config, got: %s", errMsg)
-		}
+	errText := resultError(t, result)
+	if !strings.Contains(errText, errConfigRequired.Error()) {
+		t.Errorf("expected config required error, got: %s", errText)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Require initialized rimba config before MCP `clean`, `remove`, and `status` handlers do any work.
- Reuse the loaded config's default source for `clean`/`status` main-branch resolution.
- Add regression coverage for the uninitialized-repo path on all three MCP tools.

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

Additional focused checks run:

```bash
GOPROXY=https://goproxy.cn,direct go test ./internal/mcp -run 'RequiresConfig' -count=1
GOPROXY=https://goproxy.cn,direct go test ./internal/mcp -count=1
GOPROXY=https://goproxy.cn,direct go test ./... -count=1
```

Risk and scope: scoped to MCP handler preflight checks and tests. Existing required-argument errors still run before the config gate, while valid tool calls now fail with the same friendly initialization message used by the other MCP tools when `.rimba/settings.toml` is unavailable.

## Issue

Closes #267
