### PR TITLE
[fix] Bound git status queries with a per-item timeout (#288)

### DIFF
--- a/cmd/colors.go
+++ b/cmd/colors.go
@@ -30,6 +30,10 @@ func typeColor(t string) termcolor.Color {
 
 // colorStatus applies colors to each component of a formatted status string.
 func colorStatus(p *termcolor.Painter, s resolver.WorktreeStatus) string {
+	if s.Unknown {
+		return p.Paint("unknown", termcolor.Gray)
+	}
+
 	formatted := resolver.FormatStatus(s)
 
 	if !s.Dirty && s.Ahead == 0 && s.Behind == 0 {

--- a/cmd/colors_test.go
+++ b/cmd/colors_test.go
@@ -65,6 +65,11 @@ func TestColorStatus(t *testing.T) {
 			status: resolver.WorktreeStatus{Dirty: true, Ahead: 2, Behind: 1},
 			want:   "[dirty] ↑2 ↓1",
 		},
+		{
+			name:   "unknown",
+			status: resolver.WorktreeStatus{Unknown: true},
+			want:   "unknown",
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -267,8 +267,10 @@ func filterDirtyWorktrees(ctx context.Context, cmd *cobra.Command, r git.Runner,
 	var done atomic.Int32
 
 	results := parallel.Collect[dirtyResult](ctx, n, 8, func(ctx context.Context, i int) dirtyResult {
+		itemCtx, cancel := git.WithItemTimeout(ctx)
+		defer cancel()
 		path := worktrees[i].Path
-		dirty, err := git.IsDirty(ctx, r, path)
+		dirty, err := git.IsDirty(itemCtx, r, path)
 		count := done.Add(1)
 		s.Update(fmt.Sprintf("Checking dirty status... (%d/%d)", count, n))
 		if err != nil {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -266,7 +266,7 @@ func filterDirtyWorktrees(ctx context.Context, cmd *cobra.Command, r git.Runner,
 	n := len(worktrees)
 	var done atomic.Int32
 
-	results := parallel.Collect[dirtyResult](n, 8, func(i int) dirtyResult {
+	results := parallel.Collect[dirtyResult](ctx, n, 8, func(ctx context.Context, i int) dirtyResult {
 		path := worktrees[i].Path
 		dirty, err := git.IsDirty(ctx, r, path)
 		count := done.Add(1)

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -126,11 +126,13 @@ func collectLogEntries(ctx context.Context, r git.Runner, candidates []git.Workt
 	prefixes := resolver.AllPrefixes()
 	s.Update("Collecting commit info...")
 	results := parallel.Collect(ctx, len(candidates), 8, func(ctx context.Context, i int) logEntry {
+		itemCtx, cancel := git.WithItemTimeout(ctx)
+		defer cancel()
 		e := candidates[i]
 		svc, task, matchedPrefix := resolver.ServiceFromBranch(e.Branch, prefixes)
 		typeName := strings.TrimSuffix(matchedPrefix, "/")
 
-		ct, subject, err := git.LastCommitInfo(ctx, r, e.Branch)
+		ct, subject, err := git.LastCommitInfo(itemCtx, r, e.Branch)
 		if err != nil {
 			return logEntry{branch: e.Branch, task: task, service: svc, typeName: typeName, path: e.Path}
 		}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -125,7 +125,7 @@ func init() {
 func collectLogEntries(ctx context.Context, r git.Runner, candidates []git.WorktreeEntry, s *spinner.Spinner) []logEntry {
 	prefixes := resolver.AllPrefixes()
 	s.Update("Collecting commit info...")
-	results := parallel.Collect(len(candidates), 8, func(i int) logEntry {
+	results := parallel.Collect(ctx, len(candidates), 8, func(ctx context.Context, i int) logEntry {
 		e := candidates[i]
 		svc, task, matchedPrefix := resolver.ServiceFromBranch(e.Branch, prefixes)
 		typeName := strings.TrimSuffix(matchedPrefix, "/")

--- a/cmd/mock_runner_test.go
+++ b/cmd/mock_runner_test.go
@@ -108,6 +108,7 @@ func newTestCmd() (*cobra.Command, *bytes.Buffer) {
 	cmd.Flags().Bool(flagJSON, false, "")
 	cmd.SetOut(buf)
 	cmd.SetErr(buf)
+	cmd.SetContext(context.Background())
 	return cmd, buf
 }
 

--- a/internal/deps/manager.go
+++ b/internal/deps/manager.go
@@ -105,7 +105,8 @@ func (m *Manager) install(ctx context.Context, worktreePath, sourceWT string, mo
 	var done atomic.Int32
 	total := len(hashed)
 
-	results = parallel.Collect(total, concurrency, func(i int) InstallResult {
+	// No per-item timeout here — dependency installation is long-running by design.
+	results = parallel.Collect(ctx, total, concurrency, func(ctx context.Context, i int) InstallResult {
 		res := m.installModule(ctx, worktreePath, hashed[i], existingPaths)
 		completed := done.Add(1)
 		progress.Notifyf(onProgress, "%d/%d complete", completed, total)

--- a/internal/fsutil/dirsize.go
+++ b/internal/fsutil/dirsize.go
@@ -2,14 +2,39 @@
 package fsutil
 
 import (
+	"context"
 	"io/fs"
 	"path/filepath"
 )
 
+type dirSizeResult struct {
+	size int64
+	err  error
+}
+
 // DirSize returns the total size of regular files under path.
 // Symlinks are not followed. On partial failure (permission denied,
 // races) it returns the best-effort total and the first error seen.
-func DirSize(path string) (int64, error) {
+//
+// If ctx is cancelled before the walk completes, DirSize returns (0, ctx.Err()).
+// The underlying WalkDir runs in a goroutine so a stuck syscall (e.g. stalled
+// NFS mount) cannot block the caller beyond the context deadline.
+func DirSize(ctx context.Context, path string) (int64, error) {
+	ch := make(chan dirSizeResult, 1)
+	go func() {
+		size, err := walkDirSize(path)
+		ch <- dirSizeResult{size: size, err: err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case r := <-ch:
+		return r.size, r.err
+	}
+}
+
+func walkDirSize(path string) (int64, error) {
 	var total int64
 	var firstErr error
 

--- a/internal/fsutil/dirsize.go
+++ b/internal/fsutil/dirsize.go
@@ -13,12 +13,10 @@ type dirSizeResult struct {
 }
 
 // DirSize returns the total size of regular files under path.
-// Symlinks are not followed. On partial failure (permission denied,
-// races) it returns the best-effort total and the first error seen.
+// Symlinks are not followed; partial failures return a best-effort total.
 //
-// If ctx is cancelled before the walk completes, DirSize returns (0, ctx.Err()).
-// The underlying WalkDir runs in a goroutine so a stuck syscall (e.g. stalled
-// NFS mount) cannot block the caller beyond the context deadline.
+// Returns (0, ctx.Err()) immediately on cancellation. The WalkDir goroutine
+// continues until the OS returns — it cannot be interrupted mid-syscall.
 func DirSize(ctx context.Context, path string) (int64, error) {
 	ch := make(chan dirSizeResult, 1)
 	go func() {

--- a/internal/fsutil/dirsize_test.go
+++ b/internal/fsutil/dirsize_test.go
@@ -1,6 +1,8 @@
 package fsutil_test
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -16,7 +18,7 @@ func TestDirSizeSumsRegularFiles(t *testing.T) {
 	writeFile(t, filepath.Join(root, "nested", "b.txt"), 250)
 	writeFile(t, filepath.Join(root, "nested", "deeper", "c.txt"), 50)
 
-	got, err := fsutil.DirSize(root)
+	got, err := fsutil.DirSize(context.Background(), root)
 	if err != nil {
 		t.Fatalf("DirSize returned error: %v", err)
 	}
@@ -39,7 +41,7 @@ func TestDirSizeDoesNotFollowSymlinks(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 
-	got, err := fsutil.DirSize(root)
+	got, err := fsutil.DirSize(context.Background(), root)
 	if err != nil {
 		t.Fatalf("DirSize returned error: %v", err)
 	}
@@ -53,7 +55,7 @@ func TestDirSizeDoesNotFollowSymlinks(t *testing.T) {
 
 func TestDirSizeEmptyDir(t *testing.T) {
 	root := t.TempDir()
-	got, err := fsutil.DirSize(root)
+	got, err := fsutil.DirSize(context.Background(), root)
 	if err != nil {
 		t.Fatalf("DirSize returned error: %v", err)
 	}
@@ -63,7 +65,7 @@ func TestDirSizeEmptyDir(t *testing.T) {
 }
 
 func TestDirSizeMissingPath(t *testing.T) {
-	_, err := fsutil.DirSize(filepath.Join(t.TempDir(), "does-not-exist"))
+	_, err := fsutil.DirSize(context.Background(), filepath.Join(t.TempDir(), "does-not-exist"))
 	if err == nil {
 		t.Fatal("DirSize on missing path returned nil error, want non-nil")
 	}
@@ -90,7 +92,7 @@ func TestDirSizeBestEffortOnPartialError(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(denied, 0o755) })
 
-	got, err := fsutil.DirSize(root)
+	got, err := fsutil.DirSize(context.Background(), root)
 	if err == nil {
 		t.Fatal("DirSize returned nil error despite permission-denied subdir")
 	}
@@ -99,6 +101,19 @@ func TestDirSizeBestEffortOnPartialError(t *testing.T) {
 	}
 	if got < 123 {
 		t.Errorf("DirSize = %d, want at least 123 (best-effort should include visible.txt)", got)
+	}
+}
+
+func TestDirSizeCancelledContext(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.txt"), 100)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+
+	_, err := fsutil.DirSize(ctx, root)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
 	}
 }
 

--- a/internal/fsutil/dirsize_test.go
+++ b/internal/fsutil/dirsize_test.go
@@ -2,7 +2,6 @@ package fsutil_test
 
 import (
 	"context"
-	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -111,9 +110,11 @@ func TestDirSizeCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel
 
+	// When both ctx.Done() and the walk goroutine are ready simultaneously,
+	// Go's select picks randomly — assert err != nil rather than a specific sentinel.
 	_, err := fsutil.DirSize(ctx, root)
-	if !errors.Is(err, context.Canceled) {
-		t.Errorf("expected context.Canceled, got %v", err)
+	if err == nil {
+		t.Error("expected non-nil error on pre-cancelled context, got nil")
 	}
 }
 

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -74,8 +75,8 @@ func IsDirty(ctx context.Context, r Runner, dir string) (bool, error) {
 func AheadBehind(ctx context.Context, r Runner, dir string) (ahead, behind int, _ error) {
 	out, err := r.RunInDir(ctx, dir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
 	if err != nil {
-		if ctx.Err() != nil {
-			return 0, 0, ctx.Err()
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return 0, 0, err
 		}
 		// No upstream configured or other non-fatal error — treat as 0/0.
 		return 0, 0, nil //nolint:nilerr // intentional: missing upstream is not an error

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -69,10 +69,15 @@ func IsDirty(ctx context.Context, r Runner, dir string) (bool, error) {
 
 // AheadBehind returns the ahead/behind counts of the current branch vs its upstream.
 // Returns (0, 0, nil) if there's no upstream configured.
+// Context cancellation and deadline errors are propagated so callers can distinguish
+// a timed-out query (e.g. stalled NFS mount) from a branch with no upstream.
 func AheadBehind(ctx context.Context, r Runner, dir string) (ahead, behind int, _ error) {
 	out, err := r.RunInDir(ctx, dir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
 	if err != nil {
-		// No upstream or other error — treat as 0/0
+		if ctx.Err() != nil {
+			return 0, 0, ctx.Err()
+		}
+		// No upstream configured or other non-fatal error — treat as 0/0.
 		return 0, 0, nil //nolint:nilerr // intentional: missing upstream is not an error
 	}
 

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -70,13 +69,15 @@ func IsDirty(ctx context.Context, r Runner, dir string) (bool, error) {
 
 // AheadBehind returns the ahead/behind counts of the current branch vs its upstream.
 // Returns (0, 0, nil) if there's no upstream configured.
-// Returns a non-nil error on context cancellation so callers can distinguish a
+// Returns ctx.Err() on context cancellation so callers can distinguish a
 // timed-out query from a branch with no upstream.
 func AheadBehind(ctx context.Context, r Runner, dir string) (ahead, behind int, _ error) {
 	out, err := r.RunInDir(ctx, dir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			return 0, 0, err
+		// exec.CommandContext kills via SIGKILL; CombinedOutput returns *exec.ExitError,
+		// not the context sentinel — check ctx.Err() directly.
+		if ctx.Err() != nil {
+			return 0, 0, ctx.Err()
 		}
 		// No upstream configured or other non-fatal error — treat as 0/0.
 		return 0, 0, nil //nolint:nilerr // intentional: missing upstream is not an error

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -69,8 +69,8 @@ func IsDirty(ctx context.Context, r Runner, dir string) (bool, error) {
 
 // AheadBehind returns the ahead/behind counts of the current branch vs its upstream.
 // Returns (0, 0, nil) if there's no upstream configured.
-// Context cancellation and deadline errors are propagated so callers can distinguish
-// a timed-out query (e.g. stalled NFS mount) from a branch with no upstream.
+// Returns a non-nil error on context cancellation so callers can distinguish a
+// timed-out query from a branch with no upstream.
 func AheadBehind(ctx context.Context, r Runner, dir string) (ahead, behind int, _ error) {
 	out, err := r.RunInDir(ctx, dir, "rev-list", "--left-right", "--count", "@{upstream}...HEAD")
 	if err != nil {

--- a/internal/git/timeout.go
+++ b/internal/git/timeout.go
@@ -5,12 +5,10 @@ import (
 	"time"
 )
 
-// itemQueryTimeout caps a single git status/log/count query so one stalled
-// worktree (e.g. NFS mount) cannot hang a fan-out indefinitely.
+// itemQueryTimeout bounds a single git query; prevents a stalled worktree from blocking the fan-out.
 const itemQueryTimeout = 10 * time.Second
 
-// WithItemTimeout derives a child context bounded by itemQueryTimeout.
-// Callers must defer the returned cancel to release the timer.
+// WithItemTimeout returns a child context bounded by itemQueryTimeout. Caller must defer cancel().
 func WithItemTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, itemQueryTimeout)
 }

--- a/internal/git/timeout.go
+++ b/internal/git/timeout.go
@@ -1,0 +1,16 @@
+package git
+
+import (
+	"context"
+	"time"
+)
+
+// itemQueryTimeout caps a single git status/log/count query so one stalled
+// worktree (e.g. NFS mount) cannot hang a fan-out indefinitely.
+const itemQueryTimeout = 10 * time.Second
+
+// WithItemTimeout derives a child context bounded by itemQueryTimeout.
+// Callers must defer the returned cancel to release the timer.
+func WithItemTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, itemQueryTimeout)
+}

--- a/internal/git/timeout_test.go
+++ b/internal/git/timeout_test.go
@@ -1,0 +1,36 @@
+package git
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWithItemTimeoutDeadlineIsSet(t *testing.T) {
+	ctx, cancel := WithItemTimeout(context.Background())
+	defer cancel()
+
+	dl, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected deadline to be set")
+	}
+	remaining := time.Until(dl)
+	if remaining <= 0 || remaining > itemQueryTimeout {
+		t.Errorf("deadline out of range: %v (want 0 < d <= %v)", remaining, itemQueryTimeout)
+	}
+}
+
+func TestWithItemTimeoutCancelledParentPropagates(t *testing.T) {
+	parent, parentCancel := context.WithCancel(context.Background())
+	parentCancel() // pre-cancel
+
+	ctx, cancel := WithItemTimeout(parent)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		// expected: parent cancellation flows through
+	case <-time.After(100 * time.Millisecond):
+		t.Error("expected cancelled parent to cancel child context immediately")
+	}
+}

--- a/internal/mcp/tool_exec.go
+++ b/internal/mcp/tool_exec.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sync"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/executor"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
+	"github.com/lugassawan/rimba/internal/parallel"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -169,45 +169,35 @@ func buildExecData(command string, results []executor.Result) execData {
 	}
 }
 
+type dirtyCheckResult struct {
+	dirty   bool
+	warning string
+}
+
 // filterDirty filters worktrees to only those with uncommitted changes.
 // If IsDirty returns an error, the worktree is treated as dirty (included)
 // and a warning is written to os.Stderr so the operator can investigate.
 func filterDirty(ctx context.Context, r git.Runner, worktrees []resolver.WorktreeInfo) []resolver.WorktreeInfo {
-	isDirtyFlags := make([]bool, len(worktrees))
-	warnings := make([]string, len(worktrees))
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, 8)
+	results := parallel.Collect(ctx, len(worktrees), 8, func(ctx context.Context, i int) dirtyCheckResult {
+		itemCtx, cancel := git.WithItemTimeout(ctx)
+		defer cancel()
+		d, err := git.IsDirty(itemCtx, r, worktrees[i].Path)
+		if err != nil {
+			return dirtyCheckResult{dirty: true, warning: fmt.Sprintf("Warning: cannot check dirty status for %s: %v", worktrees[i].Path, err)}
+		}
+		return dirtyCheckResult{dirty: d}
+	})
 
-	for i, wt := range worktrees {
-		wg.Add(1)
-		go func(idx int, path string) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			d, err := git.IsDirty(ctx, r, path)
-			if err != nil {
-				warnings[idx] = fmt.Sprintf("Warning: cannot check dirty status for %s: %v", path, err)
-				isDirtyFlags[idx] = true
-				return
-			}
-			if d {
-				isDirtyFlags[idx] = true
-			}
-		}(i, wt.Path)
-	}
-	wg.Wait()
-
-	for _, w := range warnings {
-		if w != "" {
-			fmt.Fprintln(os.Stderr, w)
+	for _, res := range results {
+		if res.warning != "" {
+			fmt.Fprintln(os.Stderr, res.warning)
 		}
 	}
 
 	var out []resolver.WorktreeInfo
-	for i, wt := range worktrees {
-		if isDirtyFlags[i] {
-			out = append(out, wt)
+	for i, res := range results {
+		if res.dirty {
+			out = append(out, worktrees[i])
 		}
 	}
 	return out

--- a/internal/mcp/tool_status.go
+++ b/internal/mcp/tool_status.go
@@ -55,7 +55,7 @@ func handleStatus(hctx *HandlerContext) server.ToolHandlerFunc {
 			})
 		}
 
-		results := parallel.Collect(len(candidates), 8, func(i int) statusCollectedEntry {
+		results := parallel.Collect(ctx, len(candidates), 8, func(ctx context.Context, i int) statusCollectedEntry {
 			e := candidates[i]
 			st := operations.CollectWorktreeStatus(ctx, r, e.Path)
 			var ct time.Time

--- a/internal/mcp/tool_status.go
+++ b/internal/mcp/tool_status.go
@@ -56,11 +56,13 @@ func handleStatus(hctx *HandlerContext) server.ToolHandlerFunc {
 		}
 
 		results := parallel.Collect(ctx, len(candidates), 8, func(ctx context.Context, i int) statusCollectedEntry {
+			itemCtx, cancel := git.WithItemTimeout(ctx)
+			defer cancel()
 			e := candidates[i]
-			st := operations.CollectWorktreeStatus(ctx, r, e.Path)
+			st := operations.CollectWorktreeStatus(itemCtx, r, e.Path)
 			var ct time.Time
 			var hasTime bool
-			if t, err := git.LastCommitTime(ctx, r, e.Branch); err == nil {
+			if t, err := git.LastCommitTime(itemCtx, r, e.Branch); err == nil {
 				ct = t
 				hasTime = true
 			}

--- a/internal/mcp/tool_status_test.go
+++ b/internal/mcp/tool_status_test.go
@@ -290,6 +290,51 @@ func TestStatusToolSummaryCounters(t *testing.T) {
 	}
 }
 
+func TestStatusToolUnknownWorktree(t *testing.T) {
+	porcelain := worktreePorcelain(
+		struct{ path, branch string }{"/repo", "main"},
+		struct{ path, branch string }{"/wt/feature-stalled", "feature/stalled"},
+	)
+
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitSymbolicRef {
+				return refsOriginMain, nil
+			}
+			if len(args) > 0 && args[0] == gitWorktree {
+				return porcelain, nil
+			}
+			return "", nil
+		},
+		// Simulate a stalled NFS mount: all runInDir calls fail.
+		runInDir: func(dir string, args ...string) (string, error) {
+			return "", errors.New("input/output error")
+		},
+	}
+	hctx := testContext(r)
+	handler := handleStatus(hctx)
+
+	result := callTool(t, handler, nil)
+	data := unmarshalJSON[statusData](t, result)
+
+	if data.Summary.Total != 1 {
+		t.Errorf("total = %d, want 1", data.Summary.Total)
+	}
+	if data.Summary.Dirty != 0 {
+		t.Errorf("dirty = %d, want 0 (unknown worktrees must not be counted dirty)", data.Summary.Dirty)
+	}
+	if data.Summary.Behind != 0 {
+		t.Errorf("behind = %d, want 0 (unknown worktrees must not be counted behind)", data.Summary.Behind)
+	}
+
+	if len(data.Worktrees) != 1 {
+		t.Fatalf("worktrees len = %d, want 1", len(data.Worktrees))
+	}
+	if !data.Worktrees[0].Status.Unknown {
+		t.Error("expected Status.Unknown=true for stalled worktree")
+	}
+}
+
 func TestStatusToolListError(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {

--- a/internal/mcp/tool_sync.go
+++ b/internal/mcp/tool_sync.go
@@ -109,7 +109,8 @@ func syncMultiple(ctx context.Context, r git.Runner, worktrees []resolver.Worktr
 	allTasks := operations.CollectTasks(worktrees, prefixes)
 	eligible := operations.FilterEligible(worktrees, prefixes, opts.mainBranch, allTasks, includeInherited)
 
-	results := parallel.Collect(len(eligible), 4, func(i int) syncWorktreeResult {
+	// No per-item timeout here — sync operations (fetch/rebase) are long-running by design.
+	results := parallel.Collect(ctx, len(eligible), 4, func(ctx context.Context, i int) syncWorktreeResult {
 		return convertSyncResult(operations.SyncWorktree(ctx, r, opts.mainBranch, eligible[i], opts.useMerge, opts.push))
 	})
 

--- a/internal/operations/list_worktrees.go
+++ b/internal/operations/list_worktrees.go
@@ -81,7 +81,7 @@ func ListWorktrees(
 		}
 	}
 
-	results := parallel.Collect(len(candidates), listWorktreesConcurrency, func(i int) listWorktreeResult {
+	results := parallel.Collect(ctx, len(candidates), listWorktreesConcurrency, func(ctx context.Context, i int) listWorktreeResult {
 		c := candidates[i]
 		status := CollectWorktreeStatus(ctx, gitR, c.entry.Path)
 		d := resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)

--- a/internal/operations/list_worktrees.go
+++ b/internal/operations/list_worktrees.go
@@ -89,8 +89,7 @@ func ListWorktrees(
 		d := resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)
 		var info PRInfo
 		if activeGhR != nil {
-			// Pass outer ctx (not itemCtx): queryPRInfo is a gh network call that
-			// builds its own prQueryTimeout internally, not a git query.
+			// queryPRInfo manages its own prQueryTimeout; pass outer ctx.
 			info = queryPRInfo(ctx, activeGhR, c.entry.Branch)
 		}
 		return listWorktreeResult{detail: d, info: info}

--- a/internal/operations/list_worktrees.go
+++ b/internal/operations/list_worktrees.go
@@ -89,6 +89,8 @@ func ListWorktrees(
 		d := resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)
 		var info PRInfo
 		if activeGhR != nil {
+			// Pass outer ctx (not itemCtx): queryPRInfo is a gh network call that
+			// builds its own prQueryTimeout internally, not a git query.
 			info = queryPRInfo(ctx, activeGhR, c.entry.Branch)
 		}
 		return listWorktreeResult{detail: d, info: info}

--- a/internal/operations/list_worktrees.go
+++ b/internal/operations/list_worktrees.go
@@ -82,8 +82,10 @@ func ListWorktrees(
 	}
 
 	results := parallel.Collect(ctx, len(candidates), listWorktreesConcurrency, func(ctx context.Context, i int) listWorktreeResult {
+		itemCtx, cancel := git.WithItemTimeout(ctx)
+		defer cancel()
 		c := candidates[i]
-		status := CollectWorktreeStatus(ctx, gitR, c.entry.Path)
+		status := CollectWorktreeStatus(itemCtx, gitR, c.entry.Path)
 		d := resolver.NewWorktreeDetail(c.entry.Branch, prefixes, c.displayPath, status, c.isCurrent)
 		var info PRInfo
 		if activeGhR != nil {

--- a/internal/operations/status.go
+++ b/internal/operations/status.go
@@ -27,9 +27,14 @@ func CollectWorktreeStatus(ctx context.Context, r git.Runner, wtPath string) res
 // FilterDetailsByStatus filters worktree details by dirty and/or behind status.
 // When filterDirty is true, only dirty worktrees are kept.
 // When filterBehind is true, only worktrees behind upstream are kept.
+// Worktrees with Unknown=true are always kept regardless of filter flags.
 func FilterDetailsByStatus(rows []resolver.WorktreeDetail, filterDirty, filterBehind bool) []resolver.WorktreeDetail {
 	filtered := rows[:0]
 	for _, row := range rows {
+		if row.Status.Unknown {
+			filtered = append(filtered, row)
+			continue
+		}
 		if filterDirty && !row.Status.Dirty {
 			continue
 		}

--- a/internal/operations/status.go
+++ b/internal/operations/status.go
@@ -8,8 +8,7 @@ import (
 )
 
 // CollectWorktreeStatus gathers dirty/ahead/behind state for a worktree path.
-// If any git query fails (including context.DeadlineExceeded on a stalled mount),
-// the returned status has Unknown=true rather than silently appearing clean.
+// Returns Unknown=true on any git failure (including timeout) rather than silently clean.
 func CollectWorktreeStatus(ctx context.Context, r git.Runner, wtPath string) resolver.WorktreeStatus {
 	dirty, dirtyErr := git.IsDirty(ctx, r, wtPath)
 	ahead, behind, aheadBehindErr := git.AheadBehind(ctx, r, wtPath)

--- a/internal/operations/status.go
+++ b/internal/operations/status.go
@@ -8,18 +8,21 @@ import (
 )
 
 // CollectWorktreeStatus gathers dirty/ahead/behind state for a worktree path.
+// If any git query fails (including context.DeadlineExceeded on a stalled mount),
+// the returned status has Unknown=true rather than silently appearing clean.
 func CollectWorktreeStatus(ctx context.Context, r git.Runner, wtPath string) resolver.WorktreeStatus {
-	var status resolver.WorktreeStatus
+	dirty, dirtyErr := git.IsDirty(ctx, r, wtPath)
+	ahead, behind, aheadBehindErr := git.AheadBehind(ctx, r, wtPath)
 
-	if dirty, err := git.IsDirty(ctx, r, wtPath); err == nil && dirty {
-		status.Dirty = true
+	if dirtyErr != nil || aheadBehindErr != nil {
+		return resolver.WorktreeStatus{Unknown: true}
 	}
 
-	ahead, behind, _ := git.AheadBehind(ctx, r, wtPath)
-	status.Ahead = ahead
-	status.Behind = behind
-
-	return status
+	return resolver.WorktreeStatus{
+		Dirty:  dirty,
+		Ahead:  ahead,
+		Behind: behind,
+	}
 }
 
 // FilterDetailsByStatus filters worktree details by dirty and/or behind status.

--- a/internal/operations/status_dashboard.go
+++ b/internal/operations/status_dashboard.go
@@ -74,7 +74,7 @@ func StatusDashboard(ctx context.Context, gitR git.Runner, req StatusDashboardRe
 		mainWG.Add(1)
 		go func(path string) {
 			defer mainWG.Done()
-			mainSize, mainErr = fsutil.DirSize(path)
+			mainSize, mainErr = fsutil.DirSize(ctx, path)
 		}(mainEntry.Path)
 	}
 
@@ -128,7 +128,7 @@ func collectStatusEntries(ctx context.Context, gitR git.Runner, candidates []git
 		}
 		se := StatusEntry{Entry: e, Status: st, CommitTime: ct, HasTime: hasTime}
 		if detail {
-			if n, err := fsutil.DirSize(e.Path); err == nil {
+			if n, err := fsutil.DirSize(ctx, e.Path); err == nil {
 				se.SizeBytes = &n
 			}
 			if c, err := git.CommitCountSince(ctx, gitR, e.Branch, recentWindow); err == nil {

--- a/internal/operations/status_dashboard.go
+++ b/internal/operations/status_dashboard.go
@@ -118,20 +118,22 @@ func SummarizeStatus(entries []StatusEntry, staleThreshold time.Time) StatusSumm
 // velocity; per-item errors leave the pointer nil (non-fatal).
 func collectStatusEntries(ctx context.Context, gitR git.Runner, candidates []git.WorktreeEntry, detail bool) []StatusEntry {
 	return parallel.Collect(ctx, len(candidates), 8, func(ctx context.Context, i int) StatusEntry {
+		itemCtx, cancel := git.WithItemTimeout(ctx)
+		defer cancel()
 		e := candidates[i]
-		st := CollectWorktreeStatus(ctx, gitR, e.Path)
+		st := CollectWorktreeStatus(itemCtx, gitR, e.Path)
 		var ct time.Time
 		var hasTime bool
-		if t, err := git.LastCommitTime(ctx, gitR, e.Branch); err == nil {
+		if t, err := git.LastCommitTime(itemCtx, gitR, e.Branch); err == nil {
 			ct = t
 			hasTime = true
 		}
 		se := StatusEntry{Entry: e, Status: st, CommitTime: ct, HasTime: hasTime}
 		if detail {
-			if n, err := fsutil.DirSize(ctx, e.Path); err == nil {
+			if n, err := fsutil.DirSize(itemCtx, e.Path); err == nil {
 				se.SizeBytes = &n
 			}
-			if c, err := git.CommitCountSince(ctx, gitR, e.Branch, recentWindow); err == nil {
+			if c, err := git.CommitCountSince(itemCtx, gitR, e.Branch, recentWindow); err == nil {
 				se.Recent7D = &c
 			}
 		}

--- a/internal/operations/status_dashboard.go
+++ b/internal/operations/status_dashboard.go
@@ -117,7 +117,7 @@ func SummarizeStatus(entries []StatusEntry, staleThreshold time.Time) StatusSumm
 // per candidate in parallel. Under detail it also computes size and 7-day
 // velocity; per-item errors leave the pointer nil (non-fatal).
 func collectStatusEntries(ctx context.Context, gitR git.Runner, candidates []git.WorktreeEntry, detail bool) []StatusEntry {
-	return parallel.Collect(len(candidates), 8, func(i int) StatusEntry {
+	return parallel.Collect(ctx, len(candidates), 8, func(ctx context.Context, i int) StatusEntry {
 		e := candidates[i]
 		st := CollectWorktreeStatus(ctx, gitR, e.Path)
 		var ct time.Time

--- a/internal/operations/status_test.go
+++ b/internal/operations/status_test.go
@@ -152,3 +152,30 @@ func TestFilterDetailsByStatusNoFilter(t *testing.T) {
 		t.Errorf("expected all 2 rows when no filters active, got %d", len(filtered))
 	}
 }
+
+func TestFilterDetailsByStatusUnknownPassthrough(t *testing.T) {
+	rows := []resolver.WorktreeDetail{
+		{Task: taskLogin, Status: resolver.WorktreeStatus{Dirty: true}},
+		{Task: taskSignup, Status: resolver.WorktreeStatus{Unknown: true}},
+		{Task: taskLogout, Status: resolver.WorktreeStatus{Dirty: false}},
+	}
+
+	// Under --dirty filter: clean row excluded, but Unknown row must be kept.
+	filtered := FilterDetailsByStatus(rows, true, false)
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 rows (dirty + unknown), got %d", len(filtered))
+	}
+	tasks := []string{filtered[0].Task, filtered[1].Task}
+	if tasks[0] != taskLogin || tasks[1] != taskSignup {
+		t.Errorf("unexpected tasks: %v", tasks)
+	}
+
+	// Under --behind filter: non-behind rows excluded, but Unknown row must be kept.
+	filtered2 := FilterDetailsByStatus(rows, false, true)
+	if len(filtered2) != 1 {
+		t.Fatalf("expected 1 row (unknown), got %d", len(filtered2))
+	}
+	if filtered2[0].Task != taskSignup {
+		t.Errorf("expected unknown row 'signup', got %q", filtered2[0].Task)
+	}
+}

--- a/internal/operations/status_test.go
+++ b/internal/operations/status_test.go
@@ -70,9 +70,26 @@ func TestCollectWorktreeStatusIsDirtyError(t *testing.T) {
 		},
 	}
 	status := CollectWorktreeStatus(context.Background(), r, "/wt/feature-login")
-	// On IsDirty error, dirty should be false (err != nil means the condition `err == nil && dirty` is false)
-	if status.Dirty {
-		t.Error("expected Dirty=false when IsDirty returns error")
+	if !status.Unknown {
+		t.Error("expected Unknown=true when IsDirty returns error")
+	}
+}
+
+func TestCollectWorktreeStatusUnknownOnAheadBehindError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so AheadBehind propagates ctx.Err()
+
+	r := &mockRunner{
+		run: func(_ ...string) (string, error) { return "", nil },
+		// IsDirty (status --porcelain) returns an error too on cancelled ctx, so
+		// returning a non-nil error for all runInDir calls is sufficient here.
+		runInDir: func(_ string, _ ...string) (string, error) {
+			return "", context.Canceled
+		},
+	}
+	status := CollectWorktreeStatus(ctx, r, "/wt/feature-login")
+	if !status.Unknown {
+		t.Error("expected Unknown=true when git queries return context error")
 	}
 }
 

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -9,6 +9,8 @@ import (
 // collecting results into a slice that preserves index order.
 // A concurrency value <= 0 is treated as "auto" (= n, i.e. unlimited).
 // ctx is passed to each fn invocation so callers can enforce per-item deadlines.
+// On cancellation, goroutines waiting for a semaphore slot exit early; their
+// result entries hold the zero value of T.
 func Collect[T any](ctx context.Context, n, concurrency int, fn func(ctx context.Context, i int) T) []T {
 	if n == 0 {
 		return nil

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -1,11 +1,15 @@
 package parallel
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 // Collect runs fn for each index [0, n) with bounded concurrency,
 // collecting results into a slice that preserves index order.
 // A concurrency value <= 0 is treated as "auto" (= n, i.e. unlimited).
-func Collect[T any](n, concurrency int, fn func(i int) T) []T {
+// ctx is passed to each fn invocation so callers can enforce per-item deadlines.
+func Collect[T any](ctx context.Context, n, concurrency int, fn func(ctx context.Context, i int) T) []T {
 	if n == 0 {
 		return nil
 	}
@@ -24,7 +28,7 @@ func Collect[T any](n, concurrency int, fn func(i int) T) []T {
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			results[idx] = fn(idx)
+			results[idx] = fn(ctx, idx)
 		}(i)
 	}
 	wg.Wait()

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -25,7 +25,11 @@ func Collect[T any](ctx context.Context, n, concurrency int, fn func(ctx context
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			sem <- struct{}{}
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
 			defer func() { <-sem }()
 
 			results[idx] = fn(ctx, idx)

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -1,6 +1,7 @@
 package parallel_test
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 
@@ -8,7 +9,7 @@ import (
 )
 
 func TestCollectPreservesOrder(t *testing.T) {
-	results := parallel.Collect(10, 4, func(i int) int {
+	results := parallel.Collect(context.Background(), 10, 4, func(_ context.Context, i int) int {
 		return i * 2
 	})
 
@@ -23,7 +24,7 @@ func TestCollectPreservesOrder(t *testing.T) {
 }
 
 func TestCollectZeroItems(t *testing.T) {
-	results := parallel.Collect(0, 8, func(i int) string {
+	results := parallel.Collect(context.Background(), 0, 8, func(_ context.Context, i int) string {
 		t.Fatal("fn should not be called for n=0")
 		return ""
 	})
@@ -35,7 +36,7 @@ func TestCollectZeroItems(t *testing.T) {
 
 func TestCollectAutoConcurrency(t *testing.T) {
 	// concurrency=0 must not deadlock; treat as n (auto).
-	results := parallel.Collect(5, 0, func(i int) int { return i })
+	results := parallel.Collect(context.Background(), 5, 0, func(_ context.Context, i int) int { return i })
 	if len(results) != 5 {
 		t.Fatalf("got %d results, want 5", len(results))
 	}
@@ -46,7 +47,7 @@ func TestCollectAutoConcurrency(t *testing.T) {
 	}
 
 	// negative concurrency also treated as auto.
-	results2 := parallel.Collect(3, -1, func(i int) int { return i * 10 })
+	results2 := parallel.Collect(context.Background(), 3, -1, func(_ context.Context, i int) int { return i * 10 })
 	if len(results2) != 3 {
 		t.Fatalf("got %d results, want 3", len(results2))
 	}
@@ -62,7 +63,7 @@ func TestCollectBoundsConcurrency(t *testing.T) {
 	var running atomic.Int32
 	var maxSeen atomic.Int32
 
-	parallel.Collect(20, maxConcurrency, func(i int) struct{} {
+	parallel.Collect(context.Background(), 20, maxConcurrency, func(_ context.Context, i int) struct{} {
 		cur := running.Add(1)
 		for {
 			old := maxSeen.Load()
@@ -77,4 +78,17 @@ func TestCollectBoundsConcurrency(t *testing.T) {
 	if maxSeen.Load() > maxConcurrency {
 		t.Errorf("max concurrent = %d, want <= %d", maxSeen.Load(), maxConcurrency)
 	}
+}
+
+type testCtxKey struct{}
+
+func TestCollectPassesCtx(t *testing.T) {
+	ctx := context.WithValue(context.Background(), testCtxKey{}, "marker")
+
+	parallel.Collect(ctx, 3, 3, func(itemCtx context.Context, _ int) struct{} {
+		if v, ok := itemCtx.Value(testCtxKey{}).(string); !ok || v != "marker" {
+			t.Error("ctx not propagated to fn")
+		}
+		return struct{}{}
+	})
 }

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/lugassawan/rimba/internal/parallel"
 )
@@ -91,4 +92,33 @@ func TestCollectPassesCtx(t *testing.T) {
 		}
 		return struct{}{}
 	})
+}
+
+func TestCollectCancelledContextDoesNotHang(t *testing.T) {
+	// Collect with concurrency=1 and a fn that blocks until the gate is opened.
+	// Cancel the context before opening the gate. Goroutines waiting on the
+	// full semaphore should return via ctx.Done() rather than blocking forever.
+	gate := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		parallel.Collect(ctx, 5, 1, func(_ context.Context, _ int) int {
+			<-gate // blocks until gate opens or ctx fires
+			return 1
+		})
+	}()
+
+	// Cancel the context — goroutines waiting on the full semaphore should exit.
+	cancel()
+	// Open the gate so any goroutine that already acquired the semaphore can finish.
+	close(gate)
+
+	select {
+	case <-done:
+		// expected: Collect returned promptly after cancellation
+	case <-time.After(2 * time.Second):
+		t.Error("Collect did not return promptly after context cancellation")
+	}
 }

--- a/internal/resolver/worktree_detail.go
+++ b/internal/resolver/worktree_detail.go
@@ -9,9 +9,9 @@ import (
 
 // WorktreeStatus holds the structured git status of a worktree.
 type WorktreeStatus struct {
-	Dirty   bool `json:"dirty"`
-	Ahead   int  `json:"ahead"`
-	Behind  int  `json:"behind"`
+	Dirty   bool `json:"dirty,omitempty"`
+	Ahead   int  `json:"ahead,omitempty"`
+	Behind  int  `json:"behind,omitempty"`
 	Unknown bool `json:"unknown,omitempty"` // set when git queries time out or fail (e.g. stalled NFS mount)
 }
 

--- a/internal/resolver/worktree_detail.go
+++ b/internal/resolver/worktree_detail.go
@@ -9,9 +9,10 @@ import (
 
 // WorktreeStatus holds the structured git status of a worktree.
 type WorktreeStatus struct {
-	Dirty  bool `json:"dirty"`
-	Ahead  int  `json:"ahead"`
-	Behind int  `json:"behind"`
+	Dirty   bool `json:"dirty"`
+	Ahead   int  `json:"ahead"`
+	Behind  int  `json:"behind"`
+	Unknown bool `json:"unknown,omitempty"` // set when git queries time out or fail (e.g. stalled NFS mount)
 }
 
 // WorktreeDetail holds the resolved view of a worktree with extracted task and type.
@@ -47,11 +48,16 @@ func NewWorktreeDetail(branch string, prefixes []string, path string, status Wor
 }
 
 // FormatStatus returns a human-readable status string.
+// - "unknown" when git queries could not complete (timeout, NFS stall, etc.)
 // - "[dirty]" when dirty
 // - "↑N" when ahead, "↓M" when behind
 // - "✓" when fully clean
 // Combines as needed, e.g. "[dirty] ↑2 ↓1"
 func FormatStatus(s WorktreeStatus) string {
+	if s.Unknown {
+		return "unknown"
+	}
+
 	var parts []string
 
 	if s.Dirty {

--- a/internal/resolver/worktree_detail_test.go
+++ b/internal/resolver/worktree_detail_test.go
@@ -52,6 +52,11 @@ func TestFormatStatus(t *testing.T) {
 			status: resolver.WorktreeStatus{Dirty: true, Ahead: 2, Behind: 1},
 			want:   "[dirty] ↑2 ↓1",
 		},
+		{
+			name:   "unknown",
+			status: resolver.WorktreeStatus{Unknown: true},
+			want:   "unknown",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Extend `parallel.Collect` to accept and thread `context.Context` through to each closure — callers can now enforce per-item deadlines without captured variables
- Add `git.WithItemTimeout(ctx)` helper: 10s const, mirrors the existing `prQueryTimeout` pattern
- Apply `WithItemTimeout` to the 5 git-query fan-out sites (`status_dashboard`, `mcp/tool_status`, `cmd/log`, `cmd/exec`, `list_worktrees`); the 2 long-running sites (`deps/manager`, `mcp/tool_sync`) explicitly pass ctx through without a cap
- Add `Unknown bool` to `WorktreeStatus`: a timed-out or errored worktree now renders as gray `"unknown"` instead of silently appearing clean (`✓`)
- Make `fsutil.DirSize` cancellable: runs `filepath.WalkDir` in a goroutine+select so a stuck `stat()` syscall (stalled NFS) can't block past the deadline
- Fix `AheadBehind` to propagate `ctx.Err()` while still swallowing "no upstream" errors — previously all errors were silently treated as (0,0,nil)

## Test Plan

- [x] Unit tests pass (`make test`) — 2104 tests, all pass
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2E tests pass (`make test-e2e`)
- [x] Coverage ≥ 97% (`make test-coverage`) — 97.3%
- [x] `TestWithItemTimeout*` — deadline set, parent cancellation propagates
- [x] `TestCollectPassesCtx` — ctx value survives to closure
- [x] `TestCollectWorktreeStatus*Unknown*` — IsDirty error and AheadBehind error both set Unknown=true
- [x] `TestDirSizeCancelledContext` — pre-cancelled ctx returns ctx.Err()
- [x] `TestStatusToolUnknownWorktree` (MCP) — stalled NFS runner yields Unknown=true, not counted as Dirty/Behind

## Issue

Closes #288