### PR TITLE
[fix] Thread context through the git package (#283)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -56,7 +56,7 @@ main repo and is not the default branch. --source is not valid in branch: mode.`
 
 		r := newRunner()
 
-		repoRoot, err := git.MainRepoRoot(r)
+		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
 			return err
 		}

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -30,7 +30,7 @@ var archiveCmd = &cobra.Command{
 		task := args[0]
 		r := newRunner()
 
-		wt, err := findWorktree(r, task)
+		wt, err := findWorktree(cmd.Context(), r, task)
 		if err != nil {
 			return err
 		}
@@ -47,7 +47,7 @@ var archiveCmd = &cobra.Command{
 		defer s.Stop()
 
 		s.Start("Archiving worktree...")
-		result, err := operations.ArchiveWorktree(r, operations.ArchiveParams{
+		result, err := operations.ArchiveWorktree(cmd.Context(), r, operations.ArchiveParams{
 			Path:   wt.Path,
 			Branch: wt.Branch,
 			Force:  force,

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -74,7 +74,7 @@ func cleanPrune(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 	defer s.Stop()
 
 	s.Start("Pruning stale references...")
-	out, err := git.Prune(r, dryRun)
+	out, err := git.Prune(ctx, r, dryRun)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func cleanPrune(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 // Skips gracefully when there are no remotes; warns and continues on per-remote failure.
 func cleanRemotePrune(ctx context.Context, cmd *cobra.Command, r git.Runner, s *spinner.Spinner, dryRun bool) error {
 	s.Start("Pruning remote-tracking refs...")
-	remotes, err := git.ListRemotes(r)
+	remotes, err := git.ListRemotes(ctx, r)
 	if err != nil {
 		s.Stop()
 		return err
@@ -133,8 +133,8 @@ type hintEntry struct {
 }
 
 // cleanResolveAndHint resolves the main branch and shows relevant flag hints.
-func cleanResolveAndHint(cmd *cobra.Command, r git.Runner, entries []hintEntry) (string, error) {
-	mainBranch, err := resolveMainBranch(r)
+func cleanResolveAndHint(ctx context.Context, cmd *cobra.Command, r git.Runner, entries []hintEntry) (string, error) {
+	mainBranch, err := resolveMainBranch(ctx, r)
 	if err != nil {
 		return "", err
 	}
@@ -207,7 +207,7 @@ func runClean(ctx context.Context, cmd *cobra.Command, r git.Runner, s cleanStra
 }
 
 func cleanMerged(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
-	mainBranch, err := cleanResolveAndHint(cmd, r, []hintEntry{
+	mainBranch, err := cleanResolveAndHint(ctx, cmd, r, []hintEntry{
 		{flagDryRun, hintDryRunClean},
 		{flagForce, hintForce},
 	})
@@ -215,7 +215,7 @@ func cleanMerged(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 		return err
 	}
 
-	remotePresent := git.RemoteExists(r, git.DefaultRemote)
+	remotePresent := git.RemoteExists(ctx, r, git.DefaultRemote)
 	var mergeRef string
 	return runClean(ctx, cmd, r, cleanStrategy{
 		label:         "merged",
@@ -229,7 +229,7 @@ func cleanMerged(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 			return err
 		},
 		find: func(rr git.Runner) ([]operations.CleanCandidate, []string, error) {
-			result, err := operations.FindMergedCandidates(rr, mergeRef, mainBranch)
+			result, err := operations.FindMergedCandidates(ctx, rr, mergeRef, mainBranch)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -242,7 +242,7 @@ func cleanMerged(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 }
 
 func cleanStale(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
-	mainBranch, err := cleanResolveAndHint(cmd, r, []hintEntry{
+	mainBranch, err := cleanResolveAndHint(ctx, cmd, r, []hintEntry{
 		{flagDryRun, hintDryRunClean},
 		{flagForce, hintForce},
 		{flagStaleDays, "Customize the staleness threshold (default: 14 days)"},
@@ -260,7 +260,7 @@ func cleanStale(ctx context.Context, cmd *cobra.Command, r git.Runner) error {
 		summaryFmt:    "Cleaned %d stale worktree(s).\n",
 		originPresent: false, // stale mode is local-only
 		find: func(rr git.Runner) ([]operations.CleanCandidate, []string, error) {
-			result, err := operations.FindStaleCandidates(rr, mainBranch, staleDays)
+			result, err := operations.FindStaleCandidates(ctx, rr, mainBranch, staleDays)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -47,7 +48,7 @@ func init() {
 // completeWorktreeTasks returns task names for shell completion.
 func completeWorktreeTasks(_ *cobra.Command, toComplete string) []string {
 	r := newRunner()
-	entries, err := git.ListWorktrees(r)
+	entries, err := git.ListWorktrees(context.Background(), r)
 	if err != nil {
 		return nil
 	}
@@ -86,10 +87,11 @@ func completeOpenShortcuts(cmd *cobra.Command, toComplete string) []string {
 // completeArchivedTasks returns task names from archived branches (branches not in any active worktree).
 func completeArchivedTasks(_ *cobra.Command, toComplete string) []string {
 	r := newRunner()
+	ctx := context.Background()
 
-	mainBranch, _ := resolveMainBranch(r)
+	mainBranch, _ := resolveMainBranch(ctx, r)
 
-	archived, err := operations.ListArchivedBranches(r, mainBranch)
+	archived, err := operations.ListArchivedBranches(ctx, r, mainBranch)
 	if err != nil {
 		return nil
 	}
@@ -108,7 +110,7 @@ func completeArchivedTasks(_ *cobra.Command, toComplete string) []string {
 // completeBranchNames returns branch names for shell completion.
 func completeBranchNames(_ *cobra.Command, toComplete string) []string {
 	r := newRunner()
-	out, err := r.Run("branch", "--format=%(refname:short)")
+	out, err := r.RunContext(context.Background(), "branch", "--format=%(refname:short)")
 	if err != nil {
 		return nil
 	}

--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -110,7 +110,7 @@ func completeArchivedTasks(_ *cobra.Command, toComplete string) []string {
 // completeBranchNames returns branch names for shell completion.
 func completeBranchNames(_ *cobra.Command, toComplete string) []string {
 	r := newRunner()
-	out, err := r.RunContext(context.Background(), "branch", "--format=%(refname:short)")
+	out, err := r.Run(context.Background(), "branch", "--format=%(refname:short)")
 	if err != nil {
 		return nil
 	}

--- a/cmd/conflict_check.go
+++ b/cmd/conflict_check.go
@@ -39,7 +39,7 @@ var conflictCheckCmd = &cobra.Command{
 
 		r := newRunner()
 
-		worktrees, err := listWorktreeInfos(r)
+		worktrees, err := listWorktreeInfos(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
@@ -68,7 +68,7 @@ var conflictCheckCmd = &cobra.Command{
 		defer s.Stop()
 		s.Start("Collecting file changes...")
 
-		diffs, err := conflict.CollectDiffs(r, cfg.DefaultSource, eligible)
+		diffs, err := conflict.CollectDiffs(cmd.Context(), r, cfg.DefaultSource, eligible)
 		if err != nil {
 			return err
 		}
@@ -79,7 +79,7 @@ var conflictCheckCmd = &cobra.Command{
 		var dryResults []conflict.DryMergeResult
 		if dryMerge {
 			s.Update("Running dry merges...")
-			dryResults, err = conflict.DryMergeAll(r, eligible)
+			dryResults, err = conflict.DryMergeAll(cmd.Context(), r, eligible)
 			if err != nil {
 				return err
 			}

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -35,7 +35,7 @@ var depsStatusCmd = &cobra.Command{
 		cfg := config.FromContext(cmd.Context())
 
 		r := newRunner()
-		worktrees, err := listWorktreeInfos(r)
+		worktrees, err := listWorktreeInfos(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
@@ -141,12 +141,12 @@ var depsInstallCmd = &cobra.Command{
 
 		r := newRunner()
 
-		repoRoot, err := git.MainRepoRoot(r)
+		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
 
-		worktrees, err := listWorktreeInfos(r)
+		worktrees, err := listWorktreeInfos(cmd.Context(), r)
 		if err != nil {
 			return err
 		}

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -41,13 +41,14 @@ var duplicateCmd = &cobra.Command{
 		cfg := config.FromContext(cmd.Context())
 
 		r := newRunner()
+		ctx := cmd.Context()
 
-		repoRoot, err := git.MainRepoRoot(r)
+		repoRoot, err := git.MainRepoRoot(ctx, r)
 		if err != nil {
 			return err
 		}
 
-		wt, err := findWorktree(r, task)
+		wt, err := findWorktree(ctx, r, task)
 		if err != nil {
 			return err
 		}
@@ -75,7 +76,7 @@ var duplicateCmd = &cobra.Command{
 			for i := 1; i <= maxDuplicateSuffix; i++ {
 				candidate := fmt.Sprintf("%s-%d", task, i)
 				candidateBranch := resolver.FullBranchName(svc, matchedPrefix, candidate)
-				if !git.BranchExists(r, candidateBranch) {
+				if !git.BranchExists(ctx, r, candidateBranch) {
 					newTask = candidate
 					break
 				}
@@ -90,7 +91,7 @@ var duplicateCmd = &cobra.Command{
 		wtPath := resolver.WorktreePath(wtDir, newBranch)
 
 		// Validate
-		if git.BranchExists(r, newBranch) {
+		if git.BranchExists(ctx, r, newBranch) {
 			return fmt.Errorf("branch %q already exists", newBranch)
 		}
 		if _, err := os.Stat(wtPath); err == nil {
@@ -132,7 +133,7 @@ var duplicateCmd = &cobra.Command{
 
 		// Create worktree from source branch
 		s.Start("Creating worktree...")
-		if err := git.AddWorktree(r, wtPath, newBranch, wt.Branch); err != nil {
+		if err := git.AddWorktree(ctx, r, wtPath, newBranch, wt.Branch); err != nil {
 			return err
 		}
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -146,8 +147,9 @@ func execShowHints(cmd *cobra.Command) {
 }
 
 func execSelectWorktrees(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, opts execOpts, prefixes []string) ([]resolver.WorktreeInfo, error) {
-	cfg := config.FromContext(cmd.Context())
-	worktrees, err := listWorktreeInfos(r)
+	ctx := cmd.Context()
+	cfg := config.FromContext(ctx)
+	worktrees, err := listWorktreeInfos(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +163,7 @@ func execSelectWorktrees(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, o
 	}
 
 	if opts.dirty {
-		filtered = filterDirtyWorktrees(cmd, r, s, filtered)
+		filtered = filterDirtyWorktrees(ctx, cmd, r, s, filtered)
 	}
 	return filtered, nil
 }
@@ -233,13 +235,13 @@ func init() {
 // filterDirtyWorktrees filters worktrees to only those with uncommitted changes.
 // If IsDirty returns an error for a worktree, it is treated as dirty (included)
 // and a warning is emitted to cmd.ErrOrStderr() so the error is visible.
-func filterDirtyWorktrees(cmd *cobra.Command, r git.Runner, s *spinner.Spinner, worktrees []resolver.WorktreeInfo) []resolver.WorktreeInfo {
+func filterDirtyWorktrees(ctx context.Context, cmd *cobra.Command, r git.Runner, s *spinner.Spinner, worktrees []resolver.WorktreeInfo) []resolver.WorktreeInfo {
 	n := len(worktrees)
 	var done atomic.Int32
 
 	results := parallel.Collect[dirtyResult](n, 8, func(i int) dirtyResult {
 		path := worktrees[i].Path
-		dirty, err := git.IsDirty(r, path)
+		dirty, err := git.IsDirty(ctx, r, path)
 		count := done.Add(1)
 		s.Update(fmt.Sprintf("Checking dirty status... (%d/%d)", count, n))
 		if err != nil {

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -234,7 +234,7 @@ func TestFilterDirtyWorktrees(t *testing.T) {
 	s := testExecSpinner(cmd)
 	defer s.Stop()
 
-	result := filterDirtyWorktrees(cmd, r, s, worktrees)
+	result := filterDirtyWorktrees(context.Background(), cmd, r, s, worktrees)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 dirty worktree, got %d", len(result))
 	}
@@ -262,7 +262,7 @@ func TestFilterDirtyWorktreesIsDirtyErrorIncludedAndWarned(t *testing.T) {
 	s := testExecSpinner(cmd)
 	defer s.Stop()
 
-	result := filterDirtyWorktrees(cmd, r, s, worktrees)
+	result := filterDirtyWorktrees(context.Background(), cmd, r, s, worktrees)
 
 	if len(result) != 1 {
 		t.Fatalf("expected erroring worktree to be included (treated as dirty), got %d", len(result))

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"io"
 
 	"github.com/lugassawan/rimba/internal/config"
@@ -44,8 +45,8 @@ func spinnerOpts(cmd *cobra.Command) spinner.Options {
 }
 
 // resolveMainBranch tries to get the main branch from config, falling back to DefaultBranch.
-func resolveMainBranch(r git.Runner) (string, error) {
-	repoRoot, err := git.MainRepoRoot(r)
+func resolveMainBranch(ctx context.Context, r git.Runner) (string, error) {
+	repoRoot, err := git.MainRepoRoot(ctx, r)
 	if err != nil {
 		return "", err
 	}
@@ -55,21 +56,21 @@ func resolveMainBranch(r git.Runner) (string, error) {
 		configDefault = cfg.DefaultSource
 	}
 
-	return operations.ResolveMainBranch(r, configDefault)
+	return operations.ResolveMainBranch(ctx, r, configDefault)
 }
 
 // listWorktreeInfos converts git worktree entries to resolver-compatible WorktreeInfo slice.
-func listWorktreeInfos(r git.Runner) ([]resolver.WorktreeInfo, error) {
-	return operations.ListWorktreeInfos(r)
+func listWorktreeInfos(ctx context.Context, r git.Runner) ([]resolver.WorktreeInfo, error) {
+	return operations.ListWorktreeInfos(ctx, r)
 }
 
 // findWorktree looks up a worktree by user input (task or service/task).
 // It resolves the input to detect monorepo service names.
-func findWorktree(r git.Runner, input string) (resolver.WorktreeInfo, error) {
-	repoRoot, err := git.MainRepoRoot(r)
+func findWorktree(ctx context.Context, r git.Runner, input string) (resolver.WorktreeInfo, error) {
+	repoRoot, err := git.MainRepoRoot(ctx, r)
 	if err != nil {
-		return operations.FindWorktree(r, "", input)
+		return operations.FindWorktree(ctx, r, "", input)
 	}
 	service, task := operations.ResolveTaskInput(input, repoRoot)
-	return operations.FindWorktree(r, service, task)
+	return operations.FindWorktree(ctx, r, service, task)
 }

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -55,7 +56,7 @@ func TestResolveMainBranchFromConfig(t *testing.T) {
 	}
 
 	r := repoRootRunner(dir, nil)
-	branch, err := resolveMainBranch(r)
+	branch, err := resolveMainBranch(context.Background(), r)
 	if err != nil {
 		t.Fatalf("resolveMainBranch: %v", err)
 	}
@@ -76,7 +77,7 @@ func TestResolveMainBranchFromDirConfig(t *testing.T) {
 	}
 
 	r := repoRootRunner(dir, nil)
-	branch, err := resolveMainBranch(r)
+	branch, err := resolveMainBranch(context.Background(), r)
 	if err != nil {
 		t.Fatalf("resolveMainBranch: %v", err)
 	}
@@ -95,7 +96,7 @@ func TestResolveMainBranchFallback(t *testing.T) {
 		return "", errors.New("unexpected")
 	})
 
-	branch, err := resolveMainBranch(r)
+	branch, err := resolveMainBranch(context.Background(), r)
 	if err != nil {
 		t.Fatalf("resolveMainBranch: %v", err)
 	}
@@ -109,7 +110,7 @@ func TestResolveMainBranchError(t *testing.T) {
 		run:      func(_ ...string) (string, error) { return "", errors.New("not a git repo") },
 		runInDir: noopRunInDir,
 	}
-	if _, err := resolveMainBranch(r); err == nil {
+	if _, err := resolveMainBranch(context.Background(), r); err == nil {
 		t.Fatal(errExpected)
 	}
 }
@@ -131,7 +132,7 @@ func TestListWorktreeInfos(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	infos, err := listWorktreeInfos(r)
+	infos, err := listWorktreeInfos(context.Background(), r)
 	if err != nil {
 		t.Fatalf("listWorktreeInfos: %v", err)
 	}
@@ -151,7 +152,7 @@ func TestListWorktreeInfosError(t *testing.T) {
 		run:      func(_ ...string) (string, error) { return "", errGitFailed },
 		runInDir: noopRunInDir,
 	}
-	if _, err := listWorktreeInfos(r); err == nil {
+	if _, err := listWorktreeInfos(context.Background(), r); err == nil {
 		t.Fatal(errExpected)
 	}
 }
@@ -174,7 +175,7 @@ func TestFindWorktree(t *testing.T) {
 	}
 
 	t.Run("found", func(t *testing.T) {
-		wt, err := findWorktree(r, "login")
+		wt, err := findWorktree(context.Background(), r, "login")
 		if err != nil {
 			t.Fatalf("findWorktree: %v", err)
 		}
@@ -184,7 +185,7 @@ func TestFindWorktree(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		if _, err := findWorktree(r, "nonexistent"); err == nil {
+		if _, err := findWorktree(context.Background(), r, "nonexistent"); err == nil {
 			t.Fatal("expected error for missing worktree")
 		}
 	})
@@ -195,7 +196,7 @@ func TestFindWorktreeError(t *testing.T) {
 		run:      func(_ ...string) (string, error) { return "", errGitFailed },
 		runInDir: noopRunInDir,
 	}
-	if _, err := findWorktree(r, "login"); err == nil {
+	if _, err := findWorktree(context.Background(), r, "login"); err == nil {
 		t.Fatal(errExpected)
 	}
 }

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -23,12 +23,12 @@ var hookInstallCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
 
-		branch, err := resolveMainBranch(r)
+		branch, err := resolveMainBranch(cmd.Context(), r)
 		if err != nil {
 			return fmt.Errorf("resolve main branch: %w", err)
 		}
 
-		hooksDir, err := git.HooksDir(r)
+		hooksDir, err := git.HooksDir(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
@@ -66,7 +66,7 @@ var hookUninstallCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
 
-		hooksDir, err := git.HooksDir(r)
+		hooksDir, err := git.HooksDir(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
@@ -110,7 +110,7 @@ var hookStatusCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
 
-		hooksDir, err := git.HooksDir(r)
+		hooksDir, err := git.HooksDir(cmd.Context(), r)
 		if err != nil {
 			return err
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -73,7 +74,8 @@ register MCP — it only updates agent files. Registration is idempotent.`,
 
 		r := newRunner()
 
-		repoRoot, err := git.RepoRoot(r)
+		ctx := cmd.Context()
+		repoRoot, err := git.RepoRoot(ctx, r)
 		if err != nil {
 			return err
 		}
@@ -104,7 +106,7 @@ register MCP — it only updates agent files. Registration is idempotent.`,
 			}
 
 		default:
-			if err := runInitFresh(cmd, r, repoRoot, dirPath, gitignoreEntry, personal); err != nil {
+			if err := runInitFresh(cmd, ctx, r, repoRoot, dirPath, gitignoreEntry, personal); err != nil {
 				return err
 			}
 		}
@@ -118,13 +120,13 @@ register MCP — it only updates agent files. Registration is idempotent.`,
 	},
 }
 
-func runInitFresh(cmd *cobra.Command, r git.Runner, repoRoot, dirPath, gitignoreEntry string, personal bool) error {
-	repoName, err := git.RepoName(r)
+func runInitFresh(cmd *cobra.Command, ctx context.Context, r git.Runner, repoRoot, dirPath, gitignoreEntry string, personal bool) error {
+	repoName, err := git.RepoName(ctx, r)
 	if err != nil {
 		return err
 	}
 
-	defaultBranch, err := git.DefaultBranch(r)
+	defaultBranch, err := git.DefaultBranch(ctx, r)
 	if err != nil {
 		return err
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -106,7 +106,7 @@ register MCP — it only updates agent files. Registration is idempotent.`,
 			}
 
 		default:
-			if err := runInitFresh(cmd, ctx, r, repoRoot, dirPath, gitignoreEntry, personal); err != nil {
+			if err := runInitFresh(ctx, cmd, r, repoRoot, dirPath, gitignoreEntry, personal); err != nil {
 				return err
 			}
 		}
@@ -120,7 +120,7 @@ register MCP — it only updates agent files. Registration is idempotent.`,
 	},
 }
 
-func runInitFresh(cmd *cobra.Command, ctx context.Context, r git.Runner, repoRoot, dirPath, gitignoreEntry string, personal bool) error {
+func runInitFresh(ctx context.Context, cmd *cobra.Command, r git.Runner, repoRoot, dirPath, gitignoreEntry string, personal bool) error {
 	repoName, err := git.RepoName(ctx, r)
 	if err != nil {
 		return err

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -47,9 +47,10 @@ and CI rollup. CI symbols: ✓ success · ● pending · ✗ failure · – unkn
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := listReadFlags(cmd)
 
+		ctx := cmd.Context()
 		if opts.archived {
 			r := newRunner()
-			mainBranch, err := resolveMainBranch(r)
+			mainBranch, err := resolveMainBranch(ctx, r)
 			if err != nil {
 				return err
 			}
@@ -62,7 +63,7 @@ and CI rollup. CI symbols: ✓ success · ● pending · ✗ failure · – unkn
 
 		r := newRunner()
 		cfg := config.FromContext(cmd.Context())
-		repoRoot, err := git.MainRepoRoot(r)
+		repoRoot, err := git.MainRepoRoot(ctx, r)
 		if err != nil {
 			return err
 		}

--- a/cmd/list_bench_test.go
+++ b/cmd/list_bench_test.go
@@ -15,21 +15,16 @@ const benchFilterType = "bugfix"
 // benchMockRunner simulates git status calls with minimal overhead.
 type benchMockRunner struct{}
 
-func (m *benchMockRunner) Run(_ ...string) (string, error) { return "", nil }
-func (m *benchMockRunner) RunInDir(_ string, args ...string) (string, error) {
-	// Simulate IsDirty returning clean, AheadBehind returning 0/0
-	if len(args) > 0 && args[0] == cmdRevList {
-		return aheadBehindZero, nil
-	}
-	return "", nil
-}
-
 func (m *benchMockRunner) RunContext(_ context.Context, _ ...string) (string, error) {
 	return "", nil
 }
 
 func (m *benchMockRunner) RunInDirContext(_ context.Context, _ string, args ...string) (string, error) {
-	return m.RunInDir("", args...)
+	// Simulate IsDirty returning clean, AheadBehind returning 0/0
+	if len(args) > 0 && args[0] == cmdRevList {
+		return aheadBehindZero, nil
+	}
+	return "", nil
 }
 
 func makeBenchEntries(n int) []git.WorktreeEntry { //nolint:unparam // n is parameterized for benchmark flexibility
@@ -55,10 +50,10 @@ func BenchmarkListStatusCollectionSequential(b *testing.B) {
 		rows := make([]resolver.WorktreeDetail, 0, len(entries))
 		for _, e := range entries {
 			var status resolver.WorktreeStatus
-			if dirty, err := git.IsDirty(r, e.Path); err == nil && dirty {
+			if dirty, err := git.IsDirty(context.Background(), r, e.Path); err == nil && dirty {
 				status.Dirty = true
 			}
-			ahead, behind, _ := git.AheadBehind(r, e.Path)
+			ahead, behind, _ := git.AheadBehind(context.Background(), r, e.Path)
 			status.Ahead = ahead
 			status.Behind = behind
 			rows = append(rows, resolver.NewWorktreeDetail(e.Branch, prefixes, e.Path, status, false))
@@ -86,10 +81,10 @@ func BenchmarkListStatusCollectionParallel(b *testing.B) {
 				defer func() { <-sem }()
 
 				var status resolver.WorktreeStatus
-				if dirty, err := git.IsDirty(r, e.Path); err == nil && dirty {
+				if dirty, err := git.IsDirty(context.Background(), r, e.Path); err == nil && dirty {
 					status.Dirty = true
 				}
-				ahead, behind, _ := git.AheadBehind(r, e.Path)
+				ahead, behind, _ := git.AheadBehind(context.Background(), r, e.Path)
 				status.Ahead = ahead
 				status.Behind = behind
 				rows[idx] = resolver.NewWorktreeDetail(e.Branch, prefixes, e.Path, status, false)
@@ -123,10 +118,10 @@ func BenchmarkListWithTypeFilter(b *testing.B) {
 		rows := make([]resolver.WorktreeDetail, len(filtered))
 		for i, e := range filtered {
 			var status resolver.WorktreeStatus
-			if dirty, err := git.IsDirty(r, e.Path); err == nil && dirty {
+			if dirty, err := git.IsDirty(context.Background(), r, e.Path); err == nil && dirty {
 				status.Dirty = true
 			}
-			ahead, behind, _ := git.AheadBehind(r, e.Path)
+			ahead, behind, _ := git.AheadBehind(context.Background(), r, e.Path)
 			status.Ahead = ahead
 			status.Behind = behind
 			rows[i] = resolver.NewWorktreeDetail(e.Branch, prefixes, e.Path, status, false)
@@ -146,10 +141,10 @@ func BenchmarkListWithoutTypeFilter(b *testing.B) {
 		rows := make([]resolver.WorktreeDetail, len(entries))
 		for i, e := range entries {
 			var status resolver.WorktreeStatus
-			if dirty, err := git.IsDirty(r, e.Path); err == nil && dirty {
+			if dirty, err := git.IsDirty(context.Background(), r, e.Path); err == nil && dirty {
 				status.Dirty = true
 			}
-			ahead, behind, _ := git.AheadBehind(r, e.Path)
+			ahead, behind, _ := git.AheadBehind(context.Background(), r, e.Path)
 			status.Ahead = ahead
 			status.Behind = behind
 			rows[i] = resolver.NewWorktreeDetail(e.Branch, prefixes, e.Path, status, false)

--- a/cmd/list_bench_test.go
+++ b/cmd/list_bench_test.go
@@ -15,11 +15,11 @@ const benchFilterType = "bugfix"
 // benchMockRunner simulates git status calls with minimal overhead.
 type benchMockRunner struct{}
 
-func (m *benchMockRunner) RunContext(_ context.Context, _ ...string) (string, error) {
+func (m *benchMockRunner) Run(_ context.Context, _ ...string) (string, error) {
 	return "", nil
 }
 
-func (m *benchMockRunner) RunInDirContext(_ context.Context, _ string, args ...string) (string, error) {
+func (m *benchMockRunner) RunInDir(_ context.Context, _ string, args ...string) (string, error) {
 	// Simulate IsDirty returning clean, AheadBehind returning 0/0
 	if len(args) > 0 && args[0] == cmdRevList {
 		return aheadBehindZero, nil

--- a/cmd/list_render.go
+++ b/cmd/list_render.go
@@ -132,7 +132,7 @@ func formatCICell(status gh.CIStatus, p *termcolor.Painter) string {
 }
 
 func listArchivedBranches(cmd *cobra.Command, r git.Runner, mainBranch string) error {
-	archived, err := operations.ListArchivedBranches(r, mainBranch)
+	archived, err := operations.ListArchivedBranches(cmd.Context(), r, mainBranch)
 	if err != nil {
 		return err
 	}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -40,14 +41,15 @@ var logCmd = &cobra.Command{
   rimba log --since 7d --limit 10`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
 		r := newRunner()
 
-		mainBranch, err := resolveMainBranch(r)
+		mainBranch, err := resolveMainBranch(ctx, r)
 		if err != nil {
 			return err
 		}
 
-		entries, err := git.ListWorktrees(r)
+		entries, err := git.ListWorktrees(ctx, r)
 		if err != nil {
 			return err
 		}
@@ -66,7 +68,7 @@ var logCmd = &cobra.Command{
 		defer s.Stop()
 		s.Start("Collecting commit info...")
 
-		valid := collectLogEntries(r, candidates, s)
+		valid := collectLogEntries(ctx, r, candidates, s)
 		s.Stop()
 
 		// Apply --since filter
@@ -120,7 +122,7 @@ func init() {
 
 // collectLogEntries gathers commit info for each candidate in parallel,
 // returning only valid entries sorted by commit time descending.
-func collectLogEntries(r git.Runner, candidates []git.WorktreeEntry, s *spinner.Spinner) []logEntry {
+func collectLogEntries(ctx context.Context, r git.Runner, candidates []git.WorktreeEntry, s *spinner.Spinner) []logEntry {
 	prefixes := resolver.AllPrefixes()
 	s.Update("Collecting commit info...")
 	results := parallel.Collect(len(candidates), 8, func(i int) logEntry {
@@ -128,7 +130,7 @@ func collectLogEntries(r git.Runner, candidates []git.WorktreeEntry, s *spinner.
 		svc, task, matchedPrefix := resolver.ServiceFromBranch(e.Branch, prefixes)
 		typeName := strings.TrimSuffix(matchedPrefix, "/")
 
-		ct, subject, err := git.LastCommitInfo(r, e.Branch)
+		ct, subject, err := git.LastCommitInfo(ctx, r, e.Branch)
 		if err != nil {
 			return logEntry{branch: e.Branch, task: task, service: svc, typeName: typeName, path: e.Path}
 		}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -22,7 +22,7 @@ rimba commands with structured parameters and typed responses.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
 
-		repoRoot, err := git.MainRepoRoot(r)
+		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
@@ -33,7 +33,7 @@ rimba commands with structured parameters and typed responses.`,
 			repoName := filepath.Base(repoRoot)
 			var defaultBranch string
 			if cfg.DefaultSource == "" {
-				defaultBranch, _ = git.DefaultBranch(r)
+				defaultBranch, _ = git.DefaultBranch(cmd.Context(), r)
 			}
 			cfg.FillDefaults(repoName, defaultBranch)
 		}

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -41,7 +41,7 @@ var mergeCmd = &cobra.Command{
 
 		r := newRunner()
 
-		repoRoot, err := git.MainRepoRoot(r)
+		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
 			return err
 		}

--- a/cmd/merge_bench_test.go
+++ b/cmd/merge_bench_test.go
@@ -11,10 +11,10 @@ import (
 // mergeBenchMockRunner simulates IsDirty calls.
 type mergeBenchMockRunner struct{}
 
-func (m *mergeBenchMockRunner) RunContext(_ context.Context, _ ...string) (string, error) {
+func (m *mergeBenchMockRunner) Run(_ context.Context, _ ...string) (string, error) {
 	return "", nil
 }
-func (m *mergeBenchMockRunner) RunInDirContext(_ context.Context, _ string, _ ...string) (string, error) {
+func (m *mergeBenchMockRunner) RunInDir(_ context.Context, _ string, _ ...string) (string, error) {
 	return "", nil
 }
 

--- a/cmd/merge_bench_test.go
+++ b/cmd/merge_bench_test.go
@@ -11,8 +11,6 @@ import (
 // mergeBenchMockRunner simulates IsDirty calls.
 type mergeBenchMockRunner struct{}
 
-func (m *mergeBenchMockRunner) Run(_ ...string) (string, error)                { return "", nil }
-func (m *mergeBenchMockRunner) RunInDir(_ string, _ ...string) (string, error) { return "", nil }
 func (m *mergeBenchMockRunner) RunContext(_ context.Context, _ ...string) (string, error) {
 	return "", nil
 }
@@ -27,8 +25,8 @@ func BenchmarkDirtyChecksSequential(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		_, _ = git.IsDirty(r, srcPath)
-		_, _ = git.IsDirty(r, tgtPath)
+		_, _ = git.IsDirty(context.Background(), r, srcPath)
+		_, _ = git.IsDirty(context.Background(), r, tgtPath)
 	}
 }
 
@@ -47,11 +45,11 @@ func BenchmarkDirtyChecksParallel(b *testing.B) {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			srcResult.dirty, srcResult.err = git.IsDirty(r, srcPath)
+			srcResult.dirty, srcResult.err = git.IsDirty(context.Background(), r, srcPath)
 		}()
 		go func() {
 			defer wg.Done()
-			tgtResult.dirty, tgtResult.err = git.IsDirty(r, tgtPath)
+			tgtResult.dirty, tgtResult.err = git.IsDirty(context.Background(), r, tgtPath)
 		}()
 		wg.Wait()
 		_ = srcResult

--- a/cmd/merge_plan.go
+++ b/cmd/merge_plan.go
@@ -23,7 +23,7 @@ var mergePlanCmd = &cobra.Command{
 
 		r := newRunner()
 
-		worktrees, err := listWorktreeInfos(r)
+		worktrees, err := listWorktreeInfos(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
@@ -41,7 +41,7 @@ var mergePlanCmd = &cobra.Command{
 		defer s.Stop()
 		s.Start("Collecting file changes...")
 
-		diffs, err := conflict.CollectDiffs(r, cfg.DefaultSource, eligible)
+		diffs, err := conflict.CollectDiffs(cmd.Context(), r, cfg.DefaultSource, eligible)
 		if err != nil {
 			return err
 		}

--- a/cmd/mock_runner_test.go
+++ b/cmd/mock_runner_test.go
@@ -86,14 +86,6 @@ type mockRunner struct {
 	runInDir func(dir string, args ...string) (string, error)
 }
 
-func (m *mockRunner) Run(args ...string) (string, error) {
-	return m.run(args...)
-}
-
-func (m *mockRunner) RunInDir(dir string, args ...string) (string, error) {
-	return m.runInDir(dir, args...)
-}
-
 func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
 	return m.run(args...)
 }

--- a/cmd/mock_runner_test.go
+++ b/cmd/mock_runner_test.go
@@ -86,11 +86,11 @@ type mockRunner struct {
 	runInDir func(dir string, args ...string) (string, error)
 }
 
-func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
+func (m *mockRunner) Run(_ context.Context, args ...string) (string, error) {
 	return m.run(args...)
 }
 
-func (m *mockRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
+func (m *mockRunner) RunInDir(_ context.Context, dir string, args ...string) (string, error) {
 	return m.runInDir(dir, args...)
 }
 

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -50,7 +50,7 @@ Shortcuts are configured in .rimba/settings.toml:
 		task := args[0]
 		r := newRunner()
 
-		wt, err := findWorktree(r, task)
+		wt, err := findWorktree(cmd.Context(), r, task)
 		if err != nil {
 			return err
 		}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -35,7 +35,7 @@ var removeCmd = &cobra.Command{
 		task := args[0]
 		r := newRunner()
 
-		wt, err := findWorktree(r, task)
+		wt, err := findWorktree(cmd.Context(), r, task)
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ var removeCmd = &cobra.Command{
 		defer s.Stop()
 		s.Start("Removing worktree...")
 
-		result, err := operations.RemoveWorktree(r, wt, task, keepBranch, force, func(msg string) {
+		result, err := operations.RemoveWorktree(cmd.Context(), r, wt, task, keepBranch, force, func(msg string) {
 			s.Update(msg)
 		})
 		if err != nil {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -34,12 +34,12 @@ var renameCmd = &cobra.Command{
 
 		r := newRunner()
 
-		repoRoot, err := git.MainRepoRoot(r)
+		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
 
-		wt, err := findWorktree(r, task)
+		wt, err := findWorktree(cmd.Context(), r, task)
 		if err != nil {
 			return err
 		}
@@ -66,7 +66,7 @@ var renameCmd = &cobra.Command{
 		force, _ := cmd.Flags().GetBool(flagForce)
 		s.Start("Renaming worktree...")
 
-		result, err := operations.RenameWorktree(r, wt, newTask, wtDir, force)
+		result, err := operations.RenameWorktree(cmd.Context(), r, wt, newTask, wtDir, force)
 		if err != nil {
 			return err
 		}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -35,7 +35,7 @@ to see available archived branches.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		r := newRunner()
 
-		repoRoot, err := git.MainRepoRoot(r)
+		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
@@ -43,7 +43,7 @@ to see available archived branches.`,
 		service, task := operations.ResolveTaskInput(args[0], repoRoot)
 		cfg := config.FromContext(cmd.Context())
 
-		branch, err := operations.FindArchivedBranch(r, service, task)
+		branch, err := operations.FindArchivedBranch(cmd.Context(), r, service, task)
 		if err != nil {
 			return err
 		}
@@ -65,7 +65,7 @@ to see available archived branches.`,
 
 		// Create worktree from existing branch
 		s.Start("Restoring worktree...")
-		if err := git.AddWorktreeFromBranch(r, wtPath, branch); err != nil {
+		if err := git.AddWorktreeFromBranch(cmd.Context(), r, wtPath, branch); err != nil {
 			return err
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,7 +68,7 @@ Persistent flags (available on every command):
 		}
 
 		r := newRunner()
-		repoRoot, err := git.MainRepoRoot(r)
+		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ Persistent flags (available on every command):
 		repoName := filepath.Base(repoRoot)
 		var defaultBranch string
 		if cfg.DefaultSource == "" {
-			defaultBranch, err = git.DefaultBranch(r)
+			defaultBranch, err = git.DefaultBranch(cmd.Context(), r)
 			if err != nil {
 				return err
 			}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -101,12 +101,12 @@ var syncCmd = &cobra.Command{
 			}
 		}
 
-		repoRoot, err := git.MainRepoRoot(r)
+		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
 
-		worktrees, err := listWorktreeInfos(r)
+		worktrees, err := listWorktreeInfos(cmd.Context(), r)
 		if err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func syncOne(ctx context.Context, sc *syncContext, input string, worktrees []res
 		return fmt.Errorf(operations.ErrWorktreeNotFoundFmt, input)
 	}
 
-	dirty, err := git.IsDirty(sc.r, wt.Path)
+	dirty, err := git.IsDirty(ctx, sc.r, wt.Path)
 	if err != nil {
 		return err
 	}

--- a/cmd/trust.go
+++ b/cmd/trust.go
@@ -31,7 +31,7 @@ Use --yes to approve without prompting (e.g. in CI, combined with RIMBA_TRUST_YE
 		cfg := config.FromContext(cmd.Context())
 
 		r := newRunner()
-		repoRoot, err := git.MainRepoRoot(r)
+		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
 			return err
 		}

--- a/cmd/update_agent_hint.go
+++ b/cmd/update_agent_hint.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -39,7 +40,7 @@ func anyInstalled(statuses []agentfile.FileStatus) bool {
 func resolvePostUpdateTipPaths() (string, string) {
 	home, _ := os.UserHomeDir()
 	var repoRoot string
-	if root, err := git.RepoRoot(newRunner()); err == nil {
+	if root, err := git.RepoRoot(context.Background(), newRunner()); err == nil {
 		repoRoot = root
 	}
 	return home, repoRoot

--- a/internal/conflict/conflict.go
+++ b/internal/conflict/conflict.go
@@ -1,6 +1,7 @@
 package conflict
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -89,7 +90,7 @@ func DetectOverlaps(diffs map[string][]string) *CheckResult {
 }
 
 // CollectDiffs runs git diff --name-only for each branch vs mainBranch, in parallel.
-func CollectDiffs(r git.Runner, mainBranch string, branches []resolver.WorktreeInfo) (map[string][]string, error) {
+func CollectDiffs(ctx context.Context, r git.Runner, mainBranch string, branches []resolver.WorktreeInfo) (map[string][]string, error) {
 	diffs := make(map[string][]string)
 	var mu sync.Mutex
 	var wg sync.WaitGroup
@@ -103,7 +104,7 @@ func CollectDiffs(r git.Runner, mainBranch string, branches []resolver.WorktreeI
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			files, err := git.DiffNameOnly(r, mainBranch, wt.Branch)
+			files, err := git.DiffNameOnly(ctx, r, mainBranch, wt.Branch)
 
 			mu.Lock()
 			defer mu.Unlock()
@@ -127,7 +128,7 @@ func CollectDiffs(r git.Runner, mainBranch string, branches []resolver.WorktreeI
 type pair struct{ i, j int }
 
 // DryMergeAll runs git merge-tree for all unique branch pairs, in parallel.
-func DryMergeAll(r git.Runner, branches []resolver.WorktreeInfo) ([]DryMergeResult, error) {
+func DryMergeAll(ctx context.Context, r git.Runner, branches []resolver.WorktreeInfo) ([]DryMergeResult, error) {
 	var pairs []pair
 	for i := range branches {
 		for j := i + 1; j < len(branches); j++ {
@@ -148,7 +149,7 @@ func DryMergeAll(r git.Runner, branches []resolver.WorktreeInfo) ([]DryMergeResu
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			mt, err := git.MergeTree(r, branches[p.i].Branch, branches[p.j].Branch)
+			mt, err := git.MergeTree(ctx, r, branches[p.i].Branch, branches[p.j].Branch)
 
 			mu.Lock()
 			defer mu.Unlock()

--- a/internal/conflict/conflict_test.go
+++ b/internal/conflict/conflict_test.go
@@ -202,7 +202,7 @@ func TestCollectDiffsSuccess(t *testing.T) {
 		{Branch: "feature/b", Path: "/wt/b"},
 	}
 
-	diffs, err := CollectDiffs(r, "main", branches)
+	diffs, err := CollectDiffs(context.Background(), r, "main", branches)
 	if err != nil {
 		t.Fatalf("CollectDiffs: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestCollectDiffsEmpty(t *testing.T) {
 		},
 	}
 
-	diffs, err := CollectDiffs(r, "main", nil)
+	diffs, err := CollectDiffs(context.Background(), r, "main", nil)
 	if err != nil {
 		t.Fatalf("CollectDiffs: %v", err)
 	}
@@ -244,7 +244,7 @@ func TestCollectDiffsError(t *testing.T) {
 		{Branch: "feature/a", Path: "/wt/a"},
 	}
 
-	_, err := CollectDiffs(r, "main", branches)
+	_, err := CollectDiffs(context.Background(), r, "main", branches)
 	if err == nil {
 		t.Fatal("expected error from CollectDiffs")
 	}
@@ -265,7 +265,7 @@ func TestDryMergeAllClean(t *testing.T) {
 		{Branch: "feature/b", Path: "/wt/b"},
 	}
 
-	results, err := DryMergeAll(r, branches)
+	results, err := DryMergeAll(context.Background(), r, branches)
 	if err != nil {
 		t.Fatalf("DryMergeAll: %v", err)
 	}
@@ -292,7 +292,7 @@ func TestDryMergeAllConflicts(t *testing.T) {
 		{Branch: "feature/b", Path: "/wt/b"},
 	}
 
-	results, err := DryMergeAll(r, branches)
+	results, err := DryMergeAll(context.Background(), r, branches)
 	if err != nil {
 		t.Fatalf("DryMergeAll: %v", err)
 	}
@@ -319,7 +319,7 @@ func TestDryMergeAllError(t *testing.T) {
 		{Branch: "feature/b", Path: "/wt/b"},
 	}
 
-	_, err := DryMergeAll(r, branches)
+	_, err := DryMergeAll(context.Background(), r, branches)
 	if err == nil {
 		t.Fatal("expected error from DryMergeAll")
 	}
@@ -338,7 +338,7 @@ func TestDryMergeAllThreeBranches(t *testing.T) {
 		{Branch: "feature/c", Path: "/wt/c"},
 	}
 
-	results, err := DryMergeAll(r, branches)
+	results, err := DryMergeAll(context.Background(), r, branches)
 	if err != nil {
 		t.Fatalf("DryMergeAll: %v", err)
 	}
@@ -380,7 +380,7 @@ func TestDryMergeAllEmpty(t *testing.T) {
 		},
 	}
 
-	results, err := DryMergeAll(r, nil)
+	results, err := DryMergeAll(context.Background(), r, nil)
 	if err != nil {
 		t.Fatalf("DryMergeAll: %v", err)
 	}

--- a/internal/conflict/conflict_test.go
+++ b/internal/conflict/conflict_test.go
@@ -14,19 +14,11 @@ type mockRunner struct {
 	run func(args ...string) (string, error)
 }
 
-func (m *mockRunner) Run(args ...string) (string, error) {
+func (m *mockRunner) Run(_ context.Context, args ...string) (string, error) {
 	return m.run(args...)
 }
 
-func (m *mockRunner) RunInDir(_ string, _ ...string) (string, error) {
-	return "", nil
-}
-
-func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
-	return m.run(args...)
-}
-
-func (m *mockRunner) RunInDirContext(_ context.Context, _ string, _ ...string) (string, error) {
+func (m *mockRunner) RunInDir(_ context.Context, _ string, _ ...string) (string, error) {
 	return "", nil
 }
 

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -37,18 +37,18 @@ type TimedRunner struct {
 	Inner git.Runner
 }
 
-func (r *TimedRunner) RunContext(ctx context.Context, args ...string) (string, error) {
+func (r *TimedRunner) Run(ctx context.Context, args ...string) (string, error) {
 	label := "git " + strings.Join(args, " ")
 	start := time.Now()
-	out, err := r.Inner.RunContext(ctx, args...)
+	out, err := r.Inner.Run(ctx, args...)
 	logf("%s: %s", label, time.Since(start).Round(time.Millisecond))
 	return out, err
 }
 
-func (r *TimedRunner) RunInDirContext(ctx context.Context, dir string, args ...string) (string, error) {
+func (r *TimedRunner) RunInDir(ctx context.Context, dir string, args ...string) (string, error) {
 	label := fmt.Sprintf("git %s [%s]", strings.Join(args, " "), filepath.Base(dir))
 	start := time.Now()
-	out, err := r.Inner.RunInDirContext(ctx, dir, args...)
+	out, err := r.Inner.RunInDir(ctx, dir, args...)
 	logf("%s: %s", label, time.Since(start).Round(time.Millisecond))
 	return out, err
 }

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -37,22 +37,6 @@ type TimedRunner struct {
 	Inner git.Runner
 }
 
-func (r *TimedRunner) Run(args ...string) (string, error) {
-	label := "git " + strings.Join(args, " ")
-	start := time.Now()
-	out, err := r.Inner.Run(args...)
-	logf("%s: %s", label, time.Since(start).Round(time.Millisecond))
-	return out, err
-}
-
-func (r *TimedRunner) RunInDir(dir string, args ...string) (string, error) {
-	label := fmt.Sprintf("git %s [%s]", strings.Join(args, " "), filepath.Base(dir))
-	start := time.Now()
-	out, err := r.Inner.RunInDir(dir, args...)
-	logf("%s: %s", label, time.Since(start).Round(time.Millisecond))
-	return out, err
-}
-
 func (r *TimedRunner) RunContext(ctx context.Context, args ...string) (string, error) {
 	label := "git " + strings.Join(args, " ")
 	start := time.Now()

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -13,12 +13,12 @@ type stubRunner struct {
 	runInDirCtxCalled bool
 }
 
-func (s *stubRunner) RunContext(_ context.Context, args ...string) (string, error) {
+func (s *stubRunner) Run(_ context.Context, args ...string) (string, error) {
 	s.runContextCalled = true
 	return "ok", nil
 }
 
-func (s *stubRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
+func (s *stubRunner) RunInDir(_ context.Context, dir string, args ...string) (string, error) {
 	s.runInDirCtxCalled = true
 	return "ok", nil
 }
@@ -88,13 +88,13 @@ func TestStartTimerDisabled(t *testing.T) {
 	}
 }
 
-func TestTimedRunnerRunContext(t *testing.T) {
+func TestTimedRunnerRun(t *testing.T) {
 	t.Setenv("RIMBA_DEBUG", "1")
 
 	stub := &stubRunner{}
 	wrapped := WrapRunner(stub)
 
-	out, err := wrapped.RunContext(context.Background(), "status")
+	out, err := wrapped.Run(context.Background(), "status")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,17 +102,17 @@ func TestTimedRunnerRunContext(t *testing.T) {
 		t.Errorf("expected ok, got %s", out)
 	}
 	if !stub.runContextCalled {
-		t.Error("inner runner RunContext was not called")
+		t.Error("inner runner Run was not called")
 	}
 }
 
-func TestTimedRunnerRunInDirContext(t *testing.T) {
+func TestTimedRunnerRunInDir(t *testing.T) {
 	t.Setenv("RIMBA_DEBUG", "1")
 
 	stub := &stubRunner{}
 	wrapped := WrapRunner(stub)
 
-	out, err := wrapped.RunInDirContext(context.Background(), "/tmp/test", "status")
+	out, err := wrapped.RunInDir(context.Background(), "/tmp/test", "status")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,6 +120,6 @@ func TestTimedRunnerRunInDirContext(t *testing.T) {
 		t.Errorf("expected ok, got %s", out)
 	}
 	if !stub.runInDirCtxCalled {
-		t.Error("inner runner RunInDirContext was not called")
+		t.Error("inner runner RunInDir was not called")
 	}
 }

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -9,20 +9,8 @@ import (
 )
 
 type stubRunner struct {
-	runCalled         bool
-	runInDirCalled    bool
 	runContextCalled  bool
 	runInDirCtxCalled bool
-}
-
-func (s *stubRunner) Run(args ...string) (string, error) {
-	s.runCalled = true
-	return "ok", nil
-}
-
-func (s *stubRunner) RunInDir(dir string, args ...string) (string, error) {
-	s.runInDirCalled = true
-	return "ok", nil
 }
 
 func (s *stubRunner) RunContext(_ context.Context, args ...string) (string, error) {
@@ -55,42 +43,6 @@ func TestWrapRunnerDisabled(t *testing.T) {
 
 	if wrapped != stub {
 		t.Error("expected original runner returned when RIMBA_DEBUG is unset")
-	}
-}
-
-func TestTimedRunnerRun(t *testing.T) {
-	t.Setenv("RIMBA_DEBUG", "1")
-
-	stub := &stubRunner{}
-	wrapped := WrapRunner(stub)
-
-	out, err := wrapped.Run("status")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if out != "ok" {
-		t.Errorf("expected ok, got %s", out)
-	}
-	if !stub.runCalled {
-		t.Error("inner runner Run was not called")
-	}
-}
-
-func TestTimedRunnerRunInDir(t *testing.T) {
-	t.Setenv("RIMBA_DEBUG", "1")
-
-	stub := &stubRunner{}
-	wrapped := WrapRunner(stub)
-
-	out, err := wrapped.RunInDir("/tmp/test", "status")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if out != "ok" {
-		t.Errorf("expected ok, got %s", out)
-	}
-	if !stub.runInDirCalled {
-		t.Error("inner runner RunInDir was not called")
 	}
 }
 

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -9,17 +9,17 @@ import (
 )
 
 type stubRunner struct {
-	runContextCalled  bool
-	runInDirCtxCalled bool
+	runCalled      bool
+	runInDirCalled bool
 }
 
 func (s *stubRunner) Run(_ context.Context, args ...string) (string, error) {
-	s.runContextCalled = true
+	s.runCalled = true
 	return "ok", nil
 }
 
 func (s *stubRunner) RunInDir(_ context.Context, dir string, args ...string) (string, error) {
-	s.runInDirCtxCalled = true
+	s.runInDirCalled = true
 	return "ok", nil
 }
 
@@ -101,7 +101,7 @@ func TestTimedRunnerRun(t *testing.T) {
 	if out != "ok" {
 		t.Errorf("expected ok, got %s", out)
 	}
-	if !stub.runContextCalled {
+	if !stub.runCalled {
 		t.Error("inner runner Run was not called")
 	}
 }
@@ -119,7 +119,7 @@ func TestTimedRunnerRunInDir(t *testing.T) {
 	if out != "ok" {
 		t.Errorf("expected ok, got %s", out)
 	}
-	if !stub.runInDirCtxCalled {
+	if !stub.runInDirCalled {
 		t.Error("inner runner RunInDir was not called")
 	}
 }

--- a/internal/deps/manager.go
+++ b/internal/deps/manager.go
@@ -90,7 +90,7 @@ func (m *Manager) install(ctx context.Context, worktreePath, sourceWT string, mo
 
 	entries := existingEntries
 	if entries == nil {
-		entries, err = git.ListWorktrees(m.Runner)
+		entries, err = git.ListWorktrees(ctx, m.Runner)
 		if err != nil {
 			for _, mod := range modules {
 				results = append(results, InstallResult{Module: mod, Error: err})

--- a/internal/deps/manager_test.go
+++ b/internal/deps/manager_test.go
@@ -35,20 +35,12 @@ type mockRunner struct {
 
 var errGitFailed = errors.New("git worktree list failed")
 
-func (m *mockRunner) Run(args ...string) (string, error) {
+func (m *mockRunner) Run(_ context.Context, args ...string) (string, error) {
 	return m.worktreeOutput, nil
 }
 
-func (m *mockRunner) RunInDir(dir string, args ...string) (string, error) {
-	return m.Run(args...)
-}
-
-func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
-	return m.Run(args...)
-}
-
-func (m *mockRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
-	return m.Run(args...)
+func (m *mockRunner) RunInDir(_ context.Context, dir string, args ...string) (string, error) {
+	return m.worktreeOutput, nil
 }
 
 func mockWorktreeList(paths ...string) string {
@@ -614,10 +606,8 @@ type errorRunner struct {
 	err error
 }
 
-func (e *errorRunner) Run(_ ...string) (string, error)                           { return "", e.err }
-func (e *errorRunner) RunInDir(_ string, _ ...string) (string, error)            { return "", e.err }
-func (e *errorRunner) RunContext(_ context.Context, _ ...string) (string, error) { return "", e.err }
-func (e *errorRunner) RunInDirContext(_ context.Context, _ string, _ ...string) (string, error) {
+func (e *errorRunner) Run(_ context.Context, _ ...string) (string, error) { return "", e.err }
+func (e *errorRunner) RunInDir(_ context.Context, _ string, _ ...string) (string, error) {
 	return "", e.err
 }
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -193,7 +193,7 @@ func TestRunEmptyTargets(t *testing.T) {
 	}
 }
 
-func TestRunContextCancellation(t *testing.T) {
+func TestRunCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 

--- a/internal/git/bench_test.go
+++ b/internal/git/bench_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -74,7 +75,7 @@ func BenchmarkListWorktrees5(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		if _, err := ListWorktrees(r); err != nil {
+		if _, err := ListWorktrees(context.Background(), r); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -90,7 +91,7 @@ func BenchmarkListWorktrees10(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		if _, err := ListWorktrees(r); err != nil {
+		if _, err := ListWorktrees(context.Background(), r); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -106,7 +107,7 @@ func BenchmarkIsDirty(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		if _, err := IsDirty(r, wts[0]); err != nil {
+		if _, err := IsDirty(context.Background(), r, wts[0]); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -122,7 +123,7 @@ func BenchmarkAheadBehind(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		_, _, err := AheadBehind(r, wts[0])
+		_, _, err := AheadBehind(context.Background(), r, wts[0])
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -141,7 +142,7 @@ func BenchmarkIsDirtyParallel(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
 		for pb.Next() {
-			if _, err := IsDirty(r, wts[i%len(wts)]); err != nil {
+			if _, err := IsDirty(context.Background(), r, wts[i%len(wts)]); err != nil {
 				b.Fatal(err)
 			}
 			i++

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -12,19 +13,19 @@ import (
 const internalGitInvariantHint = "report this — git output unexpectedly malformed"
 
 // BranchExists checks whether a local branch exists.
-func BranchExists(r Runner, branch string) bool {
-	_, err := r.Run(cmdRevParse, flagVerify, refsHeadsPrefix+branch)
+func BranchExists(ctx context.Context, r Runner, branch string) bool {
+	_, err := r.RunContext(ctx, cmdRevParse, flagVerify, refsHeadsPrefix+branch)
 	return err == nil
 }
 
 // DeleteBranch deletes a local branch. If force is true, uses -D instead of -d.
 // Already-gone branches are treated as success (idempotent).
-func DeleteBranch(r Runner, branch string, force bool) error {
+func DeleteBranch(ctx context.Context, r Runner, branch string, force bool) error {
 	flag := "-d"
 	if force {
 		flag = "-D"
 	}
-	_, err := r.Run("branch", flag, branch)
+	_, err := r.RunContext(ctx, "branch", flag, branch)
 	// git emits "error: branch 'X' not found." — assumes LC_ALL=C or English git.
 	if err != nil && strings.Contains(err.Error(), "branch '") && strings.Contains(err.Error(), "not found") {
 		return nil // already gone — idempotent
@@ -33,15 +34,15 @@ func DeleteBranch(r Runner, branch string, force bool) error {
 }
 
 // RenameBranch renames a local branch from oldBranch to newBranch.
-func RenameBranch(r Runner, oldBranch, newBranch string) error {
-	_, err := r.Run("branch", "-m", oldBranch, newBranch)
+func RenameBranch(ctx context.Context, r Runner, oldBranch, newBranch string) error {
+	_, err := r.RunContext(ctx, "branch", "-m", oldBranch, newBranch)
 	return err
 }
 
 // CurrentBranch returns the short branch name checked out in the given directory.
 // Returns an error with a hint if HEAD is detached.
-func CurrentBranch(r Runner, dir string) (string, error) {
-	out, err := r.RunInDir(dir, "symbolic-ref", "--short", "HEAD")
+func CurrentBranch(ctx context.Context, r Runner, dir string) (string, error) {
+	out, err := r.RunInDirContext(ctx, dir, "symbolic-ref", "--short", "HEAD")
 	if err != nil {
 		return "", errhint.WithFix(
 			fmt.Errorf("could not determine current branch: %w", err),
@@ -52,14 +53,14 @@ func CurrentBranch(r Runner, dir string) (string, error) {
 }
 
 // Checkout switches the working tree in dir to the given branch.
-func Checkout(r Runner, dir, branch string) error {
-	_, err := r.RunInDir(dir, "switch", "--", branch)
+func Checkout(ctx context.Context, r Runner, dir, branch string) error {
+	_, err := r.RunInDirContext(ctx, dir, "switch", "--", branch)
 	return err
 }
 
 // IsDirty returns true if the working tree at the given directory has uncommitted changes.
-func IsDirty(r Runner, dir string) (bool, error) {
-	out, err := r.RunInDir(dir, "status", "--porcelain")
+func IsDirty(ctx context.Context, r Runner, dir string) (bool, error) {
+	out, err := r.RunInDirContext(ctx, dir, "status", "--porcelain")
 	if err != nil {
 		return false, err
 	}
@@ -68,8 +69,8 @@ func IsDirty(r Runner, dir string) (bool, error) {
 
 // AheadBehind returns the ahead/behind counts of the current branch vs its upstream.
 // Returns (0, 0, nil) if there's no upstream configured.
-func AheadBehind(r Runner, dir string) (ahead, behind int, _ error) {
-	out, err := r.RunInDir(dir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
+func AheadBehind(ctx context.Context, r Runner, dir string) (ahead, behind int, _ error) {
+	out, err := r.RunInDirContext(ctx, dir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
 	if err != nil {
 		// No upstream or other error — treat as 0/0
 		return 0, 0, nil //nolint:nilerr // intentional: missing upstream is not an error
@@ -91,23 +92,23 @@ func AheadBehind(r Runner, dir string) (ahead, behind int, _ error) {
 // branch's tree on the merge-base, then check if that content is already in mergeRef.
 // Note: each call creates an unreferenced commit object in the git store; these are
 // cleaned up automatically by git gc.
-func IsSquashMerged(r Runner, mergeRef, branch string) (bool, error) {
-	mergeBase, err := MergeBase(r, mergeRef, branch)
+func IsSquashMerged(ctx context.Context, r Runner, mergeRef, branch string) (bool, error) {
+	mergeBase, err := MergeBase(ctx, r, mergeRef, branch)
 	if err != nil {
 		return false, err
 	}
 
-	tree, err := r.Run(cmdRevParse, branch+treeSuffix)
+	tree, err := r.RunContext(ctx, cmdRevParse, branch+treeSuffix)
 	if err != nil {
 		return false, err
 	}
 
-	tempCommit, err := r.Run(cmdCommitTree, tree, "-p", mergeBase, "-m", "temp")
+	tempCommit, err := r.RunContext(ctx, cmdCommitTree, tree, "-p", mergeBase, "-m", "temp")
 	if err != nil {
 		return false, err
 	}
 
-	out, err := r.Run(cmdCherry, mergeRef, tempCommit)
+	out, err := r.RunContext(ctx, cmdCherry, mergeRef, tempCommit)
 	if err != nil {
 		return false, err
 	}
@@ -117,8 +118,8 @@ func IsSquashMerged(r Runner, mergeRef, branch string) (bool, error) {
 
 // MergedBranches returns branches that have been merged into the given branch.
 // Runs `git branch --merged <branch>` and parses the output.
-func MergedBranches(r Runner, branch string) ([]string, error) {
-	out, err := r.Run("branch", "--merged", branch)
+func MergedBranches(ctx context.Context, r Runner, branch string) ([]string, error) {
+	out, err := r.RunContext(ctx, "branch", "--merged", branch)
 	if err != nil {
 		return nil, err
 	}
@@ -137,14 +138,14 @@ func MergedBranches(r Runner, branch string) ([]string, error) {
 }
 
 // LastCommitTime returns the time of the last commit on the given branch.
-func LastCommitTime(r Runner, branch string) (time.Time, error) {
-	t, _, err := LastCommitInfo(r, branch)
+func LastCommitTime(ctx context.Context, r Runner, branch string) (time.Time, error) {
+	t, _, err := LastCommitInfo(ctx, r, branch)
 	return t, err
 }
 
 // LastCommitInfo returns the time and subject of the last commit on the given branch.
-func LastCommitInfo(r Runner, branch string) (time.Time, string, error) {
-	out, err := r.Run("log", "-1", "--format=%ct\t%s", branch)
+func LastCommitInfo(ctx context.Context, r Runner, branch string) (time.Time, string, error) {
+	out, err := r.RunContext(ctx, "log", "-1", "--format=%ct\t%s", branch)
 	if err != nil {
 		return time.Time{}, "", errhint.WithFix(
 			fmt.Errorf("last commit info for %s: %w", branch, err),
@@ -178,8 +179,8 @@ func LastCommitInfo(r Runner, branch string) (time.Time, string, error) {
 }
 
 // LocalBranches returns the list of local branch names.
-func LocalBranches(r Runner) ([]string, error) {
-	out, err := r.Run("branch", "--format=%(refname:short)")
+func LocalBranches(ctx context.Context, r Runner) ([]string, error) {
+	out, err := r.RunContext(ctx, "branch", "--format=%(refname:short)")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -14,7 +14,7 @@ const internalGitInvariantHint = "report this — git output unexpectedly malfor
 
 // BranchExists checks whether a local branch exists.
 func BranchExists(ctx context.Context, r Runner, branch string) bool {
-	_, err := r.RunContext(ctx, cmdRevParse, flagVerify, refsHeadsPrefix+branch)
+	_, err := r.Run(ctx, cmdRevParse, flagVerify, refsHeadsPrefix+branch)
 	return err == nil
 }
 
@@ -25,7 +25,7 @@ func DeleteBranch(ctx context.Context, r Runner, branch string, force bool) erro
 	if force {
 		flag = "-D"
 	}
-	_, err := r.RunContext(ctx, "branch", flag, branch)
+	_, err := r.Run(ctx, "branch", flag, branch)
 	// git emits "error: branch 'X' not found." — assumes LC_ALL=C or English git.
 	if err != nil && strings.Contains(err.Error(), "branch '") && strings.Contains(err.Error(), "not found") {
 		return nil // already gone — idempotent
@@ -35,14 +35,14 @@ func DeleteBranch(ctx context.Context, r Runner, branch string, force bool) erro
 
 // RenameBranch renames a local branch from oldBranch to newBranch.
 func RenameBranch(ctx context.Context, r Runner, oldBranch, newBranch string) error {
-	_, err := r.RunContext(ctx, "branch", "-m", oldBranch, newBranch)
+	_, err := r.Run(ctx, "branch", "-m", oldBranch, newBranch)
 	return err
 }
 
 // CurrentBranch returns the short branch name checked out in the given directory.
 // Returns an error with a hint if HEAD is detached.
 func CurrentBranch(ctx context.Context, r Runner, dir string) (string, error) {
-	out, err := r.RunInDirContext(ctx, dir, "symbolic-ref", "--short", "HEAD")
+	out, err := r.RunInDir(ctx, dir, "symbolic-ref", "--short", "HEAD")
 	if err != nil {
 		return "", errhint.WithFix(
 			fmt.Errorf("could not determine current branch: %w", err),
@@ -54,13 +54,13 @@ func CurrentBranch(ctx context.Context, r Runner, dir string) (string, error) {
 
 // Checkout switches the working tree in dir to the given branch.
 func Checkout(ctx context.Context, r Runner, dir, branch string) error {
-	_, err := r.RunInDirContext(ctx, dir, "switch", "--", branch)
+	_, err := r.RunInDir(ctx, dir, "switch", "--", branch)
 	return err
 }
 
 // IsDirty returns true if the working tree at the given directory has uncommitted changes.
 func IsDirty(ctx context.Context, r Runner, dir string) (bool, error) {
-	out, err := r.RunInDirContext(ctx, dir, "status", "--porcelain")
+	out, err := r.RunInDir(ctx, dir, "status", "--porcelain")
 	if err != nil {
 		return false, err
 	}
@@ -70,7 +70,7 @@ func IsDirty(ctx context.Context, r Runner, dir string) (bool, error) {
 // AheadBehind returns the ahead/behind counts of the current branch vs its upstream.
 // Returns (0, 0, nil) if there's no upstream configured.
 func AheadBehind(ctx context.Context, r Runner, dir string) (ahead, behind int, _ error) {
-	out, err := r.RunInDirContext(ctx, dir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
+	out, err := r.RunInDir(ctx, dir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
 	if err != nil {
 		// No upstream or other error — treat as 0/0
 		return 0, 0, nil //nolint:nilerr // intentional: missing upstream is not an error
@@ -98,17 +98,17 @@ func IsSquashMerged(ctx context.Context, r Runner, mergeRef, branch string) (boo
 		return false, err
 	}
 
-	tree, err := r.RunContext(ctx, cmdRevParse, branch+treeSuffix)
+	tree, err := r.Run(ctx, cmdRevParse, branch+treeSuffix)
 	if err != nil {
 		return false, err
 	}
 
-	tempCommit, err := r.RunContext(ctx, cmdCommitTree, tree, "-p", mergeBase, "-m", "temp")
+	tempCommit, err := r.Run(ctx, cmdCommitTree, tree, "-p", mergeBase, "-m", "temp")
 	if err != nil {
 		return false, err
 	}
 
-	out, err := r.RunContext(ctx, cmdCherry, mergeRef, tempCommit)
+	out, err := r.Run(ctx, cmdCherry, mergeRef, tempCommit)
 	if err != nil {
 		return false, err
 	}
@@ -119,7 +119,7 @@ func IsSquashMerged(ctx context.Context, r Runner, mergeRef, branch string) (boo
 // MergedBranches returns branches that have been merged into the given branch.
 // Runs `git branch --merged <branch>` and parses the output.
 func MergedBranches(ctx context.Context, r Runner, branch string) ([]string, error) {
-	out, err := r.RunContext(ctx, "branch", "--merged", branch)
+	out, err := r.Run(ctx, "branch", "--merged", branch)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func LastCommitTime(ctx context.Context, r Runner, branch string) (time.Time, er
 
 // LastCommitInfo returns the time and subject of the last commit on the given branch.
 func LastCommitInfo(ctx context.Context, r Runner, branch string) (time.Time, string, error) {
-	out, err := r.RunContext(ctx, "log", "-1", "--format=%ct\t%s", branch)
+	out, err := r.Run(ctx, "log", "-1", "--format=%ct\t%s", branch)
 	if err != nil {
 		return time.Time{}, "", errhint.WithFix(
 			fmt.Errorf("last commit info for %s: %w", branch, err),
@@ -180,7 +180,7 @@ func LastCommitInfo(ctx context.Context, r Runner, branch string) (time.Time, st
 
 // LocalBranches returns the list of local branch names.
 func LocalBranches(ctx context.Context, r Runner) ([]string, error) {
-	out, err := r.RunContext(ctx, "branch", "--format=%(refname:short)")
+	out, err := r.Run(ctx, "branch", "--format=%(refname:short)")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/branch_test.go
+++ b/internal/git/branch_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -24,11 +25,11 @@ func TestBranchExists(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	if !git.BranchExists(r, "main") {
+	if !git.BranchExists(context.Background(), r, "main") {
 		t.Error("expected main branch to exist")
 	}
 
-	if git.BranchExists(r, "nonexistent") {
+	if git.BranchExists(context.Background(), r, "nonexistent") {
 		t.Error("expected nonexistent branch to not exist")
 	}
 }
@@ -44,15 +45,15 @@ func TestDeleteBranch(t *testing.T) {
 	// Create a branch
 	testutil.GitCmd(t, repo, "branch", branchToDelete)
 
-	if !git.BranchExists(r, branchToDelete) {
+	if !git.BranchExists(context.Background(), r, branchToDelete) {
 		t.Fatal("branch should exist before delete")
 	}
 
-	if err := git.DeleteBranch(r, branchToDelete, false); err != nil {
+	if err := git.DeleteBranch(context.Background(), r, branchToDelete, false); err != nil {
 		t.Fatalf("DeleteBranch: %v", err)
 	}
 
-	if git.BranchExists(r, branchToDelete) {
+	if git.BranchExists(context.Background(), r, branchToDelete) {
 		t.Error("branch should not exist after delete")
 	}
 }
@@ -65,7 +66,7 @@ func TestLastCommitTime(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	ct, err := git.LastCommitTime(r, "main")
+	ct, err := git.LastCommitTime(context.Background(), r, "main")
 	if err != nil {
 		t.Fatalf("LastCommitTime: %v", err)
 	}
@@ -84,7 +85,7 @@ func TestLastCommitInfo(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	ct, subject, err := git.LastCommitInfo(r, "main")
+	ct, subject, err := git.LastCommitInfo(context.Background(), r, "main")
 	if err != nil {
 		t.Fatalf("LastCommitInfo: %v", err)
 	}
@@ -105,7 +106,7 @@ func TestLastCommitInfoError(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	_, _, err := git.LastCommitInfo(r, "nonexistent")
+	_, _, err := git.LastCommitInfo(context.Background(), r, "nonexistent")
 	if err == nil {
 		t.Error("expected error for nonexistent branch")
 	}
@@ -119,7 +120,7 @@ func TestLastCommitTimeError(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	_, err := git.LastCommitTime(r, "nonexistent")
+	_, err := git.LastCommitTime(context.Background(), r, "nonexistent")
 	if err == nil {
 		t.Error("expected error for nonexistent branch")
 	}
@@ -133,7 +134,7 @@ func TestLocalBranches(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	branches, err := git.LocalBranches(r)
+	branches, err := git.LocalBranches(context.Background(), r)
 	if err != nil {
 		t.Fatalf("LocalBranches: %v", err)
 	}
@@ -157,7 +158,7 @@ func TestLocalBranchesMultiple(t *testing.T) {
 
 	testutil.GitCmd(t, repo, "branch", "feature/test-branch")
 
-	branches, err := git.LocalBranches(r)
+	branches, err := git.LocalBranches(context.Background(), r)
 	if err != nil {
 		t.Fatalf("LocalBranches: %v", err)
 	}
@@ -175,7 +176,7 @@ func TestIsDirty(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	dirty, err := git.IsDirty(r, repo)
+	dirty, err := git.IsDirty(context.Background(), r, repo)
 	if err != nil {
 		t.Fatalf("IsDirty: %v", err)
 	}
@@ -186,7 +187,7 @@ func TestIsDirty(t *testing.T) {
 	// Make it dirty
 	testutil.CreateFile(t, repo, "new.txt", "dirty")
 
-	dirty, err = git.IsDirty(r, repo)
+	dirty, err = git.IsDirty(context.Background(), r, repo)
 	if err != nil {
 		t.Fatalf("IsDirty: %v", err)
 	}
@@ -215,7 +216,7 @@ func TestIsSquashMergedIntegration(t *testing.T) {
 	testutil.GitCmd(t, repo, "commit", "-m", "squash merge feature")
 
 	// The branch should be detected as squash-merged
-	merged, err := git.IsSquashMerged(r, "main", "feature/squash-test")
+	merged, err := git.IsSquashMerged(context.Background(), r, "main", "feature/squash-test")
 	if err != nil {
 		t.Fatalf("IsSquashMerged: %v", err)
 	}
@@ -240,7 +241,7 @@ func TestIsSquashMergedIntegrationNotMerged(t *testing.T) {
 
 	testutil.GitCmd(t, repo, "checkout", "main")
 
-	merged, err := git.IsSquashMerged(r, "main", "feature/unmerged")
+	merged, err := git.IsSquashMerged(context.Background(), r, "main", "feature/unmerged")
 	if err != nil {
 		t.Fatalf("IsSquashMerged: %v", err)
 	}
@@ -257,7 +258,7 @@ func TestCurrentBranch(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	branch, err := git.CurrentBranch(r, repo)
+	branch, err := git.CurrentBranch(context.Background(), r, repo)
 	if err != nil {
 		t.Fatalf("CurrentBranch: %v", err)
 	}
@@ -276,7 +277,7 @@ func TestCurrentBranchAfterSwitch(t *testing.T) {
 
 	testutil.GitCmd(t, repo, "checkout", "-b", "feature/cur-branch-test")
 
-	branch, err := git.CurrentBranch(r, repo)
+	branch, err := git.CurrentBranch(context.Background(), r, repo)
 	if err != nil {
 		t.Fatalf("CurrentBranch after switch: %v", err)
 	}
@@ -295,11 +296,11 @@ func TestCheckout(t *testing.T) {
 
 	testutil.GitCmd(t, repo, "branch", "feature/checkout-test")
 
-	if err := git.Checkout(r, repo, "feature/checkout-test"); err != nil {
+	if err := git.Checkout(context.Background(), r, repo, "feature/checkout-test"); err != nil {
 		t.Fatalf("Checkout: %v", err)
 	}
 
-	branch, err := git.CurrentBranch(r, repo)
+	branch, err := git.CurrentBranch(context.Background(), r, repo)
 	if err != nil {
 		t.Fatalf("CurrentBranch after Checkout: %v", err)
 	}
@@ -316,7 +317,7 @@ func TestCheckoutError(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	if err := git.Checkout(r, repo, "nonexistent-branch"); err == nil {
+	if err := git.Checkout(context.Background(), r, repo, "nonexistent-branch"); err == nil {
 		t.Error("expected error for nonexistent branch")
 	}
 }
@@ -333,7 +334,7 @@ func TestCurrentBranchDetachedHead(t *testing.T) {
 	sha := testutil.GitCmd(t, repo, "rev-parse", "HEAD")
 	testutil.GitCmd(t, repo, "checkout", "--detach", strings.TrimSpace(sha))
 
-	_, err := git.CurrentBranch(r, repo)
+	_, err := git.CurrentBranch(context.Background(), r, repo)
 	if err == nil {
 		t.Fatal("expected error for detached HEAD")
 	}

--- a/internal/git/commit_count.go
+++ b/internal/git/commit_count.go
@@ -18,7 +18,7 @@ import (
 // here: recent activity on the tip, not total commits in history.
 func CommitCountSince(ctx context.Context, r Runner, branch string, since time.Duration) (int, error) {
 	cutoff := time.Now().Add(-since).Unix()
-	out, err := r.RunContext(
+	out, err := r.Run(
 		ctx,
 		"rev-list", "--count",
 		fmt.Sprintf("--since=%d", cutoff),

--- a/internal/git/commit_count.go
+++ b/internal/git/commit_count.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -15,9 +16,10 @@ import (
 // git's --since stops at the first commit older than the cutoff, so an
 // older ancestor hides anything beyond it. That matches what we want
 // here: recent activity on the tip, not total commits in history.
-func CommitCountSince(r Runner, branch string, since time.Duration) (int, error) {
+func CommitCountSince(ctx context.Context, r Runner, branch string, since time.Duration) (int, error) {
 	cutoff := time.Now().Add(-since).Unix()
-	out, err := r.Run(
+	out, err := r.RunContext(
+		ctx,
 		"rev-list", "--count",
 		fmt.Sprintf("--since=%d", cutoff),
 		branch,

--- a/internal/git/commit_count_test.go
+++ b/internal/git/commit_count_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,7 +28,7 @@ func TestCommitCountSinceCountsRecent(t *testing.T) {
 		testutil.GitCmd(t, repo, "commit", "-m", "recent")
 	}
 
-	got, err := git.CommitCountSince(r, "main", 24*time.Hour)
+	got, err := git.CommitCountSince(context.Background(), r, "main", 24*time.Hour)
 	if err != nil {
 		t.Fatalf("CommitCountSince: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestCommitCountSinceExcludesOldCommits(t *testing.T) {
 	oldDate := time.Now().Add(-30 * 24 * time.Hour).Format(time.RFC3339)
 	gitCmdWithCommitterDate(t, repo, oldDate, "commit", "--amend", "--no-edit")
 
-	got, err := git.CommitCountSince(r, "main", 7*24*time.Hour)
+	got, err := git.CommitCountSince(context.Background(), r, "main", 7*24*time.Hour)
 	if err != nil {
 		t.Fatalf("CommitCountSince: %v", err)
 	}
@@ -67,7 +68,7 @@ func TestCommitCountSinceUnknownBranch(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	_, err := git.CommitCountSince(r, "no-such-branch", 7*24*time.Hour)
+	_, err := git.CommitCountSince(context.Background(), r, "no-such-branch", 7*24*time.Hour)
 	if err == nil {
 		t.Fatal("CommitCountSince on unknown branch returned nil error, want non-nil")
 	}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -8,7 +8,7 @@ import (
 // DiffNameOnly returns files changed between base and branch using three-dot diff.
 // The three-dot notation (base...branch) shows changes on branch since it diverged from base.
 func DiffNameOnly(ctx context.Context, r Runner, base, branch string) ([]string, error) {
-	out, err := r.RunContext(ctx, "diff", "--name-only", base+"..."+branch)
+	out, err := r.Run(ctx, "diff", "--name-only", base+"..."+branch)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +28,7 @@ type MergeTreeResult struct {
 // touching the working tree. Requires git 2.38+.
 // Exit code 0 = clean merge, exit code 1 = conflicts, other = error.
 func MergeTree(ctx context.Context, r Runner, branch1, branch2 string) (MergeTreeResult, error) {
-	out, err := r.RunContext(ctx, "merge-tree", "--write-tree", branch1, branch2)
+	out, err := r.Run(ctx, "merge-tree", "--write-tree", branch1, branch2)
 	if err != nil {
 		// git merge-tree exits 1 for both conflicts and errors.
 		// We distinguish by checking whether the output contains CONFLICT lines.

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -1,11 +1,14 @@
 package git
 
-import "strings"
+import (
+	"context"
+	"strings"
+)
 
 // DiffNameOnly returns files changed between base and branch using three-dot diff.
 // The three-dot notation (base...branch) shows changes on branch since it diverged from base.
-func DiffNameOnly(r Runner, base, branch string) ([]string, error) {
-	out, err := r.Run("diff", "--name-only", base+"..."+branch)
+func DiffNameOnly(ctx context.Context, r Runner, base, branch string) ([]string, error) {
+	out, err := r.RunContext(ctx, "diff", "--name-only", base+"..."+branch)
 	if err != nil {
 		return nil, err
 	}
@@ -24,8 +27,8 @@ type MergeTreeResult struct {
 // MergeTree runs git merge-tree --write-tree to simulate a merge without
 // touching the working tree. Requires git 2.38+.
 // Exit code 0 = clean merge, exit code 1 = conflicts, other = error.
-func MergeTree(r Runner, branch1, branch2 string) (MergeTreeResult, error) {
-	out, err := r.Run("merge-tree", "--write-tree", branch1, branch2)
+func MergeTree(ctx context.Context, r Runner, branch1, branch2 string) (MergeTreeResult, error) {
+	out, err := r.RunContext(ctx, "merge-tree", "--write-tree", branch1, branch2)
 	if err != nil {
 		// git merge-tree exits 1 for both conflicts and errors.
 		// We distinguish by checking whether the output contains CONFLICT lines.

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
@@ -45,7 +46,7 @@ func TestDiffNameOnly(t *testing.T) {
 				},
 			}
 
-			got, err := DiffNameOnly(r, "main", "feature/x")
+			got, err := DiffNameOnly(context.Background(), r, "main", "feature/x")
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("DiffNameOnly error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -74,7 +75,7 @@ func TestMergeTreeClean(t *testing.T) {
 		},
 	}
 
-	result, err := MergeTree(r, "main", "feature/x")
+	result, err := MergeTree(context.Background(), r, "main", "feature/x")
 	if err != nil {
 		t.Fatalf("MergeTree: %v", err)
 	}
@@ -91,7 +92,7 @@ func TestMergeTreeConflicts(t *testing.T) {
 		},
 	}
 
-	result, err := MergeTree(r, "main", "feature/x")
+	result, err := MergeTree(context.Background(), r, "main", "feature/x")
 	if err != nil {
 		t.Fatalf("MergeTree: %v", err)
 	}
@@ -116,7 +117,7 @@ func TestMergeTreeError(t *testing.T) {
 		},
 	}
 
-	_, err := MergeTree(r, "main", "nonexistent")
+	_, err := MergeTree(context.Background(), r, "main", "nonexistent")
 	if err == nil {
 		t.Fatal("expected error from MergeTree")
 	}
@@ -131,7 +132,7 @@ func TestMergeTreeArgs(t *testing.T) {
 		},
 	}
 
-	_, _ = MergeTree(r, "main", "feature/x")
+	_, _ = MergeTree(context.Background(), r, "main", "feature/x")
 	want := []string{"merge-tree", "--write-tree", "main", "feature/x"}
 	if len(captured) != len(want) {
 		t.Fatalf("args = %v, want %v", captured, want)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -10,8 +10,8 @@ import (
 
 // Runner abstracts git command execution for testability.
 type Runner interface {
-	RunContext(ctx context.Context, args ...string) (string, error)
-	RunInDirContext(ctx context.Context, dir string, args ...string) (string, error)
+	Run(ctx context.Context, args ...string) (string, error)
+	RunInDir(ctx context.Context, dir string, args ...string) (string, error)
 }
 
 // ExecRunner is the production implementation of Runner.
@@ -20,8 +20,8 @@ type ExecRunner struct {
 	Dir string
 }
 
-// RunInDirContext is the single execution primitive: all other methods delegate here.
-func (r *ExecRunner) RunInDirContext(ctx context.Context, dir string, args ...string) (string, error) {
+// RunInDir is the single execution primitive: all other methods delegate here.
+func (r *ExecRunner) RunInDir(ctx context.Context, dir string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = stableGitEnv(os.Environ())
 	if dir != "" {
@@ -49,6 +49,6 @@ func stableGitEnv(environ []string) []string {
 	return append(env, "LANG=C", "LC_ALL=C")
 }
 
-func (r *ExecRunner) RunContext(ctx context.Context, args ...string) (string, error) {
-	return r.RunInDirContext(ctx, r.Dir, args...)
+func (r *ExecRunner) Run(ctx context.Context, args ...string) (string, error) {
+	return r.RunInDir(ctx, r.Dir, args...)
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -10,8 +10,6 @@ import (
 
 // Runner abstracts git command execution for testability.
 type Runner interface {
-	Run(args ...string) (string, error)
-	RunInDir(dir string, args ...string) (string, error)
 	RunContext(ctx context.Context, args ...string) (string, error)
 	RunInDirContext(ctx context.Context, dir string, args ...string) (string, error)
 }
@@ -53,12 +51,4 @@ func stableGitEnv(environ []string) []string {
 
 func (r *ExecRunner) RunContext(ctx context.Context, args ...string) (string, error) {
 	return r.RunInDirContext(ctx, r.Dir, args...)
-}
-
-func (r *ExecRunner) Run(args ...string) (string, error) {
-	return r.RunInDirContext(context.Background(), r.Dir, args...)
-}
-
-func (r *ExecRunner) RunInDir(dir string, args ...string) (string, error) {
-	return r.RunInDirContext(context.Background(), dir, args...)
 }

--- a/internal/git/git_ctx_test.go
+++ b/internal/git/git_ctx_test.go
@@ -21,18 +21,6 @@ func TestRunInDirContextCancelled(t *testing.T) {
 	}
 }
 
-func TestRunDelegatesToContext(t *testing.T) {
-	r := &ExecRunner{}
-	// git --version is a fast, safe command available everywhere
-	out, err := r.Run("--version")
-	if err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-	if !strings.Contains(out, "git") {
-		t.Errorf("expected git version output, got: %q", out)
-	}
-}
-
 func TestRunContextDelegatesToRunInDirContext(t *testing.T) {
 	r := &ExecRunner{}
 	out, err := r.RunContext(context.Background(), "--version")

--- a/internal/git/git_ctx_test.go
+++ b/internal/git/git_ctx_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 )
 
-func TestRunInDirContextCancelled(t *testing.T) {
+func TestRunInDirCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel
 
 	r := &ExecRunner{}
-	_, err := r.RunInDirContext(ctx, "", "status")
+	_, err := r.RunInDir(ctx, "", "status")
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
 	}
@@ -21,11 +21,11 @@ func TestRunInDirContextCancelled(t *testing.T) {
 	}
 }
 
-func TestRunContextDelegatesToRunInDirContext(t *testing.T) {
+func TestRunDelegatesToRunInDir(t *testing.T) {
 	r := &ExecRunner{}
-	out, err := r.RunContext(context.Background(), "--version")
+	out, err := r.Run(context.Background(), "--version")
 	if err != nil {
-		t.Fatalf("RunContext: %v", err)
+		t.Fatalf("Run: %v", err)
 	}
 	if !strings.Contains(out, "git") {
 		t.Errorf("expected git version output, got: %q", out)

--- a/internal/git/merge.go
+++ b/internal/git/merge.go
@@ -20,8 +20,8 @@ func Merge(ctx context.Context, r Runner, dir, branch string, noFF bool) error {
 // MergeInProgress reports whether a merge is in progress in dir (MERGE_HEAD exists).
 // Returns (false, nil) when no merge is in progress, (true, nil) when one is,
 // and (false, err) when the check itself fails (infrastructure error).
-func MergeInProgress(r Runner, dir string) (bool, error) {
-	_, err := r.RunInDir(dir, "rev-parse", "--verify", "-q", "MERGE_HEAD")
+func MergeInProgress(ctx context.Context, r Runner, dir string) (bool, error) {
+	_, err := r.RunInDirContext(ctx, dir, "rev-parse", "--verify", "-q", "MERGE_HEAD")
 	if err == nil {
 		return true, nil
 	}
@@ -38,7 +38,8 @@ func MergeInProgress(r Runner, dir string) (bool, error) {
 }
 
 // MergeAbort runs `git merge --abort` in dir.
+// Intentionally non-cancellable: merge recovery must complete after Ctrl-C to restore a clean state.
 func MergeAbort(r Runner, dir string) error {
-	_, err := r.RunInDir(dir, "merge", "--abort")
+	_, err := r.RunInDirContext(context.Background(), dir, "merge", "--abort")
 	return err
 }

--- a/internal/git/merge.go
+++ b/internal/git/merge.go
@@ -13,7 +13,7 @@ func Merge(ctx context.Context, r Runner, dir, branch string, noFF bool) error {
 		args = append(args, "--no-ff")
 	}
 	args = append(args, branch)
-	_, err := r.RunInDirContext(ctx, dir, args...)
+	_, err := r.RunInDir(ctx, dir, args...)
 	return err
 }
 
@@ -21,7 +21,7 @@ func Merge(ctx context.Context, r Runner, dir, branch string, noFF bool) error {
 // Returns (false, nil) when no merge is in progress, (true, nil) when one is,
 // and (false, err) when the check itself fails (infrastructure error).
 func MergeInProgress(ctx context.Context, r Runner, dir string) (bool, error) {
-	_, err := r.RunInDirContext(ctx, dir, "rev-parse", "--verify", "-q", "MERGE_HEAD")
+	_, err := r.RunInDir(ctx, dir, "rev-parse", "--verify", "-q", "MERGE_HEAD")
 	if err == nil {
 		return true, nil
 	}
@@ -40,6 +40,6 @@ func MergeInProgress(ctx context.Context, r Runner, dir string) (bool, error) {
 // MergeAbort runs `git merge --abort` in dir.
 // Intentionally non-cancellable: merge recovery must complete after Ctrl-C to restore a clean state.
 func MergeAbort(r Runner, dir string) error {
-	_, err := r.RunInDirContext(context.Background(), dir, "merge", "--abort")
+	_, err := r.RunInDir(context.Background(), dir, "merge", "--abort")
 	return err
 }

--- a/internal/git/merge_test.go
+++ b/internal/git/merge_test.go
@@ -19,7 +19,7 @@ func TestMergeBasic(t *testing.T) {
 
 	// Create a branch with a commit
 	wtPath := filepath.Join(filepath.Dir(repo), "wt-merge-basic")
-	if err := git.AddWorktree(r, wtPath, "feat/merge-basic", "main"); err != nil {
+	if err := git.AddWorktree(context.Background(), r, wtPath, "feat/merge-basic", "main"); err != nil {
 		t.Fatalf(fatalAddWorktree, err)
 	}
 
@@ -46,7 +46,7 @@ func TestMergeNoFF(t *testing.T) {
 
 	// Create a branch with a commit
 	wtPath := filepath.Join(filepath.Dir(repo), "wt-merge-noff")
-	if err := git.AddWorktree(r, wtPath, "feat/merge-noff", "main"); err != nil {
+	if err := git.AddWorktree(context.Background(), r, wtPath, "feat/merge-noff", "main"); err != nil {
 		t.Fatalf(fatalAddWorktree, err)
 	}
 
@@ -88,7 +88,7 @@ func TestMergeInProgress(t *testing.T) {
 	r := &git.ExecRunner{Dir: repo}
 
 	// Clean repo: no merge in progress
-	inProgress, err := git.MergeInProgress(r, repo)
+	inProgress, err := git.MergeInProgress(context.Background(), r, repo)
 	if err != nil {
 		t.Fatalf("MergeInProgress on clean repo: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestMergeInProgress(t *testing.T) {
 
 	// Set up a conflicting merge: two branches edit the same file differently.
 	wtPath := filepath.Join(filepath.Dir(repo), "wt-merge-in-progress")
-	if err := git.AddWorktree(r, wtPath, "feat/conflict-source", "main"); err != nil {
+	if err := git.AddWorktree(context.Background(), r, wtPath, "feat/conflict-source", "main"); err != nil {
 		t.Fatalf(fatalAddWorktree, err)
 	}
 	testutil.CreateFile(t, wtPath, "conflict.txt", "source version")
@@ -116,7 +116,7 @@ func TestMergeInProgress(t *testing.T) {
 	}
 
 	// Now a merge should be in progress.
-	inProgress, err = git.MergeInProgress(r, repo)
+	inProgress, err = git.MergeInProgress(context.Background(), r, repo)
 	if err != nil {
 		t.Fatalf("MergeInProgress after conflict: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestMergeAbort(t *testing.T) {
 
 	// Set up a conflicting merge (same steps as TestMergeInProgress).
 	wtPath := filepath.Join(filepath.Dir(repo), "wt-merge-abort")
-	if err := git.AddWorktree(r, wtPath, "feat/abort-source", "main"); err != nil {
+	if err := git.AddWorktree(context.Background(), r, wtPath, "feat/abort-source", "main"); err != nil {
 		t.Fatalf(fatalAddWorktree, err)
 	}
 	testutil.CreateFile(t, wtPath, "conflict.txt", "source version")
@@ -156,14 +156,14 @@ func TestMergeAbort(t *testing.T) {
 	}
 
 	// Repo should be clean and no merge in progress.
-	dirty, err := git.IsDirty(r, repo)
+	dirty, err := git.IsDirty(context.Background(), r, repo)
 	if err != nil {
 		t.Fatalf("IsDirty after abort: %v", err)
 	}
 	if dirty {
 		t.Error("expected repo to be clean after MergeAbort")
 	}
-	inProgress, err := git.MergeInProgress(r, repo)
+	inProgress, err := git.MergeInProgress(context.Background(), r, repo)
 	if err != nil {
 		t.Fatalf("MergeInProgress after abort: %v", err)
 	}

--- a/internal/git/mock_runner_test.go
+++ b/internal/git/mock_runner_test.go
@@ -37,11 +37,11 @@ type mockRunner struct {
 	runInDir func(dir string, args ...string) (string, error)
 }
 
-func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
+func (m *mockRunner) Run(_ context.Context, args ...string) (string, error) {
 	return m.run(args...)
 }
 
-func (m *mockRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
+func (m *mockRunner) RunInDir(_ context.Context, dir string, args ...string) (string, error) {
 	return m.runInDir(dir, args...)
 }
 

--- a/internal/git/mock_runner_test.go
+++ b/internal/git/mock_runner_test.go
@@ -37,14 +37,6 @@ type mockRunner struct {
 	runInDir func(dir string, args ...string) (string, error)
 }
 
-func (m *mockRunner) Run(args ...string) (string, error) {
-	return m.run(args...)
-}
-
-func (m *mockRunner) RunInDir(dir string, args ...string) (string, error) {
-	return m.runInDir(dir, args...)
-}
-
 func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
 	return m.run(args...)
 }
@@ -107,7 +99,7 @@ func TestAheadBehind(t *testing.T) {
 					return tt.out, tt.err
 				},
 			}
-			ahead, behind, err := AheadBehind(r, fakeDir)
+			ahead, behind, err := AheadBehind(context.Background(), r, fakeDir)
 			if err != nil {
 				t.Fatalf("AheadBehind returned error: %v", err)
 			}
@@ -128,7 +120,7 @@ func TestMergedBranches(t *testing.T) {
 		},
 	}
 
-	branches, err := MergedBranches(r, branchMain)
+	branches, err := MergedBranches(context.Background(), r, branchMain)
 	if err != nil {
 		t.Fatalf("MergedBranches: %v", err)
 	}
@@ -151,7 +143,7 @@ func TestMergedBranchesError(t *testing.T) {
 		},
 	}
 
-	_, err := MergedBranches(r, branchMain)
+	_, err := MergedBranches(context.Background(), r, branchMain)
 	if err == nil {
 		t.Fatal("expected error from MergedBranches")
 	}
@@ -164,7 +156,7 @@ func TestMergedBranchesEmpty(t *testing.T) {
 		},
 	}
 
-	branches, err := MergedBranches(r, branchMain)
+	branches, err := MergedBranches(context.Background(), r, branchMain)
 	if err != nil {
 		t.Fatalf("MergedBranches: %v", err)
 	}
@@ -182,7 +174,7 @@ func TestDeleteBranchForce(t *testing.T) {
 		},
 	}
 
-	if err := DeleteBranch(r, branchOld, true); err != nil {
+	if err := DeleteBranch(context.Background(), r, branchOld, true); err != nil {
 		t.Fatalf("DeleteBranch: %v", err)
 	}
 
@@ -197,7 +189,7 @@ func TestDeleteBranchNotFoundIsIdempotent(t *testing.T) {
 			return "", errors.New("error: branch 'gone' not found.")
 		},
 	}
-	if err := DeleteBranch(r, "gone", false); err != nil {
+	if err := DeleteBranch(context.Background(), r, "gone", false); err != nil {
 		t.Fatalf("expected nil for already-gone branch, got: %v", err)
 	}
 }
@@ -208,7 +200,7 @@ func TestDeleteBranchOtherErrorPropagates(t *testing.T) {
 			return "", errors.New("error: Cannot delete branch 'main' checked out at '/repo'")
 		},
 	}
-	if err := DeleteBranch(r, "main", false); err == nil {
+	if err := DeleteBranch(context.Background(), r, "main", false); err == nil {
 		t.Fatal("expected non-nil error for checked-out branch")
 	}
 }
@@ -220,7 +212,7 @@ func TestDeleteBranchNotFoundWithoutBranchKeywordPropagates(t *testing.T) {
 			return "", errors.New("ref not found")
 		},
 	}
-	if err := DeleteBranch(r, "gone", false); err == nil {
+	if err := DeleteBranch(context.Background(), r, "gone", false); err == nil {
 		t.Fatal("expected non-nil error when 'branch \\'' is absent from the message")
 	}
 }
@@ -234,7 +226,7 @@ func TestRenameBranch(t *testing.T) {
 		},
 	}
 
-	if err := RenameBranch(r, branchOld, branchNew); err != nil {
+	if err := RenameBranch(context.Background(), r, branchOld, branchNew); err != nil {
 		t.Fatalf("RenameBranch: %v", err)
 	}
 
@@ -256,7 +248,7 @@ func TestIsDirtyError(t *testing.T) {
 		},
 	}
 
-	_, err := IsDirty(r, fakeDir)
+	_, err := IsDirty(context.Background(), r, fakeDir)
 	if err == nil {
 		t.Fatal("expected error from IsDirty")
 	}
@@ -272,7 +264,7 @@ func TestPruneNormal(t *testing.T) {
 		},
 	}
 
-	if _, err := Prune(r, false); err != nil {
+	if _, err := Prune(context.Background(), r, false); err != nil {
 		t.Fatalf("Prune: %v", err)
 	}
 	if slices.Contains(captured, flagDryRun) {
@@ -289,7 +281,7 @@ func TestPruneDryRun(t *testing.T) {
 		},
 	}
 
-	out, err := Prune(r, true)
+	out, err := Prune(context.Background(), r, true)
 	if err != nil {
 		t.Fatalf("Prune: %v", err)
 	}
@@ -308,7 +300,7 @@ func TestPruneErrorWrapping(t *testing.T) {
 		},
 	}
 
-	_, err := Prune(r, false)
+	_, err := Prune(context.Background(), r, false)
 	if err == nil {
 		t.Fatal("expected error from Prune")
 	}
@@ -324,7 +316,7 @@ func TestRemoveWorktreeForce(t *testing.T) {
 		},
 	}
 
-	if err := RemoveWorktree(r, fakePath, true); err != nil {
+	if err := RemoveWorktree(context.Background(), r, fakePath, true); err != nil {
 		t.Fatalf("RemoveWorktree: %v", err)
 	}
 	if !slices.Contains(captured, flagForce) {
@@ -380,7 +372,7 @@ func TestListWorktreesError(t *testing.T) {
 		},
 	}
 
-	entries, err := ListWorktrees(r)
+	entries, err := ListWorktrees(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error from ListWorktrees")
 	}
@@ -411,7 +403,7 @@ func defaultBranchRunner(symRef, acceptBranch string) *mockRunner {
 
 func TestDefaultBranchSymbolicRef(t *testing.T) {
 	r := defaultBranchRunner("refs/remotes/origin/develop", "")
-	branch, err := DefaultBranch(r)
+	branch, err := DefaultBranch(context.Background(), r)
 	if err != nil {
 		t.Fatalf(fatalDefaultFmt, err)
 	}
@@ -422,7 +414,7 @@ func TestDefaultBranchSymbolicRef(t *testing.T) {
 
 func TestDefaultBranchFallbackMain(t *testing.T) {
 	r := defaultBranchRunner("", "main")
-	branch, err := DefaultBranch(r)
+	branch, err := DefaultBranch(context.Background(), r)
 	if err != nil {
 		t.Fatalf(fatalDefaultFmt, err)
 	}
@@ -433,7 +425,7 @@ func TestDefaultBranchFallbackMain(t *testing.T) {
 
 func TestDefaultBranchFallbackMaster(t *testing.T) {
 	r := defaultBranchRunner("", "master")
-	branch, err := DefaultBranch(r)
+	branch, err := DefaultBranch(context.Background(), r)
 	if err != nil {
 		t.Fatalf(fatalDefaultFmt, err)
 	}
@@ -444,7 +436,7 @@ func TestDefaultBranchFallbackMaster(t *testing.T) {
 
 func TestDefaultBranchNotFound(t *testing.T) {
 	r := defaultBranchRunner("", "")
-	_, err := DefaultBranch(r)
+	_, err := DefaultBranch(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error when no default branch found")
 	}
@@ -460,7 +452,7 @@ func TestHooksDirError(t *testing.T) {
 		},
 	}
 
-	_, err := HooksDir(r)
+	_, err := HooksDir(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error from HooksDir")
 	}
@@ -483,7 +475,7 @@ func TestHooksDirRelativePath(t *testing.T) {
 		},
 	}
 
-	dir, err := HooksDir(r)
+	dir, err := HooksDir(context.Background(), r)
 	if err != nil {
 		t.Fatalf("HooksDir: %v", err)
 	}
@@ -508,7 +500,7 @@ func TestHooksDirAbsolutePath(t *testing.T) {
 		},
 	}
 
-	dir, err := HooksDir(r)
+	dir, err := HooksDir(context.Background(), r)
 	if err != nil {
 		t.Fatalf("HooksDir: %v", err)
 	}
@@ -526,7 +518,7 @@ func TestRepoRootError(t *testing.T) {
 		},
 	}
 
-	_, err := RepoRoot(r)
+	_, err := RepoRoot(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error from RepoRoot")
 	}
@@ -549,7 +541,7 @@ func TestHooksDirRelativePathRepoRootError(t *testing.T) {
 		},
 	}
 
-	_, err := HooksDir(r)
+	_, err := HooksDir(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error from HooksDir when RepoRoot fails")
 	}
@@ -566,7 +558,7 @@ func TestHooksDirCoreHooksPathAbsolute(t *testing.T) {
 		},
 	}
 
-	dir, err := HooksDir(r)
+	dir, err := HooksDir(context.Background(), r)
 	if err != nil {
 		t.Fatalf("HooksDir: %v", err)
 	}
@@ -592,7 +584,7 @@ func TestHooksDirCoreHooksPathRelative(t *testing.T) {
 		},
 	}
 
-	dir, err := HooksDir(r)
+	dir, err := HooksDir(context.Background(), r)
 	if err != nil {
 		t.Fatalf("HooksDir: %v", err)
 	}
@@ -614,7 +606,7 @@ func TestHooksDirCoreHooksPathRelativeRepoRootError(t *testing.T) {
 		},
 	}
 
-	_, err := HooksDir(r)
+	_, err := HooksDir(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error from HooksDir when MainRepoRoot fails")
 	}
@@ -628,7 +620,7 @@ func TestListWorktreesBareEntry(t *testing.T) {
 		},
 	}
 
-	entries, err := ListWorktrees(r)
+	entries, err := ListWorktrees(context.Background(), r)
 	if err != nil {
 		t.Fatalf("ListWorktrees: %v", err)
 	}
@@ -662,7 +654,7 @@ func TestIsSquashMerged(t *testing.T) {
 		},
 	}
 
-	merged, err := IsSquashMerged(r, branchMain, branchFeature)
+	merged, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
 	if err != nil {
 		t.Fatalf("IsSquashMerged: %v", err)
 	}
@@ -690,7 +682,7 @@ func TestIsSquashMergedNotMerged(t *testing.T) {
 		},
 	}
 
-	merged, err := IsSquashMerged(r, branchMain, branchFeature)
+	merged, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
 	if err != nil {
 		t.Fatalf("IsSquashMerged: %v", err)
 	}
@@ -706,7 +698,7 @@ func TestIsSquashMergedMergeBaseError(t *testing.T) {
 		},
 	}
 
-	_, err := IsSquashMerged(r, branchMain, branchFeature)
+	_, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
 	if err == nil {
 		t.Fatal("expected error from MergeBase failure")
 	}
@@ -724,7 +716,7 @@ func TestIsSquashMergedRevParseError(t *testing.T) {
 		},
 	}
 
-	_, err := IsSquashMerged(r, branchMain, branchFeature)
+	_, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
 	if err == nil {
 		t.Fatal("expected error from rev-parse failure")
 	}
@@ -745,7 +737,7 @@ func TestIsSquashMergedCommitTreeError(t *testing.T) {
 		},
 	}
 
-	_, err := IsSquashMerged(r, branchMain, branchFeature)
+	_, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
 	if err == nil {
 		t.Fatal("expected error from commit-tree failure")
 	}
@@ -770,7 +762,7 @@ func TestIsSquashMergedEmptyCherry(t *testing.T) {
 		},
 	}
 
-	merged, err := IsSquashMerged(r, branchMain, branchFeature)
+	merged, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
 	if err != nil {
 		t.Fatalf("IsSquashMerged: %v", err)
 	}
@@ -796,7 +788,7 @@ func TestIsSquashMergedCherryError(t *testing.T) {
 		},
 	}
 
-	_, err := IsSquashMerged(r, branchMain, branchFeature)
+	_, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
 	if err == nil {
 		t.Fatal("expected error from cherry failure")
 	}
@@ -809,7 +801,7 @@ func TestMainRepoRootError(t *testing.T) {
 		},
 	}
 
-	_, err := MainRepoRoot(r)
+	_, err := MainRepoRoot(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error from MainRepoRoot")
 	}
@@ -829,7 +821,7 @@ func TestMainRepoRootRelativePath(t *testing.T) {
 		},
 	}
 
-	root, err := MainRepoRoot(r)
+	root, err := MainRepoRoot(context.Background(), r)
 	if err != nil {
 		t.Fatalf("MainRepoRoot: %v", err)
 	}
@@ -849,7 +841,7 @@ func TestMainRepoRootAbsolutePath(t *testing.T) {
 		},
 	}
 
-	root, err := MainRepoRoot(r)
+	root, err := MainRepoRoot(context.Background(), r)
 	if err != nil {
 		t.Fatalf("MainRepoRoot: %v", err)
 	}
@@ -872,7 +864,7 @@ func TestMainRepoRootRelativePathRepoRootError(t *testing.T) {
 		},
 	}
 
-	_, err := MainRepoRoot(r)
+	_, err := MainRepoRoot(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error from MainRepoRoot when RepoRoot fails")
 	}
@@ -885,7 +877,7 @@ func TestLastCommitInfoEmptyOutput(t *testing.T) {
 			return "", nil
 		},
 	}
-	_, _, err := LastCommitInfo(r, branchFeature)
+	_, _, err := LastCommitInfo(context.Background(), r, branchFeature)
 	if err == nil {
 		t.Fatal("expected error for empty output")
 	}
@@ -898,7 +890,7 @@ func TestLastCommitInfoMalformed(t *testing.T) {
 			return "no-tab-separator", nil
 		},
 	}
-	_, _, err := LastCommitInfo(r, branchFeature)
+	_, _, err := LastCommitInfo(context.Background(), r, branchFeature)
 	if err == nil {
 		t.Fatal("expected error for malformed output")
 	}
@@ -911,7 +903,7 @@ func TestLastCommitInfoBadTimestamp(t *testing.T) {
 			return "not-a-number\tcommit subject", nil
 		},
 	}
-	_, _, err := LastCommitInfo(r, branchFeature)
+	_, _, err := LastCommitInfo(context.Background(), r, branchFeature)
 	if err == nil {
 		t.Fatal("expected error for non-numeric timestamp")
 	}
@@ -924,7 +916,7 @@ func TestLastCommitInfoRunError(t *testing.T) {
 			return "", errors.New(errNotARepo)
 		},
 	}
-	_, _, err := LastCommitInfo(r, branchFeature)
+	_, _, err := LastCommitInfo(context.Background(), r, branchFeature)
 	if err == nil {
 		t.Fatal("expected error from runner failure")
 	}
@@ -938,7 +930,7 @@ func TestLocalBranchesError(t *testing.T) {
 			return "", errors.New(errNotARepo)
 		},
 	}
-	_, err := LocalBranches(r)
+	_, err := LocalBranches(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error from LocalBranches")
 	}
@@ -951,7 +943,7 @@ func TestRepoNameError(t *testing.T) {
 		},
 	}
 
-	_, err := RepoName(r)
+	_, err := RepoName(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error from RepoName")
 	}
@@ -970,7 +962,7 @@ func TestCheckoutInsertsDashDash(t *testing.T) {
 		},
 	}
 
-	if err := Checkout(r, fakeDir, branch); err != nil {
+	if err := Checkout(context.Background(), r, fakeDir, branch); err != nil {
 		t.Fatalf("Checkout: %v", err)
 	}
 
@@ -993,7 +985,7 @@ func TestAddWorktreeFromBranchInsertsDashDash(t *testing.T) {
 		},
 	}
 
-	if err := AddWorktreeFromBranch(r, fakePath, branch); err != nil {
+	if err := AddWorktreeFromBranch(context.Background(), r, fakePath, branch); err != nil {
 		t.Fatalf("AddWorktreeFromBranch: %v", err)
 	}
 

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -18,8 +18,8 @@ type RemoteFailure struct {
 const DefaultRemote = "origin"
 
 // RemoteExists reports whether a remote with the given name is configured.
-func RemoteExists(r Runner, name string) bool {
-	_, err := r.Run("remote", "get-url", name)
+func RemoteExists(ctx context.Context, r Runner, name string) bool {
+	_, err := r.RunContext(ctx, "remote", "get-url", name)
 	return err == nil
 }
 
@@ -59,15 +59,15 @@ func DeleteRemoteBranch(ctx context.Context, r Runner, remote, branch string) er
 }
 
 // AddRemote adds a new remote with the given name and URL.
-func AddRemote(r Runner, name, url string) error {
-	_, err := r.Run("remote", "add", name, url)
+func AddRemote(ctx context.Context, r Runner, name, url string) error {
+	_, err := r.RunContext(ctx, "remote", "add", name, url)
 	return err
 }
 
 // ListRemotes returns the names of all configured remotes by running `git remote`.
 // It returns an empty (non-nil) slice when there are no remotes configured.
-func ListRemotes(r Runner) ([]string, error) {
-	out, err := r.Run("remote")
+func ListRemotes(ctx context.Context, r Runner) ([]string, error) {
+	out, err := r.RunContext(ctx, "remote")
 	if err != nil {
 		return nil, errhint.WithFix(
 			fmt.Errorf("list remotes: %w", err),

--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -19,7 +19,7 @@ const DefaultRemote = "origin"
 
 // RemoteExists reports whether a remote with the given name is configured.
 func RemoteExists(ctx context.Context, r Runner, name string) bool {
-	_, err := r.RunContext(ctx, "remote", "get-url", name)
+	_, err := r.Run(ctx, "remote", "get-url", name)
 	return err == nil
 }
 
@@ -31,7 +31,7 @@ func RemotePrune(ctx context.Context, r Runner, remote string, dryRun bool) ([]s
 		args = append(args, "--dry-run")
 	}
 	args = append(args, remote)
-	out, err := r.RunContext(ctx, args...)
+	out, err := r.Run(ctx, args...)
 	if err != nil {
 		return nil, errhint.WithFix(
 			fmt.Errorf("remote prune: %w", err),
@@ -44,7 +44,7 @@ func RemotePrune(ctx context.Context, r Runner, remote string, dryRun bool) ([]s
 // DeleteRemoteBranch deletes a branch on the given remote.
 // An already-gone remote ref is treated as success (idempotent).
 func DeleteRemoteBranch(ctx context.Context, r Runner, remote, branch string) error {
-	_, err := r.RunContext(ctx, "push", remote, "--delete", branch)
+	_, err := r.Run(ctx, "push", remote, "--delete", branch)
 	if err == nil {
 		return nil
 	}
@@ -60,14 +60,14 @@ func DeleteRemoteBranch(ctx context.Context, r Runner, remote, branch string) er
 
 // AddRemote adds a new remote with the given name and URL.
 func AddRemote(ctx context.Context, r Runner, name, url string) error {
-	_, err := r.RunContext(ctx, "remote", "add", name, url)
+	_, err := r.Run(ctx, "remote", "add", name, url)
 	return err
 }
 
 // ListRemotes returns the names of all configured remotes by running `git remote`.
 // It returns an empty (non-nil) slice when there are no remotes configured.
 func ListRemotes(ctx context.Context, r Runner) ([]string, error) {
-	out, err := r.RunContext(ctx, "remote")
+	out, err := r.Run(ctx, "remote")
 	if err != nil {
 		return nil, errhint.WithFix(
 			fmt.Errorf("list remotes: %w", err),

--- a/internal/git/remote_test.go
+++ b/internal/git/remote_test.go
@@ -65,7 +65,7 @@ func TestRemoteExistsTrue(t *testing.T) {
 			return "https://github.com/owner/repo.git", nil
 		},
 	}
-	if !RemoteExists(r, "origin") {
+	if !RemoteExists(context.Background(), r, "origin") {
 		t.Error("expected remote to exist")
 	}
 }
@@ -76,7 +76,7 @@ func TestRemoteExistsFalse(t *testing.T) {
 			return "", errors.New("no such remote 'gh-fork-bob'")
 		},
 	}
-	if RemoteExists(r, "gh-fork-bob") {
+	if RemoteExists(context.Background(), r, "gh-fork-bob") {
 		t.Error("expected remote to not exist")
 	}
 }
@@ -89,7 +89,7 @@ func TestAddRemote(t *testing.T) {
 			return "", nil
 		},
 	}
-	if err := AddRemote(r, "gh-fork-alice", "https://github.com/alice/repo.git"); err != nil {
+	if err := AddRemote(context.Background(), r, "gh-fork-alice", "https://github.com/alice/repo.git"); err != nil {
 		t.Fatalf("AddRemote: %v", err)
 	}
 	want := []string{"remote", "add", "gh-fork-alice", "https://github.com/alice/repo.git"}
@@ -109,7 +109,7 @@ func TestAddRemoteError(t *testing.T) {
 			return "", errors.New("remote already exists")
 		},
 	}
-	if err := AddRemote(r, "origin", "https://github.com/x/y.git"); err == nil {
+	if err := AddRemote(context.Background(), r, "origin", "https://github.com/x/y.git"); err == nil {
 		t.Fatal("expected error from AddRemote")
 	}
 }
@@ -236,7 +236,7 @@ func TestListRemotesTwoRemotes(t *testing.T) {
 			return "origin\nupstream\n", nil
 		},
 	}
-	remotes, err := ListRemotes(r)
+	remotes, err := ListRemotes(context.Background(), r)
 	if err != nil {
 		t.Fatalf("ListRemotes: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestListRemotesEmpty(t *testing.T) {
 			return "", nil
 		},
 	}
-	remotes, err := ListRemotes(r)
+	remotes, err := ListRemotes(context.Background(), r)
 	if err != nil {
 		t.Fatalf("ListRemotes: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestListRemotesRunnerError(t *testing.T) {
 			return "", errors.New("not a git repository")
 		},
 	}
-	_, err := ListRemotes(r)
+	_, err := ListRemotes(context.Background(), r)
 	if err == nil {
 		t.Fatal("expected error from ListRemotes")
 	}

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -25,7 +25,7 @@ const (
 
 // RepoRoot returns the absolute path to the repository root.
 func RepoRoot(ctx context.Context, r Runner) (string, error) {
-	out, err := r.RunContext(ctx, cmdRevParse, "--show-toplevel")
+	out, err := r.Run(ctx, cmdRevParse, "--show-toplevel")
 	if err != nil {
 		return "", errhint.WithFix(fmt.Errorf("not a git repository: %w", err), notInRepoHint)
 	}
@@ -57,7 +57,7 @@ func MainRepoRoot(ctx context.Context, r Runner) (string, error) {
 // <git-common-dir>/hooks for worktree compatibility.
 func HooksDir(ctx context.Context, r Runner) (string, error) {
 	// Check if core.hooksPath is configured (overrides default)
-	hooksPath, err := r.RunContext(ctx, cmdConfig, "core.hooksPath")
+	hooksPath, err := r.Run(ctx, cmdConfig, "core.hooksPath")
 	if err == nil && hooksPath != "" {
 		if filepath.IsAbs(hooksPath) {
 			return hooksPath, nil
@@ -81,7 +81,7 @@ func HooksDir(ctx context.Context, r Runner) (string, error) {
 // DefaultBranch detects the default branch (main or master).
 func DefaultBranch(ctx context.Context, r Runner) (string, error) {
 	// Try symbolic-ref for origin/HEAD first
-	out, err := r.RunContext(ctx, "symbolic-ref", "refs/remotes/origin/HEAD")
+	out, err := r.Run(ctx, "symbolic-ref", "refs/remotes/origin/HEAD")
 	if err == nil {
 		// refs/remotes/origin/main → main
 		parts := strings.Split(out, "/")
@@ -89,12 +89,12 @@ func DefaultBranch(ctx context.Context, r Runner) (string, error) {
 	}
 
 	// Fall back: check if main exists
-	if _, err := r.RunContext(ctx, cmdRevParse, flagVerify, refsHeadsPrefix+"main"); err == nil {
+	if _, err := r.Run(ctx, cmdRevParse, flagVerify, refsHeadsPrefix+"main"); err == nil {
 		return "main", nil
 	}
 
 	// Fall back: check if master exists
-	if _, err := r.RunContext(ctx, cmdRevParse, flagVerify, refsHeadsPrefix+"master"); err == nil {
+	if _, err := r.Run(ctx, cmdRevParse, flagVerify, refsHeadsPrefix+"master"); err == nil {
 		return "master", nil
 	}
 
@@ -107,7 +107,7 @@ func DefaultBranch(ctx context.Context, r Runner) (string, error) {
 // resolveCommonDir returns the absolute path to the git common directory.
 // --git-common-dir may return a relative path; this resolves it against the repo root.
 func resolveCommonDir(ctx context.Context, r Runner) (string, error) {
-	commonDir, err := r.RunContext(ctx, cmdRevParse, "--git-common-dir")
+	commonDir, err := r.Run(ctx, cmdRevParse, "--git-common-dir")
 	if err != nil {
 		return "", errhint.WithFix(fmt.Errorf("not a git repository: %w", err), notInRepoHint)
 	}

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -23,8 +24,8 @@ const (
 )
 
 // RepoRoot returns the absolute path to the repository root.
-func RepoRoot(r Runner) (string, error) {
-	out, err := r.Run(cmdRevParse, "--show-toplevel")
+func RepoRoot(ctx context.Context, r Runner) (string, error) {
+	out, err := r.RunContext(ctx, cmdRevParse, "--show-toplevel")
 	if err != nil {
 		return "", errhint.WithFix(fmt.Errorf("not a git repository: %w", err), notInRepoHint)
 	}
@@ -32,8 +33,8 @@ func RepoRoot(r Runner) (string, error) {
 }
 
 // RepoName returns the name of the repository (basename of the root directory).
-func RepoName(r Runner) (string, error) {
-	root, err := RepoRoot(r)
+func RepoName(ctx context.Context, r Runner) (string, error) {
+	root, err := RepoRoot(ctx, r)
 	if err != nil {
 		return "", err
 	}
@@ -43,8 +44,8 @@ func RepoName(r Runner) (string, error) {
 // MainRepoRoot returns the absolute path to the main repository root.
 // Unlike RepoRoot, this always returns the main repo root even when called
 // from within a worktree. Uses --git-common-dir whose parent is the main root.
-func MainRepoRoot(r Runner) (string, error) {
-	commonDir, err := resolveCommonDir(r)
+func MainRepoRoot(ctx context.Context, r Runner) (string, error) {
+	commonDir, err := resolveCommonDir(ctx, r)
 	if err != nil {
 		return "", err
 	}
@@ -54,15 +55,15 @@ func MainRepoRoot(r Runner) (string, error) {
 // HooksDir returns the absolute path to the repository's hooks directory.
 // Respects core.hooksPath if configured, otherwise falls back to
 // <git-common-dir>/hooks for worktree compatibility.
-func HooksDir(r Runner) (string, error) {
+func HooksDir(ctx context.Context, r Runner) (string, error) {
 	// Check if core.hooksPath is configured (overrides default)
-	hooksPath, err := r.Run(cmdConfig, "core.hooksPath")
+	hooksPath, err := r.RunContext(ctx, cmdConfig, "core.hooksPath")
 	if err == nil && hooksPath != "" {
 		if filepath.IsAbs(hooksPath) {
 			return hooksPath, nil
 		}
 		// Relative path: resolve against main repo root
-		root, err := MainRepoRoot(r)
+		root, err := MainRepoRoot(ctx, r)
 		if err != nil {
 			return "", err
 		}
@@ -70,7 +71,7 @@ func HooksDir(r Runner) (string, error) {
 	}
 
 	// Default: <git-common-dir>/hooks
-	commonDir, err := resolveCommonDir(r)
+	commonDir, err := resolveCommonDir(ctx, r)
 	if err != nil {
 		return "", err
 	}
@@ -78,9 +79,9 @@ func HooksDir(r Runner) (string, error) {
 }
 
 // DefaultBranch detects the default branch (main or master).
-func DefaultBranch(r Runner) (string, error) {
+func DefaultBranch(ctx context.Context, r Runner) (string, error) {
 	// Try symbolic-ref for origin/HEAD first
-	out, err := r.Run("symbolic-ref", "refs/remotes/origin/HEAD")
+	out, err := r.RunContext(ctx, "symbolic-ref", "refs/remotes/origin/HEAD")
 	if err == nil {
 		// refs/remotes/origin/main → main
 		parts := strings.Split(out, "/")
@@ -88,12 +89,12 @@ func DefaultBranch(r Runner) (string, error) {
 	}
 
 	// Fall back: check if main exists
-	if _, err := r.Run(cmdRevParse, flagVerify, refsHeadsPrefix+"main"); err == nil {
+	if _, err := r.RunContext(ctx, cmdRevParse, flagVerify, refsHeadsPrefix+"main"); err == nil {
 		return "main", nil
 	}
 
 	// Fall back: check if master exists
-	if _, err := r.Run(cmdRevParse, flagVerify, refsHeadsPrefix+"master"); err == nil {
+	if _, err := r.RunContext(ctx, cmdRevParse, flagVerify, refsHeadsPrefix+"master"); err == nil {
 		return "master", nil
 	}
 
@@ -105,14 +106,14 @@ func DefaultBranch(r Runner) (string, error) {
 
 // resolveCommonDir returns the absolute path to the git common directory.
 // --git-common-dir may return a relative path; this resolves it against the repo root.
-func resolveCommonDir(r Runner) (string, error) {
-	commonDir, err := r.Run(cmdRevParse, "--git-common-dir")
+func resolveCommonDir(ctx context.Context, r Runner) (string, error) {
+	commonDir, err := r.RunContext(ctx, cmdRevParse, "--git-common-dir")
 	if err != nil {
 		return "", errhint.WithFix(fmt.Errorf("not a git repository: %w", err), notInRepoHint)
 	}
 
 	if !filepath.IsAbs(commonDir) {
-		root, err := RepoRoot(r)
+		root, err := RepoRoot(ctx, r)
 		if err != nil {
 			return "", err
 		}

--- a/internal/git/repo_test.go
+++ b/internal/git/repo_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestRepoRoot(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	root, err := git.RepoRoot(r)
+	root, err := git.RepoRoot(context.Background(), r)
 	if err != nil {
 		t.Fatalf("RepoRoot: %v", err)
 	}
@@ -37,7 +38,7 @@ func TestRepoName(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	name, err := git.RepoName(r)
+	name, err := git.RepoName(context.Background(), r)
 	if err != nil {
 		t.Fatalf("RepoName: %v", err)
 	}
@@ -55,7 +56,7 @@ func TestHooksDir(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	dir, err := git.HooksDir(r)
+	dir, err := git.HooksDir(context.Background(), r)
 	if err != nil {
 		t.Fatalf("HooksDir: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestHooksDirWithCoreHooksPath(t *testing.T) {
 	testutil.GitCmd(t, repo, "config", "core.hooksPath", ".githooks")
 
 	r := &git.ExecRunner{Dir: repo}
-	dir, err := git.HooksDir(r)
+	dir, err := git.HooksDir(context.Background(), r)
 	if err != nil {
 		t.Fatalf("HooksDir: %v", err)
 	}
@@ -100,7 +101,7 @@ func TestMainRepoRoot(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	root, err := git.MainRepoRoot(r)
+	root, err := git.MainRepoRoot(context.Background(), r)
 	if err != nil {
 		t.Fatalf("MainRepoRoot: %v", err)
 	}
@@ -123,13 +124,13 @@ func TestMainRepoRootFromWorktree(t *testing.T) {
 
 	// Create a worktree
 	wtPath := filepath.Join(repo, ".worktrees", "test-wt")
-	if err := git.AddWorktree(r, wtPath, "feature/test-wt", "main"); err != nil {
+	if err := git.AddWorktree(context.Background(), r, wtPath, "feature/test-wt", "main"); err != nil {
 		t.Fatalf("AddWorktree: %v", err)
 	}
 
 	// Run MainRepoRoot from the worktree
 	wr := &git.ExecRunner{Dir: wtPath}
-	root, err := git.MainRepoRoot(wr)
+	root, err := git.MainRepoRoot(context.Background(), wr)
 	if err != nil {
 		t.Fatalf("MainRepoRoot from worktree: %v", err)
 	}
@@ -142,7 +143,7 @@ func TestMainRepoRootFromWorktree(t *testing.T) {
 	}
 
 	// Confirm RepoRoot would give different result (the worktree path)
-	wtRoot, err := git.RepoRoot(wr)
+	wtRoot, err := git.RepoRoot(context.Background(), wr)
 	if err != nil {
 		t.Fatalf("RepoRoot from worktree: %v", err)
 	}
@@ -161,7 +162,7 @@ func TestDefaultBranch(t *testing.T) {
 	repo := testutil.NewTestRepo(t)
 	r := &git.ExecRunner{Dir: repo}
 
-	branch, err := git.DefaultBranch(r)
+	branch, err := git.DefaultBranch(context.Background(), r)
 	if err != nil {
 		t.Fatalf("DefaultBranch: %v", err)
 	}

--- a/internal/git/stash.go
+++ b/internal/git/stash.go
@@ -1,17 +1,18 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
 
 // StashPushAndRef stashes all changes (including untracked files) with the given message
 // and returns the stash object SHA so it can be applied or dropped by reference later.
-func StashPushAndRef(r Runner, dir, message string) (string, error) {
-	if _, err := r.RunInDir(dir, "stash", "push", "-u", "-m", message); err != nil {
+func StashPushAndRef(ctx context.Context, r Runner, dir, message string) (string, error) {
+	if _, err := r.RunInDirContext(ctx, dir, "stash", "push", "-u", "-m", message); err != nil {
 		return "", fmt.Errorf("stash push: %w", err)
 	}
-	sha, err := r.RunInDir(dir, "rev-parse", "stash@{0}")
+	sha, err := r.RunInDirContext(ctx, dir, "rev-parse", "stash@{0}")
 	if err != nil {
 		return "", fmt.Errorf("resolve stash ref: %w", err)
 	}
@@ -21,25 +22,27 @@ func StashPushAndRef(r Runner, dir, message string) (string, error) {
 // StashApply applies the stash identified by sha in the given directory.
 // git stash apply accepts commit SHAs directly.
 // On conflict the error wraps the stderr output so conflict markers surface to the caller.
+// Intentionally non-cancellable: working-tree restores must complete after cancellation to avoid data loss.
 func StashApply(r Runner, dir, sha string) error {
-	_, err := r.RunInDir(dir, "stash", "apply", sha)
+	_, err := r.RunInDirContext(context.Background(), dir, "stash", "apply", sha)
 	return err
 }
 
 // StashDrop drops the stash entry whose commit SHA matches sha.
 // git stash drop requires stash@{N} form; this function resolves the SHA to the ref first.
+// Intentionally non-cancellable: stash cleanup must complete to avoid orphaned stash entries.
 func StashDrop(r Runner, dir, sha string) error {
 	ref, err := stashRefBySHA(r, dir, sha)
 	if err != nil {
 		return err
 	}
-	_, err = r.RunInDir(dir, "stash", "drop", ref)
+	_, err = r.RunInDirContext(context.Background(), dir, "stash", "drop", ref)
 	return err
 }
 
 // stashRefBySHA walks the stash list to find the stash@{N} ref matching sha.
 func stashRefBySHA(r Runner, dir, sha string) (string, error) {
-	out, err := r.RunInDir(dir, "stash", "list", "--format=%H %gd")
+	out, err := r.RunInDirContext(context.Background(), dir, "stash", "list", "--format=%H %gd")
 	if err != nil {
 		return "", fmt.Errorf("stash list: %w", err)
 	}

--- a/internal/git/stash.go
+++ b/internal/git/stash.go
@@ -9,10 +9,10 @@ import (
 // StashPushAndRef stashes all changes (including untracked files) with the given message
 // and returns the stash object SHA so it can be applied or dropped by reference later.
 func StashPushAndRef(ctx context.Context, r Runner, dir, message string) (string, error) {
-	if _, err := r.RunInDirContext(ctx, dir, "stash", "push", "-u", "-m", message); err != nil {
+	if _, err := r.RunInDir(ctx, dir, "stash", "push", "-u", "-m", message); err != nil {
 		return "", fmt.Errorf("stash push: %w", err)
 	}
-	sha, err := r.RunInDirContext(ctx, dir, "rev-parse", "stash@{0}")
+	sha, err := r.RunInDir(ctx, dir, "rev-parse", "stash@{0}")
 	if err != nil {
 		return "", fmt.Errorf("resolve stash ref: %w", err)
 	}
@@ -24,7 +24,7 @@ func StashPushAndRef(ctx context.Context, r Runner, dir, message string) (string
 // On conflict the error wraps the stderr output so conflict markers surface to the caller.
 // Intentionally non-cancellable: working-tree restores must complete after cancellation to avoid data loss.
 func StashApply(r Runner, dir, sha string) error {
-	_, err := r.RunInDirContext(context.Background(), dir, "stash", "apply", sha)
+	_, err := r.RunInDir(context.Background(), dir, "stash", "apply", sha)
 	return err
 }
 
@@ -36,13 +36,14 @@ func StashDrop(r Runner, dir, sha string) error {
 	if err != nil {
 		return err
 	}
-	_, err = r.RunInDirContext(context.Background(), dir, "stash", "drop", ref)
+	_, err = r.RunInDir(context.Background(), dir, "stash", "drop", ref)
 	return err
 }
 
 // stashRefBySHA walks the stash list to find the stash@{N} ref matching sha.
+// Intentionally non-cancellable: called only from StashDrop, a recovery path.
 func stashRefBySHA(r Runner, dir, sha string) (string, error) {
-	out, err := r.RunInDirContext(context.Background(), dir, "stash", "list", "--format=%H %gd")
+	out, err := r.RunInDir(context.Background(), dir, "stash", "list", "--format=%H %gd")
 	if err != nil {
 		return "", fmt.Errorf("stash list: %w", err)
 	}

--- a/internal/git/stash_test.go
+++ b/internal/git/stash_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -17,7 +18,7 @@ func TestStashPushAndRef(t *testing.T) {
 	r := &git.ExecRunner{Dir: repo}
 	testutil.CreateFile(t, repo, "dirty.txt", "dirty content")
 
-	sha, err := git.StashPushAndRef(r, repo, "test stash")
+	sha, err := git.StashPushAndRef(context.Background(), r, repo, "test stash")
 	if err != nil {
 		t.Fatalf("StashPushAndRef: %v", err)
 	}
@@ -38,12 +39,12 @@ func TestStashApply(t *testing.T) {
 	r := &git.ExecRunner{Dir: repo}
 	testutil.CreateFile(t, repo, "stash-apply.txt", "content")
 
-	sha, err := git.StashPushAndRef(r, repo, "apply test")
+	sha, err := git.StashPushAndRef(context.Background(), r, repo, "apply test")
 	if err != nil {
 		t.Fatalf("StashPushAndRef: %v", err)
 	}
 
-	dirty, err := git.IsDirty(r, repo)
+	dirty, err := git.IsDirty(context.Background(), r, repo)
 	if err != nil {
 		t.Fatalf("IsDirty: %v", err)
 	}
@@ -55,7 +56,7 @@ func TestStashApply(t *testing.T) {
 		t.Fatalf("StashApply: %v", err)
 	}
 
-	dirty, err = git.IsDirty(r, repo)
+	dirty, err = git.IsDirty(context.Background(), r, repo)
 	if err != nil {
 		t.Fatalf("IsDirty after apply: %v", err)
 	}
@@ -73,7 +74,7 @@ func TestStashDrop(t *testing.T) {
 	r := &git.ExecRunner{Dir: repo}
 	testutil.CreateFile(t, repo, "stash-drop.txt", "content")
 
-	sha, err := git.StashPushAndRef(r, repo, "drop test")
+	sha, err := git.StashPushAndRef(context.Background(), r, repo, "drop test")
 	if err != nil {
 		t.Fatalf("StashPushAndRef: %v", err)
 	}

--- a/internal/git/sync.go
+++ b/internal/git/sync.go
@@ -28,25 +28,25 @@ func Rebase(ctx context.Context, r Runner, dir, branch string) error {
 // AbortRebase runs `git rebase --abort` inside the given directory.
 // Intentionally non-cancellable: rebase recovery must succeed even after Ctrl-C.
 func AbortRebase(r Runner, dir string) error {
-	_, err := r.RunInDir(dir, "rebase", "--abort")
+	_, err := r.RunInDirContext(context.Background(), dir, "rebase", "--abort")
 	return err
 }
 
 // MergeBase returns the merge-base commit of two refs.
-func MergeBase(r Runner, ref1, ref2 string) (string, error) {
-	return r.Run("merge-base", ref1, ref2)
+func MergeBase(ctx context.Context, r Runner, ref1, ref2 string) (string, error) {
+	return r.RunContext(ctx, "merge-base", ref1, ref2)
 }
 
 // IsMergeBaseAncestor checks if ancestor is an ancestor of descendant
 // using `git merge-base --is-ancestor`.
-func IsMergeBaseAncestor(r Runner, ancestor, descendant string) bool {
-	_, err := r.Run("merge-base", "--is-ancestor", ancestor, descendant)
+func IsMergeBaseAncestor(ctx context.Context, r Runner, ancestor, descendant string) bool {
+	_, err := r.RunContext(ctx, "merge-base", "--is-ancestor", ancestor, descendant)
 	return err == nil
 }
 
 // HasUpstream checks whether the current branch in dir has a remote tracking branch.
-func HasUpstream(r Runner, dir string) bool {
-	_, err := r.RunInDir(dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+func HasUpstream(ctx context.Context, r Runner, dir string) bool {
+	_, err := r.RunInDirContext(ctx, dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
 	return err == nil
 }
 

--- a/internal/git/sync.go
+++ b/internal/git/sync.go
@@ -15,49 +15,49 @@ func Fetch(ctx context.Context, r Runner, remote string, args FetchArgs) error {
 		gitArgs = append(gitArgs, "--prune")
 	}
 	gitArgs = append(gitArgs, remote)
-	_, err := r.RunContext(ctx, gitArgs...)
+	_, err := r.Run(ctx, gitArgs...)
 	return err
 }
 
 // Rebase runs `git rebase <branch>` inside the given directory.
 func Rebase(ctx context.Context, r Runner, dir, branch string) error {
-	_, err := r.RunInDirContext(ctx, dir, "rebase", branch)
+	_, err := r.RunInDir(ctx, dir, "rebase", branch)
 	return err
 }
 
 // AbortRebase runs `git rebase --abort` inside the given directory.
 // Intentionally non-cancellable: rebase recovery must succeed even after Ctrl-C.
 func AbortRebase(r Runner, dir string) error {
-	_, err := r.RunInDirContext(context.Background(), dir, "rebase", "--abort")
+	_, err := r.RunInDir(context.Background(), dir, "rebase", "--abort")
 	return err
 }
 
 // MergeBase returns the merge-base commit of two refs.
 func MergeBase(ctx context.Context, r Runner, ref1, ref2 string) (string, error) {
-	return r.RunContext(ctx, "merge-base", ref1, ref2)
+	return r.Run(ctx, "merge-base", ref1, ref2)
 }
 
 // IsMergeBaseAncestor checks if ancestor is an ancestor of descendant
 // using `git merge-base --is-ancestor`.
 func IsMergeBaseAncestor(ctx context.Context, r Runner, ancestor, descendant string) bool {
-	_, err := r.RunContext(ctx, "merge-base", "--is-ancestor", ancestor, descendant)
+	_, err := r.Run(ctx, "merge-base", "--is-ancestor", ancestor, descendant)
 	return err == nil
 }
 
 // HasUpstream checks whether the current branch in dir has a remote tracking branch.
 func HasUpstream(ctx context.Context, r Runner, dir string) bool {
-	_, err := r.RunInDirContext(ctx, dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
+	_, err := r.RunInDir(ctx, dir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}")
 	return err == nil
 }
 
 // Push runs `git push` inside the given directory.
 func Push(ctx context.Context, r Runner, dir string) error {
-	_, err := r.RunInDirContext(ctx, dir, "push")
+	_, err := r.RunInDir(ctx, dir, "push")
 	return err
 }
 
 // PushForceWithLease runs `git push --force-with-lease` inside the given directory.
 func PushForceWithLease(ctx context.Context, r Runner, dir string) error {
-	_, err := r.RunInDirContext(ctx, dir, "push", "--force-with-lease")
+	_, err := r.RunInDir(ctx, dir, "push", "--force-with-lease")
 	return err
 }

--- a/internal/git/sync_ctx_test.go
+++ b/internal/git/sync_ctx_test.go
@@ -14,15 +14,7 @@ type ctxMockRunner struct {
 	capturedCtx context.Context
 }
 
-func (m *ctxMockRunner) Run(args ...string) (string, error) {
-	return m.RunContext(context.Background(), args...)
-}
-
-func (m *ctxMockRunner) RunInDir(dir string, args ...string) (string, error) {
-	return m.RunInDirContext(context.Background(), dir, args...)
-}
-
-func (m *ctxMockRunner) RunContext(ctx context.Context, args ...string) (string, error) {
+func (m *ctxMockRunner) Run(ctx context.Context, args ...string) (string, error) {
 	m.capturedCtx = ctx
 	if m.run != nil {
 		return m.run(ctx, args...)
@@ -30,7 +22,7 @@ func (m *ctxMockRunner) RunContext(ctx context.Context, args ...string) (string,
 	return "", nil
 }
 
-func (m *ctxMockRunner) RunInDirContext(ctx context.Context, dir string, args ...string) (string, error) {
+func (m *ctxMockRunner) RunInDir(ctx context.Context, dir string, args ...string) (string, error) {
 	m.capturedCtx = ctx
 	if m.runInDir != nil {
 		return m.runInDir(ctx, dir, args...)

--- a/internal/git/sync_test.go
+++ b/internal/git/sync_test.go
@@ -141,7 +141,7 @@ func TestMergeBase(t *testing.T) {
 		},
 	}
 
-	sha, err := MergeBase(r, branchMain, branchFeature)
+	sha, err := MergeBase(context.Background(), r, branchMain, branchFeature)
 	if err != nil {
 		t.Fatalf("MergeBase: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestMergeBaseError(t *testing.T) {
 		},
 	}
 
-	_, err := MergeBase(r, branchMain, branchFeature)
+	_, err := MergeBase(context.Background(), r, branchMain, branchFeature)
 	if err == nil {
 		t.Fatal("expected error from MergeBase")
 	}
@@ -173,7 +173,7 @@ func TestIsMergeBaseAncestor(t *testing.T) {
 		},
 	}
 
-	if !IsMergeBaseAncestor(r, branchMain, branchFeature) {
+	if !IsMergeBaseAncestor(context.Background(), r, branchMain, branchFeature) {
 		t.Error("expected true for ancestor check")
 	}
 }
@@ -185,7 +185,7 @@ func TestIsMergeBaseAncestorFalse(t *testing.T) {
 		},
 	}
 
-	if IsMergeBaseAncestor(r, branchMain, branchFeature) {
+	if IsMergeBaseAncestor(context.Background(), r, branchMain, branchFeature) {
 		t.Error("expected false for non-ancestor")
 	}
 }
@@ -200,7 +200,7 @@ func TestHasUpstream(t *testing.T) {
 		},
 	}
 
-	if !HasUpstream(r, fakeDir) {
+	if !HasUpstream(context.Background(), r, fakeDir) {
 		t.Error("expected true when upstream exists")
 	}
 }
@@ -212,7 +212,7 @@ func TestHasUpstreamFalse(t *testing.T) {
 		},
 	}
 
-	if HasUpstream(r, fakeDir) {
+	if HasUpstream(context.Background(), r, fakeDir) {
 		t.Error("expected false when no upstream")
 	}
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -26,41 +27,42 @@ type WorktreeEntry struct {
 }
 
 // AddWorktree creates a new worktree at the given path with a new branch from source.
-func AddWorktree(r Runner, path, branch, source string) error {
-	_, err := r.Run(cmdWorktree, "add", "-b", branch, path, source)
+func AddWorktree(ctx context.Context, r Runner, path, branch, source string) error {
+	_, err := r.RunContext(ctx, cmdWorktree, "add", "-b", branch, path, source)
 	return err
 }
 
 // AddWorktreeFromBranch creates a worktree from an existing branch (no -b flag).
-func AddWorktreeFromBranch(r Runner, path, branch string) error {
-	_, err := r.Run(cmdWorktree, "add", "--", path, branch)
+func AddWorktreeFromBranch(ctx context.Context, r Runner, path, branch string) error {
+	_, err := r.RunContext(ctx, cmdWorktree, "add", "--", path, branch)
 	return err
 }
 
 // RemoveWorktree removes the worktree at the given path.
-func RemoveWorktree(r Runner, path string, force bool) error {
+func RemoveWorktree(ctx context.Context, r Runner, path string, force bool) error {
 	args := []string{cmdWorktree, "remove", path}
 	if force {
 		args = append(args, flagForce)
 	}
-	_, err := r.Run(args...)
+	_, err := r.RunContext(ctx, args...)
 	return err
 }
 
 // MoveWorktree moves the worktree from oldPath to newPath.
 // When force is true, --force is passed twice so that even locked worktrees can be moved.
+// Intentionally non-cancellable: rollback moves must complete to avoid stranded worktrees.
 func MoveWorktree(r Runner, oldPath, newPath string, force bool) error {
 	args := []string{cmdWorktree, "move", oldPath, newPath}
 	if force {
 		args = append(args, flagForce, flagForce)
 	}
-	_, err := r.Run(args...)
+	_, err := r.RunContext(context.Background(), args...)
 	return err
 }
 
 // ListWorktrees returns all worktrees by parsing `git worktree list --porcelain`.
-func ListWorktrees(r Runner) ([]WorktreeEntry, error) {
-	out, err := r.Run(cmdWorktree, "list", "--porcelain")
+func ListWorktrees(ctx context.Context, r Runner) ([]WorktreeEntry, error) {
+	out, err := r.RunContext(ctx, cmdWorktree, "list", "--porcelain")
 	if err != nil {
 		return nil, err
 	}
@@ -119,12 +121,12 @@ func FindEntry(entries []WorktreeEntry, branch string) *WorktreeEntry {
 }
 
 // Prune runs `git worktree prune` to clean up stale worktree references.
-func Prune(r Runner, dryRun bool) (string, error) {
+func Prune(ctx context.Context, r Runner, dryRun bool) (string, error) {
 	args := []string{cmdWorktree, "prune"}
 	if dryRun {
 		args = append(args, "--dry-run")
 	}
-	out, err := r.Run(args...)
+	out, err := r.RunContext(ctx, args...)
 	if err != nil {
 		return "", errhint.WithFix(
 			fmt.Errorf("prune: %w", err),

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -28,13 +28,13 @@ type WorktreeEntry struct {
 
 // AddWorktree creates a new worktree at the given path with a new branch from source.
 func AddWorktree(ctx context.Context, r Runner, path, branch, source string) error {
-	_, err := r.RunContext(ctx, cmdWorktree, "add", "-b", branch, path, source)
+	_, err := r.Run(ctx, cmdWorktree, "add", "-b", branch, path, source)
 	return err
 }
 
 // AddWorktreeFromBranch creates a worktree from an existing branch (no -b flag).
 func AddWorktreeFromBranch(ctx context.Context, r Runner, path, branch string) error {
-	_, err := r.RunContext(ctx, cmdWorktree, "add", "--", path, branch)
+	_, err := r.Run(ctx, cmdWorktree, "add", "--", path, branch)
 	return err
 }
 
@@ -44,7 +44,7 @@ func RemoveWorktree(ctx context.Context, r Runner, path string, force bool) erro
 	if force {
 		args = append(args, flagForce)
 	}
-	_, err := r.RunContext(ctx, args...)
+	_, err := r.Run(ctx, args...)
 	return err
 }
 
@@ -56,13 +56,13 @@ func MoveWorktree(r Runner, oldPath, newPath string, force bool) error {
 	if force {
 		args = append(args, flagForce, flagForce)
 	}
-	_, err := r.RunContext(context.Background(), args...)
+	_, err := r.Run(context.Background(), args...)
 	return err
 }
 
 // ListWorktrees returns all worktrees by parsing `git worktree list --porcelain`.
 func ListWorktrees(ctx context.Context, r Runner) ([]WorktreeEntry, error) {
-	out, err := r.RunContext(ctx, cmdWorktree, "list", "--porcelain")
+	out, err := r.Run(ctx, cmdWorktree, "list", "--porcelain")
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func Prune(ctx context.Context, r Runner, dryRun bool) (string, error) {
 	if dryRun {
 		args = append(args, "--dry-run")
 	}
-	out, err := r.RunContext(ctx, args...)
+	out, err := r.Run(ctx, args...)
 	if err != nil {
 		return "", errhint.WithFix(
 			fmt.Errorf("prune: %w", err),

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -1,6 +1,7 @@
 package git_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +20,7 @@ func TestAddAndListWorktrees(t *testing.T) {
 
 	wtPath := filepath.Join(filepath.Dir(repo), "wt-feat-login")
 
-	if err := git.AddWorktree(r, wtPath, "feat/login", "main"); err != nil {
+	if err := git.AddWorktree(context.Background(), r, wtPath, "feat/login", "main"); err != nil {
 		t.Fatalf(fatalAddWorktree, err)
 	}
 
@@ -28,7 +29,7 @@ func TestAddAndListWorktrees(t *testing.T) {
 		t.Fatalf("worktree dir not created: %v", err)
 	}
 
-	entries, err := git.ListWorktrees(r)
+	entries, err := git.ListWorktrees(context.Background(), r)
 	if err != nil {
 		t.Fatalf("ListWorktrees: %v", err)
 	}
@@ -62,7 +63,7 @@ func TestAddWorktreeFromBranch(t *testing.T) {
 	testutil.GitCmd(t, repo, "branch", "feat/existing")
 
 	wtPath := filepath.Join(filepath.Dir(repo), "wt-from-branch")
-	if err := git.AddWorktreeFromBranch(r, wtPath, "feat/existing"); err != nil {
+	if err := git.AddWorktreeFromBranch(context.Background(), r, wtPath, "feat/existing"); err != nil {
 		t.Fatalf("AddWorktreeFromBranch: %v", err)
 	}
 
@@ -70,7 +71,7 @@ func TestAddWorktreeFromBranch(t *testing.T) {
 		t.Fatalf("worktree dir not created: %v", err)
 	}
 
-	entries, err := git.ListWorktrees(r)
+	entries, err := git.ListWorktrees(context.Background(), r)
 	if err != nil {
 		t.Fatalf("ListWorktrees: %v", err)
 	}
@@ -96,11 +97,11 @@ func TestRemoveWorktree(t *testing.T) {
 	r := &git.ExecRunner{Dir: repo}
 
 	wtPath := filepath.Join(filepath.Dir(repo), "wt-to-remove")
-	if err := git.AddWorktree(r, wtPath, "feat/remove-me", "main"); err != nil {
+	if err := git.AddWorktree(context.Background(), r, wtPath, "feat/remove-me", "main"); err != nil {
 		t.Fatalf(fatalAddWorktree, err)
 	}
 
-	if err := git.RemoveWorktree(r, wtPath, false); err != nil {
+	if err := git.RemoveWorktree(context.Background(), r, wtPath, false); err != nil {
 		t.Fatalf("RemoveWorktree: %v", err)
 	}
 
@@ -165,7 +166,7 @@ func TestMoveWorktree(t *testing.T) {
 	r := &git.ExecRunner{Dir: repo}
 
 	oldPath := filepath.Join(filepath.Dir(repo), "wt-to-move")
-	if err := git.AddWorktree(r, oldPath, "feat/move-me", "main"); err != nil {
+	if err := git.AddWorktree(context.Background(), r, oldPath, "feat/move-me", "main"); err != nil {
 		t.Fatalf(fatalAddWorktree, err)
 	}
 
@@ -190,7 +191,7 @@ func TestMoveWorktree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EvalSymlinks: %v", err)
 	}
-	entries, err := git.ListWorktrees(r)
+	entries, err := git.ListWorktrees(context.Background(), r)
 	if err != nil {
 		t.Fatalf("ListWorktrees: %v", err)
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -29,14 +29,14 @@ type mockRunner struct {
 	runInDir func(dir string, args ...string) (string, error)
 }
 
-func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
+func (m *mockRunner) Run(_ context.Context, args ...string) (string, error) {
 	if m.run == nil {
 		return "", nil
 	}
 	return m.run(args...)
 }
 
-func (m *mockRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
+func (m *mockRunner) RunInDir(_ context.Context, dir string, args ...string) (string, error) {
 	if m.runInDir == nil {
 		return "", nil
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -29,26 +29,18 @@ type mockRunner struct {
 	runInDir func(dir string, args ...string) (string, error)
 }
 
-func (m *mockRunner) Run(args ...string) (string, error) {
+func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
 	if m.run == nil {
 		return "", nil
 	}
 	return m.run(args...)
 }
 
-func (m *mockRunner) RunInDir(dir string, args ...string) (string, error) {
+func (m *mockRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
 	if m.runInDir == nil {
 		return "", nil
 	}
 	return m.runInDir(dir, args...)
-}
-
-func (m *mockRunner) RunContext(ctx context.Context, args ...string) (string, error) {
-	return m.Run(args...)
-}
-
-func (m *mockRunner) RunInDirContext(ctx context.Context, dir string, args ...string) (string, error) {
-	return m.RunInDir(dir, args...)
 }
 
 // testConfig returns a minimal config suitable for testing.

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -58,14 +58,14 @@ func handleClean(hctx *HandlerContext) server.ToolHandlerFunc {
 }
 
 func mcpCleanPrune(ctx context.Context, r git.Runner, dryRun bool) (*mcp.CallToolResult, error) {
-	output, err := git.Prune(r, dryRun)
+	output, err := git.Prune(ctx, r, dryRun)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	var remotePruned []string
 	warnings := []string{}
-	remotes, err := git.ListRemotes(r)
+	remotes, err := git.ListRemotes(ctx, r)
 	if err != nil {
 		warnings = append(warnings, fmt.Sprintf("failed to list remotes: %v", err))
 	} else {
@@ -87,7 +87,7 @@ func mcpCleanPrune(ctx context.Context, r git.Runner, dryRun bool) (*mcp.CallToo
 }
 
 func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dryRun bool, force bool) (*mcp.CallToolResult, error) {
-	mainBranch, err := operations.ResolveMainBranch(r, configDefault(hctx))
+	mainBranch, err := operations.ResolveMainBranch(ctx, r, configDefault(hctx))
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -100,7 +100,7 @@ func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dry
 		mergeRef = git.DefaultRemote + "/" + mainBranch
 	}
 
-	mergedResult, err := operations.FindMergedCandidates(r, mergeRef, mainBranch)
+	mergedResult, err := operations.FindMergedCandidates(ctx, r, mergeRef, mainBranch)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -119,7 +119,7 @@ func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dry
 	}
 
 	// Probe origin once so RemoveCandidates does not re-issue git remote get-url per candidate.
-	originPresent := git.RemoteExists(r, git.DefaultRemote)
+	originPresent := git.RemoteExists(ctx, r, git.DefaultRemote)
 	opItems := operations.RemoveCandidates(ctx, r, mergedResult.Candidates, originPresent, force, nil)
 	warnings := mergedResult.Warnings
 	items := make([]cleanedItem, len(opItems))
@@ -138,12 +138,12 @@ func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dry
 }
 
 func mcpCleanStale(ctx context.Context, r git.Runner, hctx *HandlerContext, dryRun bool, staleDays int, force bool) (*mcp.CallToolResult, error) {
-	mainBranch, err := operations.ResolveMainBranch(r, configDefault(hctx))
+	mainBranch, err := operations.ResolveMainBranch(ctx, r, configDefault(hctx))
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	staleResult, err := operations.FindStaleCandidates(r, mainBranch, staleDays)
+	staleResult, err := operations.FindStaleCandidates(ctx, r, mainBranch, staleDays)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}

--- a/internal/mcp/tool_conflict.go
+++ b/internal/mcp/tool_conflict.go
@@ -31,7 +31,7 @@ func handleConflictCheck(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		r := hctx.Runner
 
-		worktrees, err := operations.ListWorktreeInfos(r)
+		worktrees, err := operations.ListWorktreeInfos(ctx, r)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -46,7 +46,7 @@ func handleConflictCheck(hctx *HandlerContext) server.ToolHandlerFunc {
 			})
 		}
 
-		diffs, err := conflict.CollectDiffs(r, cfg.DefaultSource, eligible)
+		diffs, err := conflict.CollectDiffs(ctx, r, cfg.DefaultSource, eligible)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -60,7 +60,7 @@ func handleConflictCheck(hctx *HandlerContext) server.ToolHandlerFunc {
 		}
 
 		if dryMerge {
-			dryResults, err := conflict.DryMergeAll(r, eligible)
+			dryResults, err := conflict.DryMergeAll(ctx, r, eligible)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}

--- a/internal/mcp/tool_exec.go
+++ b/internal/mcp/tool_exec.go
@@ -74,7 +74,7 @@ func handleExec(hctx *HandlerContext) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("invalid type %q; valid types: feature, bugfix, hotfix, docs, test, chore", typeFilter)), nil
 		}
 
-		filtered, err := resolveExecTargets(hctx.Runner, cfg, typeFilter, dirty)
+		filtered, err := resolveExecTargets(ctx, hctx.Runner, cfg, typeFilter, dirty)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -92,8 +92,8 @@ func handleExec(hctx *HandlerContext) server.ToolHandlerFunc {
 }
 
 // resolveExecTargets collects and filters worktrees for exec.
-func resolveExecTargets(r git.Runner, cfg *config.Config, typeFilter string, dirty bool) ([]resolver.WorktreeInfo, error) {
-	worktrees, err := operations.ListWorktreeInfos(r)
+func resolveExecTargets(ctx context.Context, r git.Runner, cfg *config.Config, typeFilter string, dirty bool) ([]resolver.WorktreeInfo, error) {
+	worktrees, err := operations.ListWorktreeInfos(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func resolveExecTargets(r git.Runner, cfg *config.Config, typeFilter string, dir
 	}
 
 	if dirty {
-		filtered = filterDirty(r, filtered)
+		filtered = filterDirty(ctx, r, filtered)
 	}
 
 	return filtered, nil
@@ -172,7 +172,7 @@ func buildExecData(command string, results []executor.Result) execData {
 // filterDirty filters worktrees to only those with uncommitted changes.
 // If IsDirty returns an error, the worktree is treated as dirty (included)
 // and a warning is written to os.Stderr so the operator can investigate.
-func filterDirty(r git.Runner, worktrees []resolver.WorktreeInfo) []resolver.WorktreeInfo {
+func filterDirty(ctx context.Context, r git.Runner, worktrees []resolver.WorktreeInfo) []resolver.WorktreeInfo {
 	isDirtyFlags := make([]bool, len(worktrees))
 	warnings := make([]string, len(worktrees))
 	var wg sync.WaitGroup
@@ -185,7 +185,7 @@ func filterDirty(r git.Runner, worktrees []resolver.WorktreeInfo) []resolver.Wor
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			d, err := git.IsDirty(r, path)
+			d, err := git.IsDirty(ctx, r, path)
 			if err != nil {
 				warnings[idx] = fmt.Sprintf("Warning: cannot check dirty status for %s: %v", path, err)
 				isDirtyFlags[idx] = true

--- a/internal/mcp/tool_exec_test.go
+++ b/internal/mcp/tool_exec_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -172,7 +173,7 @@ func TestFilterDirty(t *testing.T) {
 			return "", nil // clean
 		},
 	}
-	result := filterDirty(r, worktrees)
+	result := filterDirty(context.Background(), r, worktrees)
 	if len(result) != 1 {
 		t.Fatalf("expected 1 dirty, got %d", len(result))
 	}
@@ -190,7 +191,7 @@ func TestFilterDirtyAll(t *testing.T) {
 			return dirtyOutput, nil
 		},
 	}
-	result := filterDirty(r, worktrees)
+	result := filterDirty(context.Background(), r, worktrees)
 	if len(result) != 1 {
 		t.Fatalf("expected 1, got %d", len(result))
 	}
@@ -205,7 +206,7 @@ func TestFilterDirtyNone(t *testing.T) {
 			return "", nil
 		},
 	}
-	result := filterDirty(r, worktrees)
+	result := filterDirty(context.Background(), r, worktrees)
 	if len(result) != 0 {
 		t.Fatalf("expected 0, got %d", len(result))
 	}
@@ -224,7 +225,7 @@ func TestFilterDirtyError(t *testing.T) {
 	pr, pw, _ := os.Pipe()
 	os.Stderr = pw
 
-	result := filterDirty(r, worktrees)
+	result := filterDirty(context.Background(), r, worktrees)
 
 	pw.Close()
 	os.Stderr = origStderr
@@ -249,7 +250,7 @@ func TestFilterDirtyErrorIncludedAndWarned(t *testing.T) {
 	pr, pw, _ := os.Pipe()
 	os.Stderr = pw
 
-	result := filterDirty(r, worktrees)
+	result := filterDirty(context.Background(), r, worktrees)
 
 	pw.Close()
 	os.Stderr = origStderr

--- a/internal/mcp/tool_list.go
+++ b/internal/mcp/tool_list.go
@@ -43,7 +43,7 @@ func handleList(hctx *HandlerContext) server.ToolHandlerFunc {
 		r := hctx.Runner
 
 		if archived {
-			return handleListArchived(r, hctx)
+			return handleListArchived(ctx, r, hctx)
 		}
 
 		cfg, err := hctx.requireConfig()
@@ -84,13 +84,13 @@ func detailsToListItems(rows []resolver.WorktreeDetail) []listItem {
 	return items
 }
 
-func handleListArchived(r git.Runner, hctx *HandlerContext) (*mcp.CallToolResult, error) {
-	mainBranch, err := operations.ResolveMainBranch(r, configDefault(hctx))
+func handleListArchived(ctx context.Context, r git.Runner, hctx *HandlerContext) (*mcp.CallToolResult, error) {
+	mainBranch, err := operations.ResolveMainBranch(ctx, r, configDefault(hctx))
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	archived, err := operations.ListArchivedBranches(r, mainBranch)
+	archived, err := operations.ListArchivedBranches(ctx, r, mainBranch)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}

--- a/internal/mcp/tool_remove.go
+++ b/internal/mcp/tool_remove.go
@@ -39,12 +39,12 @@ func handleRemove(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		r := hctx.Runner
 
-		wt, findErr := operations.FindWorktree(r, service, task)
+		wt, findErr := operations.FindWorktree(ctx, r, service, task)
 		if findErr != nil {
 			return mcp.NewToolResultError(findErr.Error()), nil
 		}
 
-		result, err := operations.RemoveWorktree(r, wt, task, keepBranch, force, nil)
+		result, err := operations.RemoveWorktree(ctx, r, wt, task, keepBranch, force, nil)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}

--- a/internal/mcp/tool_status.go
+++ b/internal/mcp/tool_status.go
@@ -35,12 +35,12 @@ func handleStatus(hctx *HandlerContext) server.ToolHandlerFunc {
 		staleDays := req.GetInt("stale_days", 14)
 		r := hctx.Runner
 
-		mainBranch, err := operations.ResolveMainBranch(r, configDefault(hctx))
+		mainBranch, err := operations.ResolveMainBranch(ctx, r, configDefault(hctx))
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		entries, err := git.ListWorktrees(r)
+		entries, err := git.ListWorktrees(ctx, r)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -57,10 +57,10 @@ func handleStatus(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		results := parallel.Collect(len(candidates), 8, func(i int) statusCollectedEntry {
 			e := candidates[i]
-			st := operations.CollectWorktreeStatus(r, e.Path)
+			st := operations.CollectWorktreeStatus(ctx, r, e.Path)
 			var ct time.Time
 			var hasTime bool
-			if t, err := git.LastCommitTime(r, e.Branch); err == nil {
+			if t, err := git.LastCommitTime(ctx, r, e.Branch); err == nil {
 				ct = t
 				hasTime = true
 			}

--- a/internal/mcp/tool_sync.go
+++ b/internal/mcp/tool_sync.go
@@ -72,7 +72,7 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fetchErr.Error()), nil
 		}
 
-		worktrees, err := operations.ListWorktreeInfos(r)
+		worktrees, err := operations.ListWorktreeInfos(ctx, r)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}

--- a/internal/operations/add.go
+++ b/internal/operations/add.go
@@ -63,7 +63,7 @@ func AddWorktree(ctx context.Context, r git.Runner, params AddParams, onProgress
 	}
 
 	// Validate
-	if git.BranchExists(r, branch) {
+	if git.BranchExists(ctx, r, branch) {
 		return result, errhint.WithFix(
 			fmt.Errorf("branch %q already exists", branch),
 			"run 'rimba list' to see existing tasks, or use a different task name",
@@ -78,7 +78,7 @@ func AddWorktree(ctx context.Context, r git.Runner, params AddParams, onProgress
 
 	// Create worktree
 	progress.Notify(onProgress, "Creating worktree...")
-	if err := git.AddWorktree(r, wtPath, branch, params.Source); err != nil {
+	if err := git.AddWorktree(ctx, r, wtPath, branch, params.Source); err != nil {
 		return result, err
 	}
 

--- a/internal/operations/add_branch.go
+++ b/internal/operations/add_branch.go
@@ -15,8 +15,8 @@ import (
 // PromoteBranch moves the main repo's current branch into its own worktree,
 // transferring any dirty working-tree state via git stash push / apply.
 // worktreeDir must be an absolute path to the directory that holds worktrees.
-func PromoteBranch(_ context.Context, worktreeDir string, r git.Runner, repoRoot, branch string) (string, error) {
-	defaultBranch, err := validateForPromotion(r, repoRoot, branch)
+func PromoteBranch(ctx context.Context, worktreeDir string, r git.Runner, repoRoot, branch string) (string, error) {
+	defaultBranch, err := validateForPromotion(ctx, r, repoRoot, branch)
 	if err != nil {
 		return "", err
 	}
@@ -29,46 +29,46 @@ func PromoteBranch(_ context.Context, worktreeDir string, r git.Runner, repoRoot
 		)
 	}
 
-	dirty, err := git.IsDirty(r, repoRoot)
+	dirty, err := git.IsDirty(ctx, r, repoRoot)
 	if err != nil {
 		return "", err
 	}
 	var stashSHA string
 	if dirty {
-		stashSHA, err = git.StashPushAndRef(r, repoRoot, "rimba: promote "+branch)
+		stashSHA, err = git.StashPushAndRef(ctx, r, repoRoot, "rimba: promote "+branch)
 		if err != nil {
 			return "", err
 		}
 	}
 
-	if err := git.Checkout(r, repoRoot, defaultBranch); err != nil {
-		if restoreErr := restoreStash(r, repoRoot, stashSHA); restoreErr != nil {
+	if err := git.Checkout(ctx, r, repoRoot, defaultBranch); err != nil {
+		if restoreErr := restoreStash(ctx, r, repoRoot, stashSHA); restoreErr != nil {
 			return "", fmt.Errorf("switch to %s: %w; also failed to restore stash: %w", defaultBranch, err, restoreErr)
 		}
 		return "", fmt.Errorf("switch to %s: %w", defaultBranch, err)
 	}
 
-	if err := git.AddWorktreeFromBranch(r, wtPath, branch); err != nil {
+	if err := git.AddWorktreeFromBranch(ctx, r, wtPath, branch); err != nil {
 		// Switch back first while the tree is still clean, then restore the stash.
 		// Reversing this order would make the switch fail (dirty tree).
-		if switchErr := git.Checkout(r, repoRoot, branch); switchErr != nil {
+		if switchErr := git.Checkout(ctx, r, repoRoot, branch); switchErr != nil {
 			return "", fmt.Errorf("create worktree: %w; also failed to restore HEAD to %s: %w", err, branch, switchErr)
 		}
-		if restoreErr := restoreStash(r, repoRoot, stashSHA); restoreErr != nil {
+		if restoreErr := restoreStash(ctx, r, repoRoot, stashSHA); restoreErr != nil {
 			return "", fmt.Errorf("create worktree: %w; also failed to restore stash: %w", err, restoreErr)
 		}
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
 
 	if stashSHA != "" {
-		return wtPath, applyStashToWorktree(r, wtPath, stashSHA)
+		return wtPath, applyStashToWorktree(ctx, r, wtPath, stashSHA)
 	}
 	return wtPath, nil
 }
 
 // validateForPromotion checks pre-conditions and returns the resolved default branch.
-func validateForPromotion(r git.Runner, repoRoot, branch string) (string, error) {
-	defaultBranch, err := git.DefaultBranch(r)
+func validateForPromotion(ctx context.Context, r git.Runner, repoRoot, branch string) (string, error) {
+	defaultBranch, err := git.DefaultBranch(ctx, r)
 	if err != nil {
 		return "", err
 	}
@@ -78,13 +78,13 @@ func validateForPromotion(r git.Runner, repoRoot, branch string) (string, error)
 			"checkout a feature branch first: git checkout <branch>",
 		)
 	}
-	if !git.BranchExists(r, branch) {
+	if !git.BranchExists(ctx, r, branch) {
 		return "", errhint.WithFix(
 			fmt.Errorf("branch %q does not exist", branch),
 			"create the branch first: git checkout -b "+branch,
 		)
 	}
-	entries, err := git.ListWorktrees(r)
+	entries, err := git.ListWorktrees(ctx, r)
 	if err != nil {
 		return "", err
 	}
@@ -94,7 +94,7 @@ func validateForPromotion(r git.Runner, repoRoot, branch string) (string, error)
 			"use that worktree: cd "+entry.Path,
 		)
 	}
-	current, err := git.CurrentBranch(r, repoRoot)
+	current, err := git.CurrentBranch(ctx, r, repoRoot)
 	if err != nil {
 		return "", err
 	}
@@ -109,7 +109,9 @@ func validateForPromotion(r git.Runner, repoRoot, branch string) (string, error)
 
 // restoreStash re-applies and drops a stash entry to undo a failed mid-operation stash push.
 // No-ops when sha is empty. Returns an error if the apply fails (stash entry is preserved).
-func restoreStash(r git.Runner, dir, sha string) error {
+// StashApply and StashDrop are intentionally non-cancellable (recovery paths must complete).
+func restoreStash(ctx context.Context, r git.Runner, dir, sha string) error {
+	_ = ctx
 	if sha == "" {
 		return nil
 	}
@@ -126,7 +128,9 @@ func restoreStash(r git.Runner, dir, sha string) error {
 // Any failure preserves the stash so the user can recover: real conflicts get a
 // resolve-then-cleanup hint, other apply errors surface their true cause, and a
 // failed drop after a clean apply is reported rather than swallowed.
-func applyStashToWorktree(r git.Runner, wtPath, sha string) error {
+// StashApply and StashDrop are intentionally non-cancellable (recovery paths must complete).
+func applyStashToWorktree(ctx context.Context, r git.Runner, wtPath, sha string) error {
+	_ = ctx
 	if err := git.StashApply(r, wtPath, sha); err != nil {
 		if stashApplyConflicted(err) {
 			return errhint.WithFix(

--- a/internal/operations/add_branch.go
+++ b/internal/operations/add_branch.go
@@ -42,7 +42,7 @@ func PromoteBranch(ctx context.Context, worktreeDir string, r git.Runner, repoRo
 	}
 
 	if err := git.Checkout(ctx, r, repoRoot, defaultBranch); err != nil {
-		if restoreErr := restoreStash(ctx, r, repoRoot, stashSHA); restoreErr != nil {
+		if restoreErr := restoreStash(r, repoRoot, stashSHA); restoreErr != nil {
 			return "", fmt.Errorf("switch to %s: %w; also failed to restore stash: %w", defaultBranch, err, restoreErr)
 		}
 		return "", fmt.Errorf("switch to %s: %w", defaultBranch, err)
@@ -54,14 +54,14 @@ func PromoteBranch(ctx context.Context, worktreeDir string, r git.Runner, repoRo
 		if switchErr := git.Checkout(ctx, r, repoRoot, branch); switchErr != nil {
 			return "", fmt.Errorf("create worktree: %w; also failed to restore HEAD to %s: %w", err, branch, switchErr)
 		}
-		if restoreErr := restoreStash(ctx, r, repoRoot, stashSHA); restoreErr != nil {
+		if restoreErr := restoreStash(r, repoRoot, stashSHA); restoreErr != nil {
 			return "", fmt.Errorf("create worktree: %w; also failed to restore stash: %w", err, restoreErr)
 		}
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
 
 	if stashSHA != "" {
-		return wtPath, applyStashToWorktree(ctx, r, wtPath, stashSHA)
+		return wtPath, applyStashToWorktree(r, wtPath, stashSHA)
 	}
 	return wtPath, nil
 }
@@ -110,8 +110,7 @@ func validateForPromotion(ctx context.Context, r git.Runner, repoRoot, branch st
 // restoreStash re-applies and drops a stash entry to undo a failed mid-operation stash push.
 // No-ops when sha is empty. Returns an error if the apply fails (stash entry is preserved).
 // StashApply and StashDrop are intentionally non-cancellable (recovery paths must complete).
-func restoreStash(ctx context.Context, r git.Runner, dir, sha string) error {
-	_ = ctx
+func restoreStash(r git.Runner, dir, sha string) error {
 	if sha == "" {
 		return nil
 	}
@@ -129,8 +128,7 @@ func restoreStash(ctx context.Context, r git.Runner, dir, sha string) error {
 // resolve-then-cleanup hint, other apply errors surface their true cause, and a
 // failed drop after a clean apply is reported rather than swallowed.
 // StashApply and StashDrop are intentionally non-cancellable (recovery paths must complete).
-func applyStashToWorktree(ctx context.Context, r git.Runner, wtPath, sha string) error {
-	_ = ctx
+func applyStashToWorktree(r git.Runner, wtPath, sha string) error {
 	if err := git.StashApply(r, wtPath, sha); err != nil {
 		if stashApplyConflicted(err) {
 			return errhint.WithFix(

--- a/internal/operations/add_pr_worktree.go
+++ b/internal/operations/add_pr_worktree.go
@@ -70,9 +70,9 @@ func resolveSource(ctx context.Context, gitR git.Runner, meta gh.PRMeta, onProgr
 	remoteName := "gh-fork-" + meta.HeadRepoOwner
 	remoteURL := "https://github.com/" + meta.HeadRepoOwner + "/" + meta.HeadRepoName + ".git"
 
-	if !git.RemoteExists(gitR, remoteName) {
+	if !git.RemoteExists(ctx, gitR, remoteName) {
 		progress.Notify(onProgress, fmt.Sprintf("Adding fork remote %s...", remoteName))
-		if err := git.AddRemote(gitR, remoteName, remoteURL); err != nil {
+		if err := git.AddRemote(ctx, gitR, remoteName, remoteURL); err != nil {
 			return "", errhint.WithFix(err, "check network and fork visibility")
 		}
 	}

--- a/internal/operations/archive.go
+++ b/internal/operations/archive.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lugassawan/rimba/internal/git"
@@ -22,7 +23,7 @@ type ArchiveResult struct {
 }
 
 // ArchiveWorktree removes the worktree directory while preserving the local branch.
-func ArchiveWorktree(r git.Runner, params ArchiveParams) (ArchiveResult, error) {
+func ArchiveWorktree(ctx context.Context, r git.Runner, params ArchiveParams) (ArchiveResult, error) {
 	plan := &Plan{DryRun: params.DryRun}
 	result := ArchiveResult{
 		Path:   params.Path,
@@ -32,7 +33,7 @@ func ArchiveWorktree(r git.Runner, params ArchiveParams) (ArchiveResult, error) 
 
 	desc := fmt.Sprintf("remove worktree: %s (branch %s preserved)", params.Path, params.Branch)
 	if err := plan.Do(desc, func() error {
-		return git.RemoveWorktree(r, params.Path, params.Force)
+		return git.RemoveWorktree(ctx, r, params.Path, params.Force)
 	}); err != nil {
 		return result, err
 	}

--- a/internal/operations/archive_test.go
+++ b/internal/operations/archive_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -12,7 +13,7 @@ func TestArchiveWorktreeSuccess(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := ArchiveWorktree(r, ArchiveParams{
+	result, err := ArchiveWorktree(context.Background(), r, ArchiveParams{
 		Path:   pathWtFeatureLogin,
 		Branch: branchFeature,
 	})
@@ -43,7 +44,7 @@ func TestArchiveWorktreeDryRun(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := ArchiveWorktree(r, ArchiveParams{
+	result, err := ArchiveWorktree(context.Background(), r, ArchiveParams{
 		Path:   pathWtFeatureLogin,
 		Branch: branchFeature,
 		DryRun: true,
@@ -71,7 +72,7 @@ func TestArchiveWorktreeError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := ArchiveWorktree(r, ArchiveParams{
+	_, err := ArchiveWorktree(context.Background(), r, ArchiveParams{
 		Path:   pathWtFeatureLogin,
 		Branch: branchFeature,
 	})

--- a/internal/operations/archived.go
+++ b/internal/operations/archived.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lugassawan/rimba/internal/git"
@@ -9,13 +10,13 @@ import (
 
 // FindArchivedBranch finds a branch for the given service+task that is not
 // associated with any active worktree. service may be empty for non-monorepo repos.
-func FindArchivedBranch(r git.Runner, service, task string) (string, error) {
-	branches, err := git.LocalBranches(r)
+func FindArchivedBranch(ctx context.Context, r git.Runner, service, task string) (string, error) {
+	branches, err := git.LocalBranches(ctx, r)
 	if err != nil {
 		return "", fmt.Errorf("list branches: %w", err)
 	}
 
-	active, err := buildActiveSet(r)
+	active, err := buildActiveSet(ctx, r)
 	if err != nil {
 		return "", err
 	}
@@ -37,13 +38,13 @@ func FindArchivedBranch(r git.Runner, service, task string) (string, error) {
 
 // ListArchivedBranches returns branches that are not associated with any active
 // worktree and not the main branch.
-func ListArchivedBranches(r git.Runner, mainBranch string) ([]string, error) {
-	branches, err := git.LocalBranches(r)
+func ListArchivedBranches(ctx context.Context, r git.Runner, mainBranch string) ([]string, error) {
+	branches, err := git.LocalBranches(ctx, r)
 	if err != nil {
 		return nil, err
 	}
 
-	active, err := buildActiveSet(r)
+	active, err := buildActiveSet(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +107,8 @@ func searchByTaskExtraction(branches []string, active map[string]bool, prefixes 
 }
 
 // buildActiveSet returns a set of branch names that are checked out in active worktrees.
-func buildActiveSet(r git.Runner) (map[string]bool, error) {
-	entries, err := git.ListWorktrees(r)
+func buildActiveSet(ctx context.Context, r git.Runner) (map[string]bool, error) {
+	entries, err := git.ListWorktrees(ctx, r)
 	if err != nil {
 		return nil, fmt.Errorf("list worktrees: %w", err)
 	}

--- a/internal/operations/archived_test.go
+++ b/internal/operations/archived_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"testing"
 )
 
@@ -29,7 +30,7 @@ func TestFindArchivedBranch(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "", "archived-task")
+	branch, err := FindArchivedBranch(context.Background(), mr, "", "archived-task")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -53,7 +54,7 @@ func TestFindArchivedBranchNotFound(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindArchivedBranch(mr, "", "nonexistent")
+	_, err := FindArchivedBranch(context.Background(), mr, "", "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for nonexistent archived branch")
 	}
@@ -73,7 +74,7 @@ func TestFindArchivedBranchExactMatch(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "", "my-custom-branch")
+	branch, err := FindArchivedBranch(context.Background(), mr, "", "my-custom-branch")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -96,7 +97,7 @@ func TestFindArchivedBranchByTaskExtraction(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "", "some-task")
+	branch, err := FindArchivedBranch(context.Background(), mr, "", "some-task")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -123,7 +124,7 @@ func TestFindArchivedBranchExactMatchSkipsActive(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "", "my-task")
+	branch, err := FindArchivedBranch(context.Background(), mr, "", "my-task")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -150,7 +151,7 @@ func TestFindArchivedBranchPrefixMatchSkipsActive(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "", "task-x")
+	branch, err := FindArchivedBranch(context.Background(), mr, "", "task-x")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -177,7 +178,7 @@ func TestFindArchivedBranchSkipsActiveInFallback(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindArchivedBranch(mr, "", "some-task")
+	_, err := FindArchivedBranch(context.Background(), mr, "", "some-task")
 	if err == nil {
 		t.Fatal("expected error when only matching branch is active")
 	}
@@ -194,7 +195,7 @@ func TestFindArchivedBranchError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindArchivedBranch(mr, "", "any")
+	_, err := FindArchivedBranch(context.Background(), mr, "", "any")
 	if err == nil {
 		t.Fatal("expected error from LocalBranches failure")
 	}
@@ -214,7 +215,7 @@ func TestFindArchivedBranchWorktreeError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindArchivedBranch(mr, "", "task")
+	_, err := FindArchivedBranch(context.Background(), mr, "", "task")
 	if err == nil {
 		t.Fatal("expected error from ListWorktrees failure")
 	}
@@ -235,7 +236,7 @@ func TestListArchivedBranches(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	archived, err := ListArchivedBranches(mr, branchMain)
+	archived, err := ListArchivedBranches(context.Background(), mr, branchMain)
 	if err != nil {
 		t.Fatalf("ListArchivedBranches: %v", err)
 	}
@@ -258,7 +259,7 @@ func TestListArchivedBranchesError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := ListArchivedBranches(mr, branchMain)
+	_, err := ListArchivedBranches(context.Background(), mr, branchMain)
 	if err == nil {
 		t.Fatal("expected error from LocalBranches failure")
 	}
@@ -278,7 +279,7 @@ func TestListArchivedBranchesWorktreeError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := ListArchivedBranches(mr, branchMain)
+	_, err := ListArchivedBranches(context.Background(), mr, branchMain)
 	if err == nil {
 		t.Fatal("expected error from ListWorktrees failure")
 	}
@@ -298,7 +299,7 @@ func TestFindArchivedBranchMonorepoByPrefix(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "auth-api", "login")
+	branch, err := FindArchivedBranch(context.Background(), mr, "auth-api", "login")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -321,7 +322,7 @@ func TestFindArchivedBranchMonorepoByTaskExtraction(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "auth-api", "login")
+	branch, err := FindArchivedBranch(context.Background(), mr, "auth-api", "login")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}
@@ -344,7 +345,7 @@ func TestFindArchivedBranchMonorepoWrongServiceNoMatch(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindArchivedBranch(mr, "auth-api", "login")
+	_, err := FindArchivedBranch(context.Background(), mr, "auth-api", "login")
 	if err == nil {
 		t.Fatal("expected error when service does not match")
 	}
@@ -365,7 +366,7 @@ func TestFindArchivedBranchNonMonorepoRegression(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	branch, err := FindArchivedBranch(mr, "", "archived-task")
+	branch, err := FindArchivedBranch(context.Background(), mr, "", "archived-task")
 	if err != nil {
 		t.Fatalf("FindArchivedBranch: %v", err)
 	}

--- a/internal/operations/clean.go
+++ b/internal/operations/clean.go
@@ -47,8 +47,8 @@ type StaleResult struct {
 
 // FindMergedCandidates returns worktrees whose branches are merged into mergeRef.
 // It checks both regular merges and squash-merges.
-func FindMergedCandidates(r git.Runner, mergeRef, mainBranch string) (MergedResult, error) {
-	mergedList, err := git.MergedBranches(r, mergeRef)
+func FindMergedCandidates(ctx context.Context, r git.Runner, mergeRef, mainBranch string) (MergedResult, error) {
+	mergedList, err := git.MergedBranches(ctx, r, mergeRef)
 	if err != nil {
 		return MergedResult{}, errhint.WithFix(
 			fmt.Errorf("failed to list merged branches: %w", err),
@@ -61,7 +61,7 @@ func FindMergedCandidates(r git.Runner, mergeRef, mainBranch string) (MergedResu
 		mergedSet[b] = true
 	}
 
-	entries, err := git.ListWorktrees(r)
+	entries, err := git.ListWorktrees(ctx, r)
 	if err != nil {
 		return MergedResult{}, err
 	}
@@ -74,7 +74,7 @@ func FindMergedCandidates(r git.Runner, mergeRef, mainBranch string) (MergedResu
 		}
 
 		// Fallback: squash-merge detection
-		squashed, err := git.IsSquashMerged(r, mergeRef, e.Branch)
+		squashed, err := git.IsSquashMerged(ctx, r, mergeRef, e.Branch)
 		if err != nil {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("skipped %s: squash-merge check failed: %v", e.Branch, err))
 			continue
@@ -87,8 +87,8 @@ func FindMergedCandidates(r git.Runner, mergeRef, mainBranch string) (MergedResu
 }
 
 // FindStaleCandidates returns worktrees with no commits in the last staleDays days.
-func FindStaleCandidates(r git.Runner, mainBranch string, staleDays int) (StaleResult, error) {
-	entries, err := git.ListWorktrees(r)
+func FindStaleCandidates(ctx context.Context, r git.Runner, mainBranch string, staleDays int) (StaleResult, error) {
+	entries, err := git.ListWorktrees(ctx, r)
 	if err != nil {
 		return StaleResult{}, err
 	}
@@ -97,7 +97,7 @@ func FindStaleCandidates(r git.Runner, mainBranch string, staleDays int) (StaleR
 
 	var result StaleResult
 	for _, e := range git.FilterEntries(entries, mainBranch) {
-		ct, err := git.LastCommitTime(r, e.Branch)
+		ct, err := git.LastCommitTime(ctx, r, e.Branch)
 		if err != nil {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("skipped %s: %v", e.Branch, err))
 			continue
@@ -123,7 +123,7 @@ func RemoveCandidates(ctx context.Context, r git.Runner, candidates []CleanCandi
 	items := make([]CleanedItem, 0, len(candidates))
 	for _, c := range candidates {
 		progress.Notifyf(onProgress, "Removing %s...", c.Branch)
-		wtRemoved, brDeleted, err := removeAndCleanup(r, c.Path, c.Branch, force)
+		wtRemoved, brDeleted, err := removeAndCleanup(ctx, r, c.Path, c.Branch, force)
 		item := CleanedItem{
 			Branch:          c.Branch,
 			Path:            c.Path,

--- a/internal/operations/clean_test.go
+++ b/internal/operations/clean_test.go
@@ -51,7 +51,7 @@ func TestFindMergedCandidatesNormalMerge(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := FindMergedCandidates(r, "origin/main", "main")
+	result, err := FindMergedCandidates(context.Background(), r, "origin/main", "main")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func TestFindMergedCandidatesSquashMerge(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := FindMergedCandidates(r, "origin/main", "main")
+	result, err := FindMergedCandidates(context.Background(), r, "origin/main", "main")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +125,7 @@ func TestFindMergedCandidatesNoCandidates(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := FindMergedCandidates(r, "origin/main", "main")
+	result, err := FindMergedCandidates(context.Background(), r, "origin/main", "main")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func TestFindMergedCandidatesGitError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindMergedCandidates(r, "origin/main", "main")
+	_, err := FindMergedCandidates(context.Background(), r, "origin/main", "main")
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -166,7 +166,7 @@ func TestFindStaleCandidatesFound(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := FindStaleCandidates(r, "main", 14)
+	result, err := FindStaleCandidates(context.Background(), r, "main", 14)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestFindStaleCandidatesNoneStale(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := FindStaleCandidates(r, "main", 14)
+	result, err := FindStaleCandidates(context.Background(), r, "main", 14)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +213,7 @@ func TestFindStaleCandidatesGitError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindStaleCandidates(r, "main", 14)
+	_, err := FindStaleCandidates(context.Background(), r, "main", 14)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -320,7 +320,7 @@ func TestFindMergedCandidatesSquashMergeError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := FindMergedCandidates(r, "origin/main", branchMain)
+	result, err := FindMergedCandidates(context.Background(), r, "origin/main", branchMain)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -354,7 +354,7 @@ func TestFindStaleCandidatesLastCommitError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	result, err := FindStaleCandidates(r, branchMain, 14)
+	result, err := FindStaleCandidates(context.Background(), r, branchMain, 14)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -379,7 +379,7 @@ func TestFindMergedCandidatesListWorktreesError(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindMergedCandidates(r, "origin/main", branchMain)
+	_, err := FindMergedCandidates(context.Background(), r, "origin/main", branchMain)
 	if err == nil {
 		t.Fatal("expected error when ListWorktrees fails")
 	}

--- a/internal/operations/deps_install_test.go
+++ b/internal/operations/deps_install_test.go
@@ -49,7 +49,7 @@ func TestResolveMainBranchConfigDefault(t *testing.T) {
 		},
 	}
 
-	branch, err := ResolveMainBranch(r, "develop")
+	branch, err := ResolveMainBranch(context.Background(), r, "develop")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestResolveMainBranchFallbackToGit(t *testing.T) {
 		},
 	}
 
-	branch, err := ResolveMainBranch(r, "")
+	branch, err := ResolveMainBranch(context.Background(), r, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestResolveMainBranchGitError(t *testing.T) {
 		},
 	}
 
-	_, err := ResolveMainBranch(r, "")
+	_, err := ResolveMainBranch(context.Background(), r, "")
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/internal/operations/list_worktrees.go
+++ b/internal/operations/list_worktrees.go
@@ -59,7 +59,7 @@ func ListWorktrees(
 	ghR gh.Runner,
 	req ListWorktreesRequest,
 ) (ListWorktreesResult, error) {
-	entries, err := git.ListWorktrees(gitR)
+	entries, err := git.ListWorktrees(ctx, gitR)
 	if err != nil {
 		return ListWorktreesResult{}, err
 	}
@@ -83,7 +83,7 @@ func ListWorktrees(
 
 	results := parallel.Collect(len(candidates), listWorktreesConcurrency, func(i int) listWorktreeResult {
 		c := candidates[i]
-		status := CollectWorktreeStatus(gitR, c.entry.Path)
+		status := CollectWorktreeStatus(ctx, gitR, c.entry.Path)
 		d := resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)
 		var info PRInfo
 		if activeGhR != nil {

--- a/internal/operations/merge.go
+++ b/internal/operations/merge.go
@@ -46,7 +46,7 @@ type dirtyResult struct {
 // MergeWorktree merges a source worktree branch into main or another worktree.
 // It handles worktree resolution, concurrent dirty checks, merge execution, and cleanup.
 func MergeWorktree(ctx context.Context, r git.Runner, params MergeParams, onProgress progress.Func) (MergeResult, error) {
-	worktrees, err := ListWorktreeInfos(r)
+	worktrees, err := ListWorktreeInfos(ctx, r)
 	if err != nil {
 		return MergeResult{}, err
 	}
@@ -86,7 +86,14 @@ func MergeWorktree(ctx context.Context, r git.Runner, params MergeParams, onProg
 
 	// Concurrent dirty checks (always run — read-only pre-flight)
 	progress.Notify(onProgress, "Checking for uncommitted changes...")
-	if err := checkDirty(r, source.Path, targetDir, params.SourceTask, params.IntoTask, mergingToMain, targetLabel); err != nil {
+	if err := checkDirty(ctx, r, dirtyCheckArgs{
+		sourcePath:    source.Path,
+		targetDir:     targetDir,
+		sourceTask:    params.SourceTask,
+		intoTask:      params.IntoTask,
+		targetLabel:   targetLabel,
+		mergingToMain: mergingToMain,
+	}); err != nil {
 		return result, err
 	}
 
@@ -96,7 +103,7 @@ func MergeWorktree(ctx context.Context, r git.Runner, params MergeParams, onProg
 	if err := plan.Do(mergeDesc, func() error {
 		return git.Merge(ctx, r, targetDir, source.Branch, params.NoFF)
 	}); err != nil {
-		return result, abortFailedMerge(r, targetDir, targetLabel, source.Branch, err)
+		return result, abortFailedMerge(ctx, r, targetDir, targetLabel, source.Branch, err)
 	}
 
 	// Auto-cleanup
@@ -106,7 +113,7 @@ func MergeWorktree(ctx context.Context, r git.Runner, params MergeParams, onProg
 		var wtRemoved, brDeleted bool
 		rmErr := plan.Do("remove worktree: "+source.Path, func() error {
 			var err error
-			wtRemoved, brDeleted, err = removeAndCleanup(r, source.Path, source.Branch, false)
+			wtRemoved, brDeleted, err = removeAndCleanup(ctx, r, source.Path, source.Branch, false)
 			return err
 		})
 		result.WorktreeRemoved = wtRemoved
@@ -124,8 +131,8 @@ func MergeWorktree(ctx context.Context, r git.Runner, params MergeParams, onProg
 // If the abort also fails, both errors are surfaced with a manual-cleanup hint.
 // If the MERGE_HEAD check itself fails (infrastructure error), a conservative
 // manual-cleanup hint is returned rather than assuming no merge is in progress.
-func abortFailedMerge(r git.Runner, targetDir, targetLabel, sourceBranch string, mergeErr error) error {
-	inProgress, checkErr := git.MergeInProgress(r, targetDir)
+func abortFailedMerge(ctx context.Context, r git.Runner, targetDir, targetLabel, sourceBranch string, mergeErr error) error {
+	inProgress, checkErr := git.MergeInProgress(ctx, r, targetDir)
 	if checkErr != nil {
 		// Cannot determine merge state — conservative: tell user to clean up manually.
 		return errhint.WithFix(
@@ -151,19 +158,26 @@ func abortFailedMerge(r git.Runner, targetDir, targetLabel, sourceBranch string,
 	)
 }
 
+type dirtyCheckArgs struct {
+	sourcePath, targetDir string
+	sourceTask, intoTask  string
+	targetLabel           string
+	mergingToMain         bool
+}
+
 // checkDirty checks both source and target for uncommitted changes concurrently.
-func checkDirty(r git.Runner, sourcePath, targetDir, sourceTask, intoTask string, mergingToMain bool, targetLabel string) error {
+func checkDirty(ctx context.Context, r git.Runner, args dirtyCheckArgs) error {
 	var srcCheck, tgtCheck dirtyResult
 	var wg sync.WaitGroup
 	wg.Add(2)
 
 	go func() {
 		defer wg.Done()
-		srcCheck.dirty, srcCheck.err = git.IsDirty(r, sourcePath)
+		srcCheck.dirty, srcCheck.err = git.IsDirty(ctx, r, args.sourcePath)
 	}()
 	go func() {
 		defer wg.Done()
-		tgtCheck.dirty, tgtCheck.err = git.IsDirty(r, targetDir)
+		tgtCheck.dirty, tgtCheck.err = git.IsDirty(ctx, r, args.targetDir)
 	}()
 	wg.Wait()
 
@@ -172,21 +186,21 @@ func checkDirty(r git.Runner, sourcePath, targetDir, sourceTask, intoTask string
 	}
 	if srcCheck.dirty {
 		return errhint.WithFix(
-			fmt.Errorf("source worktree %q has uncommitted changes", sourceTask),
-			"Commit or stash changes before merging: cd "+sourcePath,
+			fmt.Errorf("source worktree %q has uncommitted changes", args.sourceTask),
+			"Commit or stash changes before merging: cd "+args.sourcePath,
 		)
 	}
 	if tgtCheck.err != nil {
 		return tgtCheck.err
 	}
 	if tgtCheck.dirty {
-		label := targetLabel
-		if !mergingToMain {
-			label = intoTask
+		label := args.targetLabel
+		if !args.mergingToMain {
+			label = args.intoTask
 		}
 		return errhint.WithFix(
 			fmt.Errorf("target %q has uncommitted changes", label),
-			"Commit or stash changes before merging: cd "+targetDir,
+			"Commit or stash changes before merging: cd "+args.targetDir,
 		)
 	}
 	return nil

--- a/internal/operations/mock_runner_test.go
+++ b/internal/operations/mock_runner_test.go
@@ -24,14 +24,6 @@ type mockRunner struct {
 	runInDir func(dir string, args ...string) (string, error)
 }
 
-func (m *mockRunner) Run(args ...string) (string, error) {
-	return m.run(args...)
-}
-
-func (m *mockRunner) RunInDir(dir string, args ...string) (string, error) {
-	return m.runInDir(dir, args...)
-}
-
 func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
 	return m.run(args...)
 }

--- a/internal/operations/mock_runner_test.go
+++ b/internal/operations/mock_runner_test.go
@@ -24,11 +24,11 @@ type mockRunner struct {
 	runInDir func(dir string, args ...string) (string, error)
 }
 
-func (m *mockRunner) RunContext(_ context.Context, args ...string) (string, error) {
+func (m *mockRunner) Run(_ context.Context, args ...string) (string, error) {
 	return m.run(args...)
 }
 
-func (m *mockRunner) RunInDirContext(_ context.Context, dir string, args ...string) (string, error) {
+func (m *mockRunner) RunInDir(_ context.Context, dir string, args ...string) (string, error) {
 	return m.runInDir(dir, args...)
 }
 

--- a/internal/operations/operations.go
+++ b/internal/operations/operations.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -14,16 +15,16 @@ const ErrWorktreeNotFoundFmt = "worktree not found for task %q"
 
 // ResolveMainBranch returns the main branch name.
 // If configDefault is non-empty it is used directly; otherwise git detection is used.
-func ResolveMainBranch(r git.Runner, configDefault string) (string, error) {
+func ResolveMainBranch(ctx context.Context, r git.Runner, configDefault string) (string, error) {
 	if configDefault != "" {
 		return configDefault, nil
 	}
-	return git.DefaultBranch(r)
+	return git.DefaultBranch(ctx, r)
 }
 
 // ListWorktreeInfos converts git worktree entries to resolver-compatible WorktreeInfo slice.
-func ListWorktreeInfos(r git.Runner) ([]resolver.WorktreeInfo, error) {
-	entries, err := git.ListWorktrees(r)
+func ListWorktreeInfos(ctx context.Context, r git.Runner) ([]resolver.WorktreeInfo, error) {
+	entries, err := git.ListWorktrees(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -43,8 +44,8 @@ func ListWorktreeInfos(r git.Runner) ([]resolver.WorktreeInfo, error) {
 
 // FindWorktree looks up a worktree by service and task name.
 // When service is empty and the task matches multiple services, an ambiguity error is returned.
-func FindWorktree(r git.Runner, service, task string) (resolver.WorktreeInfo, error) {
-	worktrees, err := ListWorktreeInfos(r)
+func FindWorktree(ctx context.Context, r git.Runner, service, task string) (resolver.WorktreeInfo, error) {
+	worktrees, err := ListWorktreeInfos(ctx, r)
 	if err != nil {
 		return resolver.WorktreeInfo{}, err
 	}

--- a/internal/operations/operations_test.go
+++ b/internal/operations/operations_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestListWorktreeInfos(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	infos, err := ListWorktreeInfos(r)
+	infos, err := ListWorktreeInfos(context.Background(), r)
 	if err != nil {
 		t.Fatalf("ListWorktreeInfos: %v", err)
 	}
@@ -44,7 +45,7 @@ func TestListWorktreeInfosError(t *testing.T) {
 		run:      func(_ ...string) (string, error) { return "", errGitFailed },
 		runInDir: noopRunInDir,
 	}
-	if _, err := ListWorktreeInfos(r); err == nil {
+	if _, err := ListWorktreeInfos(context.Background(), r); err == nil {
 		t.Fatal("expected error")
 	}
 }
@@ -67,7 +68,7 @@ func TestFindWorktree(t *testing.T) {
 	}
 
 	t.Run("found", func(t *testing.T) {
-		wt, err := FindWorktree(r, "", "login")
+		wt, err := FindWorktree(context.Background(), r, "", "login")
 		if err != nil {
 			t.Fatalf("FindWorktree: %v", err)
 		}
@@ -77,7 +78,7 @@ func TestFindWorktree(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		_, err := FindWorktree(r, "", "nonexistent")
+		_, err := FindWorktree(context.Background(), r, "", "nonexistent")
 		if err == nil {
 			t.Fatal("expected error for missing worktree")
 		}
@@ -112,7 +113,7 @@ func TestFindWorktreeAmbiguity(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	_, err := FindWorktree(r, "", "login")
+	_, err := FindWorktree(context.Background(), r, "", "login")
 	if err == nil {
 		t.Fatal("expected ambiguity error")
 	}
@@ -132,7 +133,7 @@ func TestFindWorktreeError(t *testing.T) {
 		run:      func(_ ...string) (string, error) { return "", errGitFailed },
 		runInDir: noopRunInDir,
 	}
-	if _, err := FindWorktree(r, "", "login"); err == nil {
+	if _, err := FindWorktree(context.Background(), r, "", "login"); err == nil {
 		t.Fatal("expected error")
 	}
 }

--- a/internal/operations/post_create.go
+++ b/internal/operations/post_create.go
@@ -55,7 +55,7 @@ func PostCreateSetup(ctx context.Context, r git.Runner, params PostCreateParams,
 	// Dependencies
 	if !params.SkipDeps {
 		progress.Notify(onProgress, "Installing dependencies...")
-		wtEntries, err := git.ListWorktrees(r)
+		wtEntries, err := git.ListWorktrees(ctx, r)
 		if err != nil {
 			return result, fmt.Errorf("failed to list worktrees for dependency setup: %w", err)
 		}

--- a/internal/operations/post_rename.go
+++ b/internal/operations/post_rename.go
@@ -34,7 +34,7 @@ func PostRenameSetup(ctx context.Context, r git.Runner, params PostRenameParams,
 
 	if !params.SkipDeps {
 		progress.Notify(onProgress, "Refreshing dependencies...")
-		wtEntries, err := git.ListWorktrees(r)
+		wtEntries, err := git.ListWorktrees(ctx, r)
 		if err != nil {
 			return result, fmt.Errorf("failed to list worktrees for dependency refresh: %w", err)
 		}

--- a/internal/operations/remove.go
+++ b/internal/operations/remove.go
@@ -1,6 +1,8 @@
 package operations
 
 import (
+	"context"
+
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/progress"
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -17,7 +19,7 @@ type RemoveResult struct {
 }
 
 // RemoveWorktree removes a worktree and optionally deletes its branch.
-func RemoveWorktree(r git.Runner, wt resolver.WorktreeInfo, task string, keepBranch, force bool, onProgress progress.Func) (RemoveResult, error) {
+func RemoveWorktree(ctx context.Context, r git.Runner, wt resolver.WorktreeInfo, task string, keepBranch, force bool, onProgress progress.Func) (RemoveResult, error) {
 	result := RemoveResult{
 		Task:   task,
 		Branch: wt.Branch,
@@ -25,14 +27,14 @@ func RemoveWorktree(r git.Runner, wt resolver.WorktreeInfo, task string, keepBra
 	}
 
 	progress.Notify(onProgress, "Removing worktree...")
-	if err := git.RemoveWorktree(r, wt.Path, force); err != nil {
+	if err := git.RemoveWorktree(ctx, r, wt.Path, force); err != nil {
 		return result, err
 	}
 	result.WorktreeRemoved = true
 
 	if !keepBranch {
 		progress.Notify(onProgress, "Deleting branch...")
-		if err := git.DeleteBranch(r, wt.Branch, true); err != nil {
+		if err := git.DeleteBranch(ctx, r, wt.Branch, true); err != nil {
 			result.BranchError = branchDeleteFailedErr(wt.Branch, err)
 			return result, nil
 		}
@@ -46,12 +48,12 @@ func RemoveWorktree(r git.Runner, wt resolver.WorktreeInfo, task string, keepBra
 // Used by remove, merge, and clean operations. force is forwarded to git
 // worktree remove so callers can discard untracked files or uncommitted
 // tracked-file modifications (e.g. node_modules, local config edits).
-func removeAndCleanup(r git.Runner, path, branch string, force bool) (wtRemoved, brDeleted bool, err error) {
-	if err := git.RemoveWorktree(r, path, force); err != nil {
+func removeAndCleanup(ctx context.Context, r git.Runner, path, branch string, force bool) (wtRemoved, brDeleted bool, err error) {
+	if err := git.RemoveWorktree(ctx, r, path, force); err != nil {
 		return false, false, err
 	}
 
-	if err := git.DeleteBranch(r, branch, true); err != nil {
+	if err := git.DeleteBranch(ctx, r, branch, true); err != nil {
 		return true, false, branchDeleteFailedErr(branch, err)
 	}
 

--- a/internal/operations/remove_test.go
+++ b/internal/operations/remove_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"errors"
 	"slices"
 	"strings"
@@ -26,7 +27,7 @@ func TestRemoveWorktreeSuccess(t *testing.T) {
 	}
 
 	wt := resolver.WorktreeInfo{Path: "/wt/feature-login", Branch: "feature/login"}
-	result, err := RemoveWorktree(r, wt, "login", false, false, nil)
+	result, err := RemoveWorktree(context.Background(), r, wt, "login", false, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -62,7 +63,7 @@ func TestRemoveWorktreeKeepBranch(t *testing.T) {
 	}
 
 	wt := resolver.WorktreeInfo{Path: "/wt/feature-login", Branch: "feature/login"}
-	result, err := RemoveWorktree(r, wt, "login", true, false, nil)
+	result, err := RemoveWorktree(context.Background(), r, wt, "login", true, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -86,7 +87,7 @@ func TestRemoveWorktreeRemovalFails(t *testing.T) {
 	}
 
 	wt := resolver.WorktreeInfo{Path: "/wt/feature-login", Branch: "feature/login"}
-	result, err := RemoveWorktree(r, wt, "login", false, false, nil)
+	result, err := RemoveWorktree(context.Background(), r, wt, "login", false, false, nil)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -111,7 +112,7 @@ func TestRemoveWorktreeBranchDeleteFails(t *testing.T) {
 	}
 
 	wt := resolver.WorktreeInfo{Path: "/wt/feature-login", Branch: "feature/login"}
-	result, err := RemoveWorktree(r, wt, "login", false, false, nil)
+	result, err := RemoveWorktree(context.Background(), r, wt, "login", false, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v (partial success should not return error)", err)
 	}
@@ -141,7 +142,7 @@ func TestRemoveWorktreeProgressCallbacks(t *testing.T) {
 	onProgress := progress.Func(func(msg string) { messages = append(messages, msg) })
 
 	wt := resolver.WorktreeInfo{Path: "/wt/feature-login", Branch: "feature/login"}
-	_, err := RemoveWorktree(r, wt, "login", false, false, onProgress)
+	_, err := RemoveWorktree(context.Background(), r, wt, "login", false, false, onProgress)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -164,7 +165,7 @@ func TestRemoveAndCleanupSuccess(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	wtRemoved, brDeleted, err := removeAndCleanup(r, "/wt/test", "feature/test", false)
+	wtRemoved, brDeleted, err := removeAndCleanup(context.Background(), r, "/wt/test", "feature/test", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -181,7 +182,7 @@ func TestRemoveAndCleanupWtRemovalFails(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	wtRemoved, brDeleted, err := removeAndCleanup(r, "/wt/test", "feature/test", false)
+	wtRemoved, brDeleted, err := removeAndCleanup(context.Background(), r, "/wt/test", "feature/test", false)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -202,7 +203,7 @@ func TestRemoveAndCleanupBranchDeleteFails(t *testing.T) {
 		runInDir: noopRunInDir,
 	}
 
-	wtRemoved, brDeleted, err := removeAndCleanup(r, "/wt/test", "feature/test", false)
+	wtRemoved, brDeleted, err := removeAndCleanup(context.Background(), r, "/wt/test", "feature/test", false)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -241,7 +242,7 @@ func TestRemoveAndCleanupForceFlag(t *testing.T) {
 				},
 				runInDir: noopRunInDir,
 			}
-			_, _, err := removeAndCleanup(r, "/wt/test", "feature/test", tt.force)
+			_, _, err := removeAndCleanup(context.Background(), r, "/wt/test", "feature/test", tt.force)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/internal/operations/rename.go
+++ b/internal/operations/rename.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/lugassawan/rimba/internal/errhint"
@@ -18,7 +19,7 @@ type RenameResult struct {
 
 // RenameWorktree renames a worktree's directory and branch to match a new task name.
 // It resolves the new branch name by inheriting the prefix from the current branch.
-func RenameWorktree(r git.Runner, wt resolver.WorktreeInfo, newTask, wtDir string, force bool) (RenameResult, error) {
+func RenameWorktree(ctx context.Context, r git.Runner, wt resolver.WorktreeInfo, newTask, wtDir string, force bool) (RenameResult, error) {
 	prefixes := resolver.AllPrefixes()
 
 	svc, _, matchedPrefix := resolver.ServiceFromBranch(wt.Branch, prefixes)
@@ -31,7 +32,7 @@ func RenameWorktree(r git.Runner, wt resolver.WorktreeInfo, newTask, wtDir strin
 		return RenameResult{}, fmt.Errorf("new name is the same as the current name: %q", newTask)
 	}
 
-	if git.BranchExists(r, newBranch) {
+	if git.BranchExists(ctx, r, newBranch) {
 		return RenameResult{}, errhint.WithFix(
 			fmt.Errorf("branch %q already exists", newBranch),
 			"choose a different task name, or remove the existing branch: git branch -D "+newBranch,
@@ -47,7 +48,7 @@ func RenameWorktree(r git.Runner, wt resolver.WorktreeInfo, newTask, wtDir strin
 		)
 	}
 
-	if err := git.RenameBranch(r, wt.Branch, newBranch); err != nil {
+	if err := git.RenameBranch(ctx, r, wt.Branch, newBranch); err != nil {
 		if rbErr := git.MoveWorktree(r, newPath, wt.Path, force); rbErr != nil {
 			return RenameResult{}, errhint.WithFix(
 				fmt.Errorf("failed to rename branch %q → %q: %w\nRollback failed — worktree is at %s: %w",

--- a/internal/operations/rename_test.go
+++ b/internal/operations/rename_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -30,7 +31,7 @@ func TestRenameWorktreeSuccess(t *testing.T) {
 	}
 
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	res, err := RenameWorktree(r, wt, "auth", wtDir, false)
+	res, err := RenameWorktree(context.Background(), r, wt, "auth", wtDir, false)
 	if err != nil {
 		t.Fatalf("RenameWorktree: %v", err)
 	}
@@ -57,7 +58,7 @@ func TestRenameWorktreeBranchExists(t *testing.T) {
 	}
 
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	_, err := RenameWorktree(r, wt, "auth", wtDir, false)
+	_, err := RenameWorktree(context.Background(), r, wt, "auth", wtDir, false)
 	if err == nil {
 		t.Fatal("expected error for existing branch")
 	}
@@ -86,7 +87,7 @@ func TestRenameWorktreeSameName(t *testing.T) {
 	}
 
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	_, err := RenameWorktree(r, wt, "login", wtDir, false)
+	_, err := RenameWorktree(context.Background(), r, wt, "login", wtDir, false)
 	if err == nil {
 		t.Fatal("expected error for same-name rename")
 	}
@@ -119,7 +120,7 @@ func TestRenameWorktreeMoveFails(t *testing.T) {
 	}
 
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	_, err := RenameWorktree(r, wt, "auth", wtDir, false)
+	_, err := RenameWorktree(context.Background(), r, wt, "auth", wtDir, false)
 	if err == nil {
 		t.Fatal("expected error from move failure")
 	}
@@ -151,7 +152,7 @@ func TestRenameWorktreeBranchRenameFails(t *testing.T) {
 	}
 
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	_, err := RenameWorktree(r, wt, "auth", wtDir, false)
+	_, err := RenameWorktree(context.Background(), r, wt, "auth", wtDir, false)
 	if err == nil {
 		t.Fatal("expected error from branch rename failure")
 	}
@@ -195,7 +196,7 @@ func TestRenameWorktreeBranchRenameFailsRollbackFails(t *testing.T) {
 	}
 
 	wt := resolver.WorktreeInfo{Branch: branchFeature, Path: pathWtFeatureLogin}
-	_, err := RenameWorktree(r, wt, "auth", wtDir, false)
+	_, err := RenameWorktree(context.Background(), r, wt, "auth", wtDir, false)
 	if err == nil {
 		t.Fatal("expected error from branch rename + rollback failure")
 	}
@@ -226,7 +227,7 @@ func TestRenameWorktreeNoPrefixMatch(t *testing.T) {
 	}
 
 	wt := resolver.WorktreeInfo{Branch: "plain-branch", Path: "/wt/plain-branch"}
-	res, err := RenameWorktree(r, wt, "new-task", wtDir, false)
+	res, err := RenameWorktree(context.Background(), r, wt, "new-task", wtDir, false)
 	if err != nil {
 		t.Fatalf("RenameWorktree: %v", err)
 	}

--- a/internal/operations/status.go
+++ b/internal/operations/status.go
@@ -1,19 +1,21 @@
 package operations
 
 import (
+	"context"
+
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/resolver"
 )
 
 // CollectWorktreeStatus gathers dirty/ahead/behind state for a worktree path.
-func CollectWorktreeStatus(r git.Runner, wtPath string) resolver.WorktreeStatus {
+func CollectWorktreeStatus(ctx context.Context, r git.Runner, wtPath string) resolver.WorktreeStatus {
 	var status resolver.WorktreeStatus
 
-	if dirty, err := git.IsDirty(r, wtPath); err == nil && dirty {
+	if dirty, err := git.IsDirty(ctx, r, wtPath); err == nil && dirty {
 		status.Dirty = true
 	}
 
-	ahead, behind, _ := git.AheadBehind(r, wtPath)
+	ahead, behind, _ := git.AheadBehind(ctx, r, wtPath)
 	status.Ahead = ahead
 	status.Behind = behind
 

--- a/internal/operations/status_dashboard.go
+++ b/internal/operations/status_dashboard.go
@@ -50,12 +50,12 @@ func StatusDashboard(ctx context.Context, gitR git.Runner, req StatusDashboardRe
 	if err := ctx.Err(); err != nil {
 		return StatusDashboardResult{}, err
 	}
-	mainBranch, err := ResolveMainBranch(gitR, "")
+	mainBranch, err := ResolveMainBranch(ctx, gitR, "")
 	if err != nil {
 		return StatusDashboardResult{}, err
 	}
 
-	allEntries, err := git.ListWorktrees(gitR)
+	allEntries, err := git.ListWorktrees(ctx, gitR)
 	if err != nil {
 		return StatusDashboardResult{}, err
 	}
@@ -78,7 +78,7 @@ func StatusDashboard(ctx context.Context, gitR git.Runner, req StatusDashboardRe
 		}(mainEntry.Path)
 	}
 
-	entries := collectStatusEntries(gitR, candidates, req.Detail)
+	entries := collectStatusEntries(ctx, gitR, candidates, req.Detail)
 	mainWG.Wait()
 
 	var footprint *DiskFootprint
@@ -116,13 +116,13 @@ func SummarizeStatus(entries []StatusEntry, staleThreshold time.Time) StatusSumm
 // collectStatusEntries gathers dirty/ahead/behind state and last commit time
 // per candidate in parallel. Under detail it also computes size and 7-day
 // velocity; per-item errors leave the pointer nil (non-fatal).
-func collectStatusEntries(gitR git.Runner, candidates []git.WorktreeEntry, detail bool) []StatusEntry {
+func collectStatusEntries(ctx context.Context, gitR git.Runner, candidates []git.WorktreeEntry, detail bool) []StatusEntry {
 	return parallel.Collect(len(candidates), 8, func(i int) StatusEntry {
 		e := candidates[i]
-		st := CollectWorktreeStatus(gitR, e.Path)
+		st := CollectWorktreeStatus(ctx, gitR, e.Path)
 		var ct time.Time
 		var hasTime bool
-		if t, err := git.LastCommitTime(gitR, e.Branch); err == nil {
+		if t, err := git.LastCommitTime(ctx, gitR, e.Branch); err == nil {
 			ct = t
 			hasTime = true
 		}
@@ -131,7 +131,7 @@ func collectStatusEntries(gitR git.Runner, candidates []git.WorktreeEntry, detai
 			if n, err := fsutil.DirSize(e.Path); err == nil {
 				se.SizeBytes = &n
 			}
-			if c, err := git.CommitCountSince(gitR, e.Branch, recentWindow); err == nil {
+			if c, err := git.CommitCountSince(ctx, gitR, e.Branch, recentWindow); err == nil {
 				se.Recent7D = &c
 			}
 		}

--- a/internal/operations/status_test.go
+++ b/internal/operations/status_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -17,7 +18,7 @@ func TestCollectWorktreeStatusClean(t *testing.T) {
 		run:      func(_ ...string) (string, error) { return "", nil },
 		runInDir: noopRunInDir,
 	}
-	status := CollectWorktreeStatus(r, "/wt/feature-login")
+	status := CollectWorktreeStatus(context.Background(), r, "/wt/feature-login")
 	if status.Dirty {
 		t.Error("expected Dirty=false for clean worktree")
 	}
@@ -36,7 +37,7 @@ func TestCollectWorktreeStatusDirty(t *testing.T) {
 			return "", nil
 		},
 	}
-	status := CollectWorktreeStatus(r, "/wt/feature-login")
+	status := CollectWorktreeStatus(context.Background(), r, "/wt/feature-login")
 	if !status.Dirty {
 		t.Error("expected Dirty=true")
 	}
@@ -52,7 +53,7 @@ func TestCollectWorktreeStatusAheadBehind(t *testing.T) {
 			return "", nil
 		},
 	}
-	status := CollectWorktreeStatus(r, "/wt/feature-login")
+	status := CollectWorktreeStatus(context.Background(), r, "/wt/feature-login")
 	if status.Ahead != 3 {
 		t.Errorf("Ahead = %d, want 3", status.Ahead)
 	}
@@ -68,7 +69,7 @@ func TestCollectWorktreeStatusIsDirtyError(t *testing.T) {
 			return "", errGitFailed
 		},
 	}
-	status := CollectWorktreeStatus(r, "/wt/feature-login")
+	status := CollectWorktreeStatus(context.Background(), r, "/wt/feature-login")
 	// On IsDirty error, dirty should be false (err != nil means the condition `err == nil && dirty` is false)
 	if status.Dirty {
 		t.Error("expected Dirty=false when IsDirty returns error")

--- a/internal/operations/sync.go
+++ b/internal/operations/sync.go
@@ -40,7 +40,7 @@ func SyncBranch(ctx context.Context, r git.Runner, dir, mainBranch string, useMe
 // Uses force-with-lease after rebase, regular push after merge.
 // Returns (pushed, skipped, error). pushed is true only on success.
 func PushBranch(ctx context.Context, r git.Runner, dir string, useMerge bool) (bool, bool, error) {
-	if !git.HasUpstream(r, dir) {
+	if !git.HasUpstream(ctx, r, dir) {
 		return false, true, nil
 	}
 	var err error
@@ -84,7 +84,7 @@ func FilterEligible(worktrees []resolver.WorktreeInfo, prefixes []string, mainBr
 func SyncWorktree(ctx context.Context, r git.Runner, mainBranch string, wt resolver.WorktreeInfo, useMerge, push bool) SyncWorktreeResult {
 	res := SyncWorktreeResult{Branch: wt.Branch}
 
-	dirty, err := git.IsDirty(r, wt.Path)
+	dirty, err := git.IsDirty(ctx, r, wt.Path)
 	if err != nil {
 		res.Skipped = true
 		res.SkipReason = fmt.Sprintf("could not check status: %v", err)


### PR DESCRIPTION
## Summary
- Thread ctx context.Context (first param) through all git package functions, replacing r.Run/r.RunInDir calls with r.Run(ctx, ...)/r.RunInDir(ctx, ...), so SIGINT and MCP per-request deadlines cancel in-flight git subprocesses.
- Remove Run/RunInDir (the context.Background() shims) from the Runner interface, ExecRunner, and the debug decorator.
- Rename RunContext->Run and RunInDirContext->RunInDir: since the shims are gone, the Context suffix is no longer needed.
- Recovery/rollback paths (AbortRebase, MergeAbort, StashApply/StashDrop, stashRefBySHA, MoveWorktree) deliberately stay non-cancellable via r.RunInDir(context.Background(), ...), each with a doc comment.

## Test Plan
- [x] go build clean
- [x] go fmt clean
- [x] make lint 0 issues
- [x] go test 2091 tests pass in 27 packages
- [x] make test-race passes
- [x] sync_ctx_test.go verifies cancellation propagation

Closes #283