### PR TITLE
[fix] Close goroutine leak in update hint + add exec cobra-level test seam

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -33,6 +33,9 @@ const (
 	hintConcurrency = "Limit the number of parallel executions"
 )
 
+// execRunner is the injectable executor function type, matching executor.Run.
+type execRunner func(context.Context, executor.Config) []executor.Result
+
 var execCmd = &cobra.Command{
 	Use:   "exec <command>",
 	Short: "Run a shell command across worktrees",
@@ -41,48 +44,73 @@ var execCmd = &cobra.Command{
   rimba exec --type bugfix "npm test"`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		opts := execReadFlags(cmd)
-		if err := execValidateFlags(opts); err != nil {
-			return err
-		}
-
-		execShowHints(cmd)
-
-		r := newRunner()
-		s := spinner.New(spinnerOpts(cmd))
-		defer s.Stop()
-		s.Start("Collecting worktrees...")
-
-		prefixes := resolver.AllPrefixes()
-		filtered, err := execSelectWorktrees(cmd, r, s, opts, prefixes)
-		if err != nil {
-			return err
-		}
-
-		if len(filtered) == 0 {
-			s.Stop()
-			fmt.Fprintln(cmd.OutOrStdout(), "No worktrees match the given filters.")
-			return nil
-		}
-
-		targets := execBuildTargets(filtered, prefixes)
-		s.Update(fmt.Sprintf("Running in %d worktree(s)...", len(targets)))
-
-		results := executor.Run(cmd.Context(), executor.Config{
-			Targets:     targets,
-			Command:     args[0],
-			Concurrency: opts.concurrency,
-			FailFast:    opts.failFast,
-			Runner:      executor.ShellRunner(),
-		})
-
-		s.Stop()
-
-		if isJSON(cmd) {
-			return execRenderJSON(cmd, args[0], results)
-		}
-		return execRenderText(cmd, results, prefixes)
+		return runExec(cmd, args, newRunner(), executor.Run)
 	},
+}
+
+// runExec is the shared implementation for the exec command, accepting
+// injected runner and executor so both production and tests use the same path.
+func runExec(cmd *cobra.Command, args []string, r git.Runner, execFn execRunner) error {
+	opts := execReadFlags(cmd)
+	if err := execValidateFlags(opts); err != nil {
+		return err
+	}
+
+	execShowHints(cmd)
+
+	s := spinner.New(spinnerOpts(cmd))
+	defer s.Stop()
+	s.Start("Collecting worktrees...")
+
+	prefixes := resolver.AllPrefixes()
+	filtered, err := execSelectWorktrees(cmd, r, s, opts, prefixes)
+	if err != nil {
+		return err
+	}
+
+	if len(filtered) == 0 {
+		s.Stop()
+		fmt.Fprintln(cmd.OutOrStdout(), "No worktrees match the given filters.")
+		return nil
+	}
+
+	targets := execBuildTargets(filtered, prefixes)
+	s.Update(fmt.Sprintf("Running in %d worktree(s)...", len(targets)))
+
+	results := execFn(cmd.Context(), executor.Config{
+		Targets:     targets,
+		Command:     args[0],
+		Concurrency: opts.concurrency,
+		FailFast:    opts.failFast,
+		Runner:      executor.ShellRunner(),
+	})
+
+	s.Stop()
+
+	if isJSON(cmd) {
+		return execRenderJSON(cmd, args[0], results)
+	}
+	return execRenderText(cmd, results, prefixes)
+}
+
+// buildExecCmd constructs a testable exec command with injected deps.
+// Used by exec_test.go to exercise the full flag-parse → filter → executor pipeline.
+func buildExecCmd(r git.Runner, execFn execRunner) *cobra.Command {
+	c := &cobra.Command{
+		Use:  "exec <command>",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runExec(cmd, args, r, execFn)
+		},
+	}
+	c.Flags().Bool(flagAll, false, "")
+	c.Flags().String(flagType, "", "")
+	c.Flags().Bool(flagDirty, false, "")
+	c.Flags().Bool(flagFailFast, false, "")
+	c.Flags().Int(flagConcurrency, 0, "")
+	c.Flags().Bool(flagJSON, false, "")
+	c.Flags().Bool(flagNoColor, false, "")
+	return c
 }
 
 // execOpts holds parsed exec flags.

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -93,6 +93,15 @@ func runExec(cmd *cobra.Command, args []string, r git.Runner, execFn execRunner)
 	return execRenderText(cmd, results, prefixes)
 }
 
+// addExecFlags registers exec-specific flags on c, shared by execCmd and buildExecCmd.
+func addExecFlags(c *cobra.Command) {
+	c.Flags().Bool(flagAll, false, "run in all eligible worktrees")
+	c.Flags().String(flagType, "", "filter by prefix type (e.g. feature, bugfix)")
+	c.Flags().Bool(flagDirty, false, "run only in dirty worktrees")
+	c.Flags().Bool(flagFailFast, false, "stop after the first failure")
+	c.Flags().Int(flagConcurrency, 0, "max parallel executions (0 = unlimited)")
+}
+
 // buildExecCmd constructs a testable exec command with injected deps.
 // Used by exec_test.go to exercise the full flag-parse → filter → executor pipeline.
 func buildExecCmd(r git.Runner, execFn execRunner) *cobra.Command {
@@ -103,11 +112,7 @@ func buildExecCmd(r git.Runner, execFn execRunner) *cobra.Command {
 			return runExec(cmd, args, r, execFn)
 		},
 	}
-	c.Flags().Bool(flagAll, false, "")
-	c.Flags().String(flagType, "", "")
-	c.Flags().Bool(flagDirty, false, "")
-	c.Flags().Bool(flagFailFast, false, "")
-	c.Flags().Int(flagConcurrency, 0, "")
+	addExecFlags(c)
 	c.Flags().Bool(flagJSON, false, "")
 	c.Flags().Bool(flagNoColor, false, "")
 	return c
@@ -249,14 +254,8 @@ func execRenderText(cmd *cobra.Command, results []executor.Result, prefixes []st
 }
 
 func init() {
-	execCmd.Flags().Bool(flagAll, false, "run in all eligible worktrees")
-	execCmd.Flags().String(flagType, "", "filter by prefix type (e.g. feature, bugfix)")
-	execCmd.Flags().Bool(flagDirty, false, "run only in dirty worktrees")
-	execCmd.Flags().Bool(flagFailFast, false, "stop after the first failure")
-	execCmd.Flags().Int(flagConcurrency, 0, "max parallel executions (0 = unlimited)")
-
+	addExecFlags(execCmd)
 	_ = execCmd.RegisterFlagCompletionFunc(flagType, typeFilterCompletion())
-
 	rootCmd.AddCommand(execCmd)
 }
 

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/executor"
+	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/output"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/spinner"
@@ -548,5 +549,152 @@ func TestExecShowHintsJSONEarlyReturn(t *testing.T) {
 	execShowHints(cmd)
 	if buf.Len() != 0 {
 		t.Errorf("expected no output in JSON mode, got %q", buf.String())
+	}
+}
+
+// newExecCmd builds a testable exec command with injected runner and executor.
+func newExecCmd(r git.Runner, execFn execRunner) (*cobra.Command, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	cfg := &config.Config{DefaultSource: "main"}
+	c := buildExecCmd(r, execFn)
+	c.SetOut(buf)
+	c.SetErr(buf)
+	c.SetContext(config.WithConfig(context.Background(), cfg))
+	return c, buf
+}
+
+func TestExecCmdMissingTargetFlag(t *testing.T) {
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", nil },
+		runInDir: noopRunInDir,
+	}
+	cmd, _ := newExecCmd(r, func(_ context.Context, _ executor.Config) []executor.Result { return nil })
+	cmd.SetArgs([]string{"echo hi"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when neither --all nor --type is set")
+	}
+	if !strings.Contains(err.Error(), "provide --all or --type") {
+		t.Errorf("error = %q, want 'provide --all or --type'", err.Error())
+	}
+}
+
+func TestExecCmdInvokesExecutor(t *testing.T) {
+	porcelain := strings.Join([]string{
+		"worktree /repo",
+		"HEAD abc",
+		"branch refs/heads/main",
+		"",
+		"worktree /wt/foo",
+		"HEAD def",
+		"branch refs/heads/feature/foo",
+		"",
+	}, "\n")
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return porcelain, nil },
+		runInDir: noopRunInDir,
+	}
+
+	var capturedCfg executor.Config
+	fakeExec := func(_ context.Context, cfg executor.Config) []executor.Result {
+		capturedCfg = cfg
+		return []executor.Result{
+			{Target: executor.Target{Branch: "feature/foo", Task: "foo", Path: "/wt/foo"}, ExitCode: 0, Stdout: []byte("ok\n")},
+		}
+	}
+
+	cmd, buf := newExecCmd(r, fakeExec)
+	cmd.SetArgs([]string{"--all", "--no-color", "echo ok"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedCfg.Command != "echo ok" {
+		t.Errorf("command = %q, want %q", capturedCfg.Command, "echo ok")
+	}
+	if len(capturedCfg.Targets) == 0 {
+		t.Error("expected at least one target")
+	}
+	if !strings.Contains(buf.String(), "foo") {
+		t.Errorf("output missing task name: %q", buf.String())
+	}
+}
+
+func TestExecCmdJSONOutput(t *testing.T) {
+	porcelain := strings.Join([]string{
+		"worktree /repo",
+		"HEAD abc",
+		"branch refs/heads/main",
+		"",
+		"worktree /wt/foo",
+		"HEAD def",
+		"branch refs/heads/feature/foo",
+		"",
+	}, "\n")
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return porcelain, nil },
+		runInDir: noopRunInDir,
+	}
+	fakeExec := func(_ context.Context, _ executor.Config) []executor.Result {
+		return []executor.Result{
+			{Target: executor.Target{Branch: "feature/foo", Task: "foo", Path: "/wt/foo"}, ExitCode: 0},
+		}
+	}
+
+	cmd, buf := newExecCmd(r, fakeExec)
+	cmd.SetArgs([]string{"--all", "--json", "echo hi"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var env output.Envelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\noutput: %s", err, buf.String())
+	}
+	if env.Command != "exec" {
+		t.Errorf("envelope command = %q, want %q", env.Command, "exec")
+	}
+	dataMap, ok := env.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("data type = %T, want map[string]any", env.Data)
+	}
+	resultsArr, ok := dataMap["results"].([]any)
+	if !ok {
+		t.Fatalf("results type = %T, want []any", dataMap["results"])
+	}
+	if len(resultsArr) != 1 {
+		t.Errorf("results length = %d, want 1", len(resultsArr))
+	}
+}
+
+func TestExecCmdNoMatchingWorktrees(t *testing.T) {
+	// Only main worktree — no non-main worktrees to match.
+	porcelain := strings.Join([]string{
+		"worktree /repo",
+		"HEAD abc",
+		"branch refs/heads/main",
+		"",
+	}, "\n")
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return porcelain, nil },
+		runInDir: noopRunInDir,
+	}
+	called := false
+	fakeExec := func(_ context.Context, _ executor.Config) []executor.Result {
+		called = true
+		return nil
+	}
+
+	cmd, buf := newExecCmd(r, fakeExec)
+	cmd.SetArgs([]string{"--all", "echo hi"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if called {
+		t.Error("executor should not be called when no worktrees match")
+	}
+	if !strings.Contains(buf.String(), "No worktrees match") {
+		t.Errorf("expected 'No worktrees match' in output, got: %q", buf.String())
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -110,7 +110,13 @@ func init() {
 	rootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		var hint <-chan *updater.CheckResult
 		if cmd == rootCmd {
-			hint = checkUpdateHint(version, 2*time.Second)
+			ctx := cmd.Context()
+			if ctx == nil {
+				// cmd.Context() is nil when HelpFunc is called outside of
+				// ExecuteContext (e.g., directly in tests).
+				ctx = context.Background()
+			}
+			hint = checkUpdateHint(ctx, version, 2*time.Second)
 			printBanner(cmd)
 		}
 		originalHelp(cmd, args)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -218,6 +218,10 @@ func TestExecute(t *testing.T) {
 	t.Cleanup(func() {
 		rootCmd.SetOut(nil)
 		rootCmd.SetErr(nil)
+		// Execute() sets rootCmd.ctx to a signal-notified context that is
+		// cancelled when Execute returns (via defer stop()). Reset it so
+		// subsequent tests that call cmd.Context() get a live context.
+		rootCmd.SetContext(context.Background())
 	})
 
 	if err := Execute(); err != nil {

--- a/cmd/update_hint.go
+++ b/cmd/update_hint.go
@@ -14,9 +14,10 @@ import (
 // Tests can override this to inject a mock server.
 var newUpdater func(string) *updater.Updater = updater.New
 
-// checkUpdateHint runs a background version check with a timeout.
+// checkUpdateHint runs a background version check bounded by timeout.
 // Returns nil if the version is dev, the check fails, times out, or is up to date.
-func checkUpdateHint(version string, timeout time.Duration) <-chan *updater.CheckResult {
+// The check is cancelled when ctx is done or timeout elapses — whichever comes first.
+func checkUpdateHint(ctx context.Context, version string, timeout time.Duration) <-chan *updater.CheckResult {
 	ch := make(chan *updater.CheckResult, 1)
 
 	if updater.IsDevVersion(version) {
@@ -24,12 +25,17 @@ func checkUpdateHint(version string, timeout time.Duration) <-chan *updater.Chec
 		return ch
 	}
 
+	// Derive a timeout-scoped child so the HTTP request is actually cancelled
+	// when timeout elapses, not just when the caller stops waiting.
+	tctx, cancel := context.WithTimeout(ctx, timeout)
+
 	// Read newUpdater before spawning the goroutine: goroutine launch
 	// establishes a happens-before edge, preventing a data race with
 	// test overrides that restore the variable via t.Cleanup.
 	u := newUpdater(version)
 	go func() {
-		result, err := u.Check(context.Background())
+		defer cancel()
+		result, err := u.Check(tctx)
 		if err != nil || result.UpToDate {
 			close(ch)
 			return
@@ -37,7 +43,7 @@ func checkUpdateHint(version string, timeout time.Duration) <-chan *updater.Chec
 		ch <- result
 	}()
 
-	// Return a channel that resolves with the result or nil after timeout
+	// Return a channel that resolves with the result or nil when tctx expires.
 	out := make(chan *updater.CheckResult, 1)
 	go func() {
 		select {
@@ -47,7 +53,7 @@ func checkUpdateHint(version string, timeout time.Duration) <-chan *updater.Chec
 			} else {
 				close(out)
 			}
-		case <-time.After(timeout):
+		case <-tctx.Done():
 			close(out)
 		}
 	}()

--- a/cmd/update_hint.go
+++ b/cmd/update_hint.go
@@ -46,6 +46,7 @@ func checkUpdateHint(ctx context.Context, version string, timeout time.Duration)
 	// Return a channel that resolves with the result or nil when tctx expires.
 	out := make(chan *updater.CheckResult, 1)
 	go func() {
+		defer cancel()
 		select {
 		case r, ok := <-ch:
 			if ok {

--- a/cmd/update_hint_test.go
+++ b/cmd/update_hint_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -48,7 +49,7 @@ func TestCheckUpdateHintNewVersionAvailable(t *testing.T) {
 	t.Cleanup(srv.Close)
 	overrideNewUpdater(t, srv)
 
-	ch := checkUpdateHint(testVersionHint, 2*time.Second)
+	ch := checkUpdateHint(context.Background(), testVersionHint, 2*time.Second)
 	result := collectHint(ch)
 	if result == nil {
 		t.Fatal("expected non-nil result for available update")
@@ -67,7 +68,7 @@ func TestCheckUpdateHintUpToDate(t *testing.T) {
 	t.Cleanup(srv.Close)
 	overrideNewUpdater(t, srv)
 
-	ch := checkUpdateHint(testVersionHint, 2*time.Second)
+	ch := checkUpdateHint(context.Background(), testVersionHint, 2*time.Second)
 	result := collectHint(ch)
 	if result != nil {
 		t.Errorf("expected nil result for up-to-date version, got %+v", result)
@@ -81,7 +82,7 @@ func TestCheckUpdateHintDevVersion(t *testing.T) {
 	t.Cleanup(srv.Close)
 	overrideNewUpdater(t, srv)
 
-	ch := checkUpdateHint("dev", 2*time.Second)
+	ch := checkUpdateHint(context.Background(), "dev", 2*time.Second)
 	result := collectHint(ch)
 	if result != nil {
 		t.Errorf("expected nil result for dev version, got %+v", result)
@@ -102,7 +103,7 @@ func TestCheckUpdateHintTimeout(t *testing.T) {
 	t.Cleanup(srv.Close)
 	overrideNewUpdater(t, srv)
 
-	ch := checkUpdateHint(testVersionHint, 50*time.Millisecond)
+	ch := checkUpdateHint(context.Background(), testVersionHint, 50*time.Millisecond)
 	result := collectHint(ch)
 	if result != nil {
 		t.Errorf("expected nil result on timeout, got %+v", result)
@@ -148,5 +149,30 @@ func TestCollectHintValue(t *testing.T) {
 	}
 	if result.LatestVersion != testVersionOther {
 		t.Errorf("LatestVersion = %q, want %q", result.LatestVersion, testVersionOther)
+	}
+}
+
+func TestCheckUpdateHintCancelledContext(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A pre-cancelled context should cause the HTTP client to fail before
+		// sending a request, so the handler must never complete a response.
+		t.Error("unexpected HTTP round-trip for pre-cancelled context")
+	}))
+	t.Cleanup(srv.Close)
+	overrideNewUpdater(t, srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	start := time.Now()
+	ch := checkUpdateHint(ctx, testVersionHint, 2*time.Second)
+	result := collectHint(ch)
+	elapsed := time.Since(start)
+
+	if result != nil {
+		t.Errorf("expected nil result for cancelled context, got %+v", result)
+	}
+	if elapsed > 400*time.Millisecond {
+		t.Errorf("expected fast return on cancelled context, took %v", elapsed)
 	}
 }

--- a/cmd/update_hint_test.go
+++ b/cmd/update_hint_test.go
@@ -77,7 +77,7 @@ func TestCheckUpdateHintUpToDate(t *testing.T) {
 
 func TestCheckUpdateHintDevVersion(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Error("unexpected HTTP request for dev version")
+		t.Fatal("unexpected HTTP request for dev version")
 	}))
 	t.Cleanup(srv.Close)
 	overrideNewUpdater(t, srv)

--- a/cmd/update_hint_test.go
+++ b/cmd/update_hint_test.go
@@ -156,7 +156,7 @@ func TestCheckUpdateHintCancelledContext(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// A pre-cancelled context should cause the HTTP client to fail before
 		// sending a request, so the handler must never complete a response.
-		t.Error("unexpected HTTP round-trip for pre-cancelled context")
+		t.Fatal("unexpected HTTP round-trip for pre-cancelled context")
 	}))
 	t.Cleanup(srv.Close)
 	overrideNewUpdater(t, srv)


### PR DESCRIPTION
## Summary

- **Finding 1 — goroutine/socket leak:** `checkUpdateHint` called `u.Check(context.Background())`, so the inner HTTP goroutine kept running for up to the updater's 30 s client timeout after the outer 2 s window elapsed. Added `ctx context.Context` param, derived `context.WithTimeout(ctx, timeout)` for the request, and passed `tctx` to `u.Check` so the HTTP round-trip is bounded by both the caller's context and the timeout. Also reset `rootCmd.ctx` in `TestExecute`'s cleanup to prevent the post-`Execute` cancelled signal-context from leaking into subsequent tests.
- **Finding 2 — missing cobra-level test seam:** Extracted `runExec(cmd, args, r git.Runner, execFn execRunner) error` from `execCmd.RunE` and added `buildExecCmd(r, execFn)` (mirrors `buildTrustCmd`, `trust.go:49`). Both production `RunE` and the test constructor delegate to `runExec`, so tests exercise the real flag-parse → filter → executor wiring. Added four cobra-level tests: `TestExecCmdMissingTargetFlag`, `TestExecCmdInvokesExecutor`, `TestExecCmdJSONOutput`, `TestExecCmdNoMatchingWorktrees`.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)
- [x] Race detector clean (`go test -race ./...`)
- [x] Coverage ≥ 97% (`make test-coverage` → 97.2%)
- [x] New `TestCheckUpdateHintCancelledContext` verifies pre-cancelled context returns quickly without calling the HTTP server
- [x] New `TestExecCmd*` tests exercise the cobra-level wiring end-to-end with injected mocks

## Issue

Closes #287