### PR TITLE
[fix] eliminate select race in checkUpdateHint (#301 regression) + test isolation

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -222,6 +222,14 @@ func TestExecute(t *testing.T) {
 		// cancelled when Execute returns (via defer stop()). Reset it so
 		// subsequent tests that call cmd.Context() get a live context.
 		rootCmd.SetContext(context.Background())
+		// Execute() makes cobra graft a default "help" command onto the global
+		// rootCmd; remove it so later tests that iterate rootCmd's children
+		// (e.g. TestExamplePresent) aren't polluted by execution order.
+		for _, c := range rootCmd.Commands() {
+			if c.Name() == "help" {
+				rootCmd.RemoveCommand(c)
+			}
+		}
 	})
 
 	if err := Execute(); err != nil {

--- a/cmd/update_hint.go
+++ b/cmd/update_hint.go
@@ -18,15 +18,17 @@ var newUpdater func(string) *updater.Updater = updater.New
 // Returns nil if the version is dev, the check fails, times out, or is up to date.
 // The check is cancelled when ctx is done or timeout elapses — whichever comes first.
 func checkUpdateHint(ctx context.Context, version string, timeout time.Duration) <-chan *updater.CheckResult {
-	ch := make(chan *updater.CheckResult, 1)
+	out := make(chan *updater.CheckResult, 1)
 
 	if updater.IsDevVersion(version) {
-		close(ch)
-		return ch
+		close(out)
+		return out
 	}
 
-	// Derive a timeout-scoped child so the HTTP request is actually cancelled
-	// when timeout elapses, not just when the caller stops waiting.
+	// Bound the check by timeout so the HTTP request is actually cancelled, not
+	// just abandoned. u.Check honours tctx, so the goroutine always terminates
+	// within timeout — no leak, and the result can never be lost to a racing
+	// cancellation (there is no select between "result" and "ctx done").
 	tctx, cancel := context.WithTimeout(ctx, timeout)
 
 	// Read newUpdater before spawning the goroutine: goroutine launch
@@ -37,26 +39,10 @@ func checkUpdateHint(ctx context.Context, version string, timeout time.Duration)
 		defer cancel()
 		result, err := u.Check(tctx)
 		if err != nil || result.UpToDate {
-			close(ch)
+			close(out)
 			return
 		}
-		ch <- result
-	}()
-
-	// Return a channel that resolves with the result or nil when tctx expires.
-	out := make(chan *updater.CheckResult, 1)
-	go func() {
-		defer cancel()
-		select {
-		case r, ok := <-ch:
-			if ok {
-				out <- r
-			} else {
-				close(out)
-			}
-		case <-tctx.Done():
-			close(out)
-		}
+		out <- result // buffered (cap 1) — never blocks
 	}()
 
 	return out

--- a/cmd/update_hint_test.go
+++ b/cmd/update_hint_test.go
@@ -152,6 +152,26 @@ func TestCollectHintValue(t *testing.T) {
 	}
 }
 
+func TestCheckUpdateHintNeverDropsResult(t *testing.T) {
+	// Regression guard for the #301 select race: a successfully-fetched, newer
+	// version must never be dropped. The race is scheduler-biased (reliably lost
+	// on linux CI, won on macOS), so this asserts the invariant over many runs.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(hdrContentType, mimeJSON)
+		_, _ = w.Write([]byte(`{"tag_name":"v99.0.0","assets":[
+			{"name":"rimba_99.0.0_linux_amd64.tar.gz","browser_download_url":"https://github.com/lugassawan/rimba/releases/download/v99.0.0/rimba_99.0.0_linux_amd64.tar.gz"},
+			{"name":"checksums.txt","browser_download_url":"https://github.com/lugassawan/rimba/releases/download/v99.0.0/checksums.txt"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	overrideNewUpdater(t, srv)
+
+	for i := range 500 {
+		if got := collectHint(checkUpdateHint(context.Background(), testVersionHint, 2*time.Second)); got == nil {
+			t.Fatalf("iteration %d: update hint dropped (nil result) for a newer version", i)
+		}
+	}
+}
+
 func TestCheckUpdateHintCancelledContext(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// A pre-cancelled context should cause the HTTP client to fail before


### PR DESCRIPTION
## Summary

- **Race fix**: collapse `checkUpdateHint` from two goroutines to one, eliminating the scheduler race introduced in #301. The original collector goroutine used `select { case r := <-ch: ... case <-tctx.Done(): close(out) }` — once the fetch goroutine sent its result and its `defer cancel()` fired, both cases were simultaneously ready and Go's pseudo-random selection dropped the valid result ~50% of the time on Linux CI (macOS always won the race). The fix writes to the buffered output channel directly from the fetch goroutine; there is no `select` to race.
- **Regression guard**: adds `TestCheckUpdateHintNeverDropsResult` (500 iterations) that fails on the old code and passes on the fix.
- **Test isolation**: `Execute()` triggers cobra's `InitDefaultHelpCmd()`, permanently grafting a `help` subcommand onto the global `rootCmd`. `TestExecute` now removes it in `t.Cleanup` so `TestExamplePresent` (which iterates `rootCmd.Commands()`) is not polluted by execution order — was failing on ~80% of `-shuffle` seeds.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)
- [x] Race detector clean: `GOFLAGS=-mod=mod make test-race` — all pass
- [x] Shuffle isolation: `go test ./cmd/ -mod=mod -shuffle=on -count=5` — 2290 passed, 0 failed (previously ~80% of seeds failed `TestExamplePresent`)
- [x] Coverage: 97.2% ≥ 97% threshold

## Issue

Issue: N/A — regression from #301; fixes red coverage CI on main