### PR TITLE
[perf] Fix IsSquashMerged object leak: replace commit-tree with patch-id (#300)

### DIFF
--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -1,8 +1,8 @@
 package git
 
 import (
+	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,28 +15,23 @@ import (
 
 const internalGitInvariantHint = "report this — git output unexpectedly malformed"
 
-// errEmptyDiff is returned by ComputePatchIDs when the input diff is empty.
-var errEmptyDiff = errors.New("empty diff")
-
-// ComputePatchIDs computes patch-ids from a diff string by piping it to
-// git patch-id --stable. Defined as a variable so tests can override it
-// with deterministic results without executing a real git subprocess.
-// Returns the set of patch-id hex strings (first field per output line).
-//
-// Not safe for concurrent modification — tests must override and restore
-// sequentially via defer:
-//
-//	defer func(orig ...) { ComputePatchIDs = orig }(ComputePatchIDs)
-//	ComputePatchIDs = func(...) { ... }
+// ComputePatchIDs pipes diff into git patch-id --stable and returns the set of
+// patch-id hex strings. Exposed as a variable so tests can stub it without a
+// real git subprocess. Not safe for concurrent modification.
 var ComputePatchIDs = func(ctx context.Context, diff string) (map[string]bool, error) {
 	if diff == "" {
-		return nil, errEmptyDiff
+		return map[string]bool{}, nil
 	}
 	cmd := exec.CommandContext(ctx, "git", "patch-id", "--stable")
 	cmd.Env = stableGitEnv(os.Environ())
 	cmd.Stdin = strings.NewReader(diff)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return nil, fmt.Errorf("git patch-id --stable: %s: %w", msg, err)
+		}
 		return nil, fmt.Errorf("git patch-id --stable: %w", err)
 	}
 
@@ -136,11 +131,8 @@ func AheadBehind(ctx context.Context, r Runner, dir string) (ahead, behind int, 
 	return ahead, behind, nil
 }
 
-// IsSquashMerged checks whether a branch's content has been squash-merged into mergeRef.
-// It computes a patch-id for the branch diff and checks whether any commit in
-// mergeRef (since the merge-base) produces the same patch-id.
-// Unlike the previous commit-tree + cherry approach, this technique creates no
-// loose objects in the git store.
+// IsSquashMerged reports whether branch's diff patch-id matches any commit in
+// mergeRef since their common merge-base, indicating a squash merge.
 func IsSquashMerged(ctx context.Context, r Runner, mergeRef, branch string) (bool, error) {
 	mergeBase, err := MergeBase(ctx, r, mergeRef, branch)
 	if err != nil {
@@ -152,37 +144,28 @@ func IsSquashMerged(ctx context.Context, r Runner, mergeRef, branch string) (boo
 		return false, err
 	}
 
-	// Empty branch (merge-base == branch tip) — nothing to squash-merge.
-	if mergeBase == tip {
+	if mergeBase == tip { // empty branch — nothing squash-merged
 		return false, nil
 	}
 
-	// Branch patch-id: diff from merge-base to branch tip.
-	branchDiff, err := r.Run(ctx, "diff", mergeBase, branch)
+	branchDiff, err := r.Run(ctx, cmdDiff, mergeBase, branch)
 	if err != nil {
 		return false, err
 	}
 	branchPIDs, err := ComputePatchIDs(ctx, branchDiff)
 	if err != nil {
-		if errors.Is(err, errEmptyDiff) {
-			return false, nil // empty diff — not squash-merged
-		}
 		return false, err
 	}
 	if len(branchPIDs) == 0 {
 		return false, nil
 	}
 
-	// MergeRef patch-ids: diffs for each non-merge commit since merge-base.
-	mergeRefDiffs, err := r.Run(ctx, "log", "-p", "--no-merges", mergeBase+".."+mergeRef)
+	mergeRefDiffs, err := r.Run(ctx, cmdLog, "-p", "--no-merges", mergeBase+".."+mergeRef)
 	if err != nil {
 		return false, err
 	}
 	mergeRefPIDs, err := ComputePatchIDs(ctx, mergeRefDiffs)
 	if err != nil {
-		if errors.Is(err, errEmptyDiff) {
-			return false, nil // no commits in mergeRef range
-		}
 		return false, err
 	}
 
@@ -223,7 +206,7 @@ func LastCommitTime(ctx context.Context, r Runner, branch string) (time.Time, er
 
 // LastCommitInfo returns the time and subject of the last commit on the given branch.
 func LastCommitInfo(ctx context.Context, r Runner, branch string) (time.Time, string, error) {
-	out, err := r.Run(ctx, "log", "-1", "--format=%ct\t%s", branch)
+	out, err := r.Run(ctx, cmdLog, "-1", "--format=%ct\t%s", branch)
 	if err != nil {
 		return time.Time{}, "", errhint.WithFix(
 			fmt.Errorf("last commit info for %s: %w", branch, err),

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -2,7 +2,10 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -11,6 +14,45 @@ import (
 )
 
 const internalGitInvariantHint = "report this — git output unexpectedly malformed"
+
+// errEmptyDiff is returned by ComputePatchIDs when the input diff is empty.
+var errEmptyDiff = errors.New("empty diff")
+
+// ComputePatchIDs computes patch-ids from a diff string by piping it to
+// git patch-id --stable. Defined as a variable so tests can override it
+// with deterministic results without executing a real git subprocess.
+// Returns the set of patch-id hex strings (first field per output line).
+//
+// Not safe for concurrent modification — tests must override and restore
+// sequentially via defer:
+//
+//	defer func(orig ...) { ComputePatchIDs = orig }(ComputePatchIDs)
+//	ComputePatchIDs = func(...) { ... }
+var ComputePatchIDs = func(ctx context.Context, diff string) (map[string]bool, error) {
+	if diff == "" {
+		return nil, errEmptyDiff
+	}
+	cmd := exec.CommandContext(ctx, "git", "patch-id", "--stable")
+	cmd.Env = stableGitEnv(os.Environ())
+	cmd.Stdin = strings.NewReader(diff)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git patch-id --stable: %w", err)
+	}
+
+	ids := make(map[string]bool)
+	for line := range strings.SplitSeq(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		pid, _, _ := strings.Cut(line, " ")
+		if pid != "" {
+			ids[pid] = true
+		}
+	}
+	return ids, nil
+}
 
 // BranchExists checks whether a local branch exists.
 func BranchExists(ctx context.Context, r Runner, branch string) bool {
@@ -95,32 +137,61 @@ func AheadBehind(ctx context.Context, r Runner, dir string) (ahead, behind int, 
 }
 
 // IsSquashMerged checks whether a branch's content has been squash-merged into mergeRef.
-// It uses the commit-tree + cherry technique: create a synthetic commit with the
-// branch's tree on the merge-base, then check if that content is already in mergeRef.
-// Note: each call creates an unreferenced commit object in the git store; these are
-// cleaned up automatically by git gc.
+// It computes a patch-id for the branch diff and checks whether any commit in
+// mergeRef (since the merge-base) produces the same patch-id.
+// Unlike the previous commit-tree + cherry approach, this technique creates no
+// loose objects in the git store.
 func IsSquashMerged(ctx context.Context, r Runner, mergeRef, branch string) (bool, error) {
 	mergeBase, err := MergeBase(ctx, r, mergeRef, branch)
 	if err != nil {
 		return false, err
 	}
 
-	tree, err := r.Run(ctx, cmdRevParse, branch+treeSuffix)
+	tip, err := r.Run(ctx, cmdRevParse, "--verify", branch)
 	if err != nil {
 		return false, err
 	}
 
-	tempCommit, err := r.Run(ctx, cmdCommitTree, tree, "-p", mergeBase, "-m", "temp")
+	// Empty branch (merge-base == branch tip) — nothing to squash-merge.
+	if mergeBase == tip {
+		return false, nil
+	}
+
+	// Branch patch-id: diff from merge-base to branch tip.
+	branchDiff, err := r.Run(ctx, "diff", mergeBase, branch)
 	if err != nil {
 		return false, err
 	}
+	branchPIDs, err := ComputePatchIDs(ctx, branchDiff)
+	if err != nil {
+		if errors.Is(err, errEmptyDiff) {
+			return false, nil // empty diff — not squash-merged
+		}
+		return false, err
+	}
+	if len(branchPIDs) == 0 {
+		return false, nil
+	}
 
-	out, err := r.Run(ctx, cmdCherry, mergeRef, tempCommit)
+	// MergeRef patch-ids: diffs for each non-merge commit since merge-base.
+	mergeRefDiffs, err := r.Run(ctx, "log", "-p", "--no-merges", mergeBase+".."+mergeRef)
 	if err != nil {
 		return false, err
 	}
+	mergeRefPIDs, err := ComputePatchIDs(ctx, mergeRefDiffs)
+	if err != nil {
+		if errors.Is(err, errEmptyDiff) {
+			return false, nil // no commits in mergeRef range
+		}
+		return false, err
+	}
 
-	return strings.HasPrefix(out, cherryMerged), nil
+	for pid := range mergeRefPIDs {
+		if branchPIDs[pid] {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // MergedBranches returns branches that have been merged into the given branch.

--- a/internal/git/branch.go
+++ b/internal/git/branch.go
@@ -144,11 +144,11 @@ func IsSquashMerged(ctx context.Context, r Runner, mergeRef, branch string) (boo
 		return false, err
 	}
 
-	if mergeBase == tip { // empty branch — nothing squash-merged
+	if strings.TrimSpace(mergeBase) == strings.TrimSpace(tip) { // empty branch — nothing squash-merged
 		return false, nil
 	}
 
-	branchDiff, err := r.Run(ctx, cmdDiff, mergeBase, branch)
+	branchDiff, err := r.Run(ctx, CmdDiff, mergeBase, branch)
 	if err != nil {
 		return false, err
 	}
@@ -160,7 +160,7 @@ func IsSquashMerged(ctx context.Context, r Runner, mergeRef, branch string) (boo
 		return false, nil
 	}
 
-	mergeRefDiffs, err := r.Run(ctx, cmdLog, "-p", "--no-merges", mergeBase+".."+mergeRef)
+	mergeRefDiffs, err := r.Run(ctx, CmdLog, "-p", "--no-merges", mergeBase+".."+mergeRef)
 	if err != nil {
 		return false, err
 	}
@@ -206,7 +206,7 @@ func LastCommitTime(ctx context.Context, r Runner, branch string) (time.Time, er
 
 // LastCommitInfo returns the time and subject of the last commit on the given branch.
 func LastCommitInfo(ctx context.Context, r Runner, branch string) (time.Time, string, error) {
-	out, err := r.Run(ctx, cmdLog, "-1", "--format=%ct\t%s", branch)
+	out, err := r.Run(ctx, CmdLog, "-1", "--format=%ct\t%s", branch)
 	if err != nil {
 		return time.Time{}, "", errhint.WithFix(
 			fmt.Errorf("last commit info for %s: %w", branch, err),

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -8,7 +8,7 @@ import (
 // DiffNameOnly returns files changed between base and branch using three-dot diff.
 // The three-dot notation (base...branch) shows changes on branch since it diverged from base.
 func DiffNameOnly(ctx context.Context, r Runner, base, branch string) ([]string, error) {
-	out, err := r.Run(ctx, "diff", "--name-only", base+"..."+branch)
+	out, err := r.Run(ctx, cmdDiff, "--name-only", base+"..."+branch)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -8,7 +8,7 @@ import (
 // DiffNameOnly returns files changed between base and branch using three-dot diff.
 // The three-dot notation (base...branch) shows changes on branch since it diverged from base.
 func DiffNameOnly(ctx context.Context, r Runner, base, branch string) ([]string, error) {
-	out, err := r.Run(ctx, cmdDiff, "--name-only", base+"..."+branch)
+	out, err := r.Run(ctx, CmdDiff, "--name-only", base+"..."+branch)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/git/mock_runner_test.go
+++ b/internal/git/mock_runner_test.go
@@ -27,8 +27,8 @@ const (
 	errBranchWantFmt = "branch = %q, want %q"
 	flagGitCommonDir = "--git-common-dir"
 	flagShowToplevel = "--show-toplevel"
-	fakeTree         = "tree123"
-	fakeTempCommit   = "temp456"
+	fakeTip          = "tip789"
+	fakeDiff         = "some diff"
 )
 
 // mockRunner implements Runner with configurable closures for testing.
@@ -636,6 +636,13 @@ func TestListWorktreesBareEntry(t *testing.T) {
 }
 
 func TestIsSquashMerged(t *testing.T) {
+	defer func(orig func(context.Context, string) (map[string]bool, error)) {
+		ComputePatchIDs = orig
+	}(ComputePatchIDs)
+	ComputePatchIDs = func(_ context.Context, _ string) (map[string]bool, error) {
+		return map[string]bool{fakeSHA: true}, nil
+	}
+
 	step := 0
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
@@ -643,12 +650,12 @@ func TestIsSquashMerged(t *testing.T) {
 			switch step {
 			case 1: // merge-base
 				return fakeSHA, nil
-			case 2: // rev-parse branch^{tree}
-				return fakeTree, nil
-			case 3: // commit-tree
-				return fakeTempCommit, nil
-			case 4: // cherry
-				return "- abc789", nil
+			case 2: // rev-parse --verify branch
+				return fakeTip, nil
+			case 3: // diff
+				return "fake diff", nil
+			case 4: // log -p --no-merges
+				return "fake log", nil
 			}
 			return "", errors.New("unexpected call")
 		},
@@ -664,19 +671,31 @@ func TestIsSquashMerged(t *testing.T) {
 }
 
 func TestIsSquashMergedNotMerged(t *testing.T) {
+	callCount := 0
+	defer func(orig func(context.Context, string) (map[string]bool, error)) {
+		ComputePatchIDs = orig
+	}(ComputePatchIDs)
+	ComputePatchIDs = func(_ context.Context, _ string) (map[string]bool, error) {
+		callCount++
+		if callCount == 1 {
+			return map[string]bool{"branch-pid": true}, nil
+		}
+		return map[string]bool{"merge-ref-pid": true}, nil
+	}
+
 	step := 0
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			step++
 			switch step {
-			case 1:
+			case 1: // merge-base
 				return fakeSHA, nil
-			case 2:
-				return fakeTree, nil
-			case 3:
-				return fakeTempCommit, nil
-			case 4:
-				return "+ abc789", nil
+			case 2: // rev-parse --verify branch
+				return fakeTip, nil
+			case 3: // diff
+				return "fake diff", nil
+			case 4: // log -p --no-merges
+				return "fake log", nil
 			}
 			return "", errors.New("unexpected call")
 		},
@@ -722,41 +741,46 @@ func TestIsSquashMergedRevParseError(t *testing.T) {
 	}
 }
 
-func TestIsSquashMergedCommitTreeError(t *testing.T) {
+func TestIsSquashMergedDiffError(t *testing.T) {
 	step := 0
 	r := &mockRunner{
 		run: func(_ ...string) (string, error) {
 			step++
 			switch step {
 			case 1:
-				return fakeSHA, nil
+				return fakeSHA, nil // merge-base
 			case 2:
-				return fakeTree, nil
+				return fakeTip, nil // rev-parse
 			}
-			return "", errors.New("commit-tree failed")
+			return "", errors.New("diff failed")
 		},
 	}
 
 	_, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
 	if err == nil {
-		t.Fatal("expected error from commit-tree failure")
+		t.Fatal("expected error from diff failure")
 	}
 }
 
-func TestIsSquashMergedEmptyCherry(t *testing.T) {
+func TestIsSquashMergedEmptyBranchPatchID(t *testing.T) {
+	defer func(orig func(context.Context, string) (map[string]bool, error)) {
+		ComputePatchIDs = orig
+	}(ComputePatchIDs)
+	ComputePatchIDs = func(_ context.Context, _ string) (map[string]bool, error) {
+		return map[string]bool{}, nil
+	}
+
 	step := 0
 	r := &mockRunner{
 		run: func(_ ...string) (string, error) {
 			step++
 			switch step {
 			case 1:
-				return fakeSHA, nil
+				return fakeSHA, nil // merge-base
 			case 2:
-				return fakeTree, nil
+				return fakeTip, nil // rev-parse
 			case 3:
-				return fakeTempCommit, nil
-			case 4:
-				return "", nil
+				return fakeDiff, nil
 			}
 			return "", errors.New("unexpected call")
 		},
@@ -767,30 +791,91 @@ func TestIsSquashMergedEmptyCherry(t *testing.T) {
 		t.Fatalf("IsSquashMerged: %v", err)
 	}
 	if merged {
-		t.Error("expected empty cherry output to not indicate squash-merge")
+		t.Error("expected empty branch patch-id to not indicate squash-merge")
 	}
 }
 
-func TestIsSquashMergedCherryError(t *testing.T) {
+func TestIsSquashMergedLogError(t *testing.T) {
+	defer func(orig func(context.Context, string) (map[string]bool, error)) {
+		ComputePatchIDs = orig
+	}(ComputePatchIDs)
+	ComputePatchIDs = func(_ context.Context, _ string) (map[string]bool, error) {
+		return map[string]bool{fakeSHA: true}, nil
+	}
+
 	step := 0
 	r := &mockRunner{
 		run: func(_ ...string) (string, error) {
 			step++
 			switch step {
 			case 1:
-				return fakeSHA, nil
+				return fakeSHA, nil // merge-base
 			case 2:
-				return fakeTree, nil
+				return fakeTip, nil // rev-parse
 			case 3:
-				return fakeTempCommit, nil
+				return fakeDiff, nil
 			}
-			return "", errors.New("cherry failed")
+			return "", errors.New("log failed")
 		},
 	}
 
 	_, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
 	if err == nil {
-		t.Fatal("expected error from cherry failure")
+		t.Fatal("expected error from log failure")
+	}
+}
+
+func TestIsSquashMergedPatchIDError(t *testing.T) {
+	defer func(orig func(context.Context, string) (map[string]bool, error)) {
+		ComputePatchIDs = orig
+	}(ComputePatchIDs)
+	ComputePatchIDs = func(_ context.Context, _ string) (map[string]bool, error) {
+		return nil, errors.New("patch-id failed")
+	}
+
+	step := 0
+	r := &mockRunner{
+		run: func(_ ...string) (string, error) {
+			step++
+			switch step {
+			case 1:
+				return fakeSHA, nil // merge-base
+			case 2:
+				return fakeTip, nil // rev-parse
+			case 3:
+				return fakeDiff, nil
+			}
+			return "", errors.New("unexpected call")
+		},
+	}
+
+	_, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
+	if err == nil {
+		t.Fatal("expected error from patch-id failure")
+	}
+}
+
+func TestIsSquashMergedMergeBaseEqualsTip(t *testing.T) {
+	step := 0
+	r := &mockRunner{
+		run: func(_ ...string) (string, error) {
+			step++
+			switch step {
+			case 1:
+				return fakeSHA, nil // merge-base
+			case 2:
+				return fakeSHA, nil // rev-parse (same SHA = empty branch)
+			}
+			return "", errors.New("unexpected call")
+		},
+	}
+
+	merged, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
+	if err != nil {
+		t.Fatalf("IsSquashMerged: %v", err)
+	}
+	if merged {
+		t.Error("expected empty branch (merge-base == tip) to not indicate squash-merge")
 	}
 }
 

--- a/internal/git/mock_runner_test.go
+++ b/internal/git/mock_runner_test.go
@@ -29,6 +29,7 @@ const (
 	flagShowToplevel = "--show-toplevel"
 	fakeTip          = "tip789"
 	fakeDiff         = "some diff"
+	fakeLog          = "fake log"
 )
 
 // mockRunner implements Runner with configurable closures for testing.
@@ -643,21 +644,19 @@ func TestIsSquashMerged(t *testing.T) {
 		return map[string]bool{fakeSHA: true}, nil
 	}
 
-	step := 0
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
-			step++
-			switch step {
-			case 1: // merge-base
+			switch args[0] {
+			case cmdMergeBase:
 				return fakeSHA, nil
-			case 2: // rev-parse --verify branch
+			case cmdRevParse:
 				return fakeTip, nil
-			case 3: // diff
+			case cmdDiff:
 				return "fake diff", nil
-			case 4: // log -p --no-merges
-				return "fake log", nil
+			case cmdLog:
+				return fakeLog, nil
 			}
-			return "", errors.New("unexpected call")
+			return "", errors.New("unexpected call: " + args[0])
 		},
 	}
 
@@ -683,21 +682,19 @@ func TestIsSquashMergedNotMerged(t *testing.T) {
 		return map[string]bool{"merge-ref-pid": true}, nil
 	}
 
-	step := 0
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
-			step++
-			switch step {
-			case 1: // merge-base
+			switch args[0] {
+			case cmdMergeBase:
 				return fakeSHA, nil
-			case 2: // rev-parse --verify branch
+			case cmdRevParse:
 				return fakeTip, nil
-			case 3: // diff
+			case cmdDiff:
 				return "fake diff", nil
-			case 4: // log -p --no-merges
-				return "fake log", nil
+			case cmdLog:
+				return fakeLog, nil
 			}
-			return "", errors.New("unexpected call")
+			return "", errors.New("unexpected call: " + args[0])
 		},
 	}
 
@@ -724,11 +721,9 @@ func TestIsSquashMergedMergeBaseError(t *testing.T) {
 }
 
 func TestIsSquashMergedRevParseError(t *testing.T) {
-	step := 0
 	r := &mockRunner{
-		run: func(_ ...string) (string, error) {
-			step++
-			if step == 1 {
+		run: func(args ...string) (string, error) {
+			if args[0] == cmdMergeBase {
 				return fakeSHA, nil
 			}
 			return "", errors.New("rev-parse failed")
@@ -742,15 +737,13 @@ func TestIsSquashMergedRevParseError(t *testing.T) {
 }
 
 func TestIsSquashMergedDiffError(t *testing.T) {
-	step := 0
 	r := &mockRunner{
-		run: func(_ ...string) (string, error) {
-			step++
-			switch step {
-			case 1:
-				return fakeSHA, nil // merge-base
-			case 2:
-				return fakeTip, nil // rev-parse
+		run: func(args ...string) (string, error) {
+			switch args[0] {
+			case cmdMergeBase:
+				return fakeSHA, nil
+			case cmdRevParse:
+				return fakeTip, nil
 			}
 			return "", errors.New("diff failed")
 		},
@@ -770,19 +763,17 @@ func TestIsSquashMergedEmptyBranchPatchID(t *testing.T) {
 		return map[string]bool{}, nil
 	}
 
-	step := 0
 	r := &mockRunner{
-		run: func(_ ...string) (string, error) {
-			step++
-			switch step {
-			case 1:
-				return fakeSHA, nil // merge-base
-			case 2:
-				return fakeTip, nil // rev-parse
-			case 3:
+		run: func(args ...string) (string, error) {
+			switch args[0] {
+			case cmdMergeBase:
+				return fakeSHA, nil
+			case cmdRevParse:
+				return fakeTip, nil
+			case cmdDiff:
 				return fakeDiff, nil
 			}
-			return "", errors.New("unexpected call")
+			return "", errors.New("unexpected call: " + args[0])
 		},
 	}
 
@@ -803,16 +794,14 @@ func TestIsSquashMergedLogError(t *testing.T) {
 		return map[string]bool{fakeSHA: true}, nil
 	}
 
-	step := 0
 	r := &mockRunner{
-		run: func(_ ...string) (string, error) {
-			step++
-			switch step {
-			case 1:
-				return fakeSHA, nil // merge-base
-			case 2:
-				return fakeTip, nil // rev-parse
-			case 3:
+		run: func(args ...string) (string, error) {
+			switch args[0] {
+			case cmdMergeBase:
+				return fakeSHA, nil
+			case cmdRevParse:
+				return fakeTip, nil
+			case cmdDiff:
 				return fakeDiff, nil
 			}
 			return "", errors.New("log failed")
@@ -833,19 +822,17 @@ func TestIsSquashMergedPatchIDError(t *testing.T) {
 		return nil, errors.New("patch-id failed")
 	}
 
-	step := 0
 	r := &mockRunner{
-		run: func(_ ...string) (string, error) {
-			step++
-			switch step {
-			case 1:
-				return fakeSHA, nil // merge-base
-			case 2:
-				return fakeTip, nil // rev-parse
-			case 3:
+		run: func(args ...string) (string, error) {
+			switch args[0] {
+			case cmdMergeBase:
+				return fakeSHA, nil
+			case cmdRevParse:
+				return fakeTip, nil
+			case cmdDiff:
 				return fakeDiff, nil
 			}
-			return "", errors.New("unexpected call")
+			return "", errors.New("unexpected call: " + args[0])
 		},
 	}
 
@@ -855,18 +842,51 @@ func TestIsSquashMergedPatchIDError(t *testing.T) {
 	}
 }
 
-func TestIsSquashMergedMergeBaseEqualsTip(t *testing.T) {
-	step := 0
+func TestIsSquashMergedPatchIDErrorOnMergeRef(t *testing.T) {
+	callCount := 0
+	defer func(orig func(context.Context, string) (map[string]bool, error)) {
+		ComputePatchIDs = orig
+	}(ComputePatchIDs)
+	ComputePatchIDs = func(_ context.Context, _ string) (map[string]bool, error) {
+		callCount++
+		if callCount == 1 {
+			return map[string]bool{fakeSHA: true}, nil
+		}
+		return nil, errors.New("patch-id failed on mergeRef")
+	}
+
 	r := &mockRunner{
-		run: func(_ ...string) (string, error) {
-			step++
-			switch step {
-			case 1:
-				return fakeSHA, nil // merge-base
-			case 2:
-				return fakeSHA, nil // rev-parse (same SHA = empty branch)
+		run: func(args ...string) (string, error) {
+			switch args[0] {
+			case cmdMergeBase:
+				return fakeSHA, nil
+			case cmdRevParse:
+				return fakeTip, nil
+			case cmdDiff:
+				return fakeDiff, nil
+			case cmdLog:
+				return fakeLog, nil
 			}
-			return "", errors.New("unexpected call")
+			return "", errors.New("unexpected call: " + args[0])
+		},
+	}
+
+	_, err := IsSquashMerged(context.Background(), r, branchMain, branchFeature)
+	if err == nil {
+		t.Fatal("expected error from patch-id failure on mergeRef diffs")
+	}
+}
+
+func TestIsSquashMergedMergeBaseEqualsTip(t *testing.T) {
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch args[0] {
+			case cmdMergeBase:
+				return fakeSHA, nil
+			case cmdRevParse:
+				return fakeSHA, nil // same SHA = empty branch
+			}
+			return "", errors.New("unexpected call: " + args[0])
 		},
 	}
 

--- a/internal/git/mock_runner_test.go
+++ b/internal/git/mock_runner_test.go
@@ -647,13 +647,13 @@ func TestIsSquashMerged(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			switch args[0] {
-			case cmdMergeBase:
+			case CmdMergeBase:
 				return fakeSHA, nil
 			case cmdRevParse:
 				return fakeTip, nil
-			case cmdDiff:
+			case CmdDiff:
 				return "fake diff", nil
-			case cmdLog:
+			case CmdLog:
 				return fakeLog, nil
 			}
 			return "", errors.New("unexpected call: " + args[0])
@@ -670,28 +670,26 @@ func TestIsSquashMerged(t *testing.T) {
 }
 
 func TestIsSquashMergedNotMerged(t *testing.T) {
-	callCount := 0
 	defer func(orig func(context.Context, string) (map[string]bool, error)) {
 		ComputePatchIDs = orig
 	}(ComputePatchIDs)
-	ComputePatchIDs = func(_ context.Context, _ string) (map[string]bool, error) {
-		callCount++
-		if callCount == 1 {
-			return map[string]bool{"branch-pid": true}, nil
+	ComputePatchIDs = func(_ context.Context, diff string) (map[string]bool, error) {
+		if diff == fakeLog {
+			return map[string]bool{"merge-ref-pid": true}, nil
 		}
-		return map[string]bool{"merge-ref-pid": true}, nil
+		return map[string]bool{"branch-pid": true}, nil
 	}
 
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			switch args[0] {
-			case cmdMergeBase:
+			case CmdMergeBase:
 				return fakeSHA, nil
 			case cmdRevParse:
 				return fakeTip, nil
-			case cmdDiff:
+			case CmdDiff:
 				return "fake diff", nil
-			case cmdLog:
+			case CmdLog:
 				return fakeLog, nil
 			}
 			return "", errors.New("unexpected call: " + args[0])
@@ -723,7 +721,7 @@ func TestIsSquashMergedMergeBaseError(t *testing.T) {
 func TestIsSquashMergedRevParseError(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
-			if args[0] == cmdMergeBase {
+			if args[0] == CmdMergeBase {
 				return fakeSHA, nil
 			}
 			return "", errors.New("rev-parse failed")
@@ -740,7 +738,7 @@ func TestIsSquashMergedDiffError(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			switch args[0] {
-			case cmdMergeBase:
+			case CmdMergeBase:
 				return fakeSHA, nil
 			case cmdRevParse:
 				return fakeTip, nil
@@ -766,11 +764,11 @@ func TestIsSquashMergedEmptyBranchPatchID(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			switch args[0] {
-			case cmdMergeBase:
+			case CmdMergeBase:
 				return fakeSHA, nil
 			case cmdRevParse:
 				return fakeTip, nil
-			case cmdDiff:
+			case CmdDiff:
 				return fakeDiff, nil
 			}
 			return "", errors.New("unexpected call: " + args[0])
@@ -797,11 +795,11 @@ func TestIsSquashMergedLogError(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			switch args[0] {
-			case cmdMergeBase:
+			case CmdMergeBase:
 				return fakeSHA, nil
 			case cmdRevParse:
 				return fakeTip, nil
-			case cmdDiff:
+			case CmdDiff:
 				return fakeDiff, nil
 			}
 			return "", errors.New("log failed")
@@ -825,11 +823,11 @@ func TestIsSquashMergedPatchIDError(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			switch args[0] {
-			case cmdMergeBase:
+			case CmdMergeBase:
 				return fakeSHA, nil
 			case cmdRevParse:
 				return fakeTip, nil
-			case cmdDiff:
+			case CmdDiff:
 				return fakeDiff, nil
 			}
 			return "", errors.New("unexpected call: " + args[0])
@@ -843,28 +841,26 @@ func TestIsSquashMergedPatchIDError(t *testing.T) {
 }
 
 func TestIsSquashMergedPatchIDErrorOnMergeRef(t *testing.T) {
-	callCount := 0
 	defer func(orig func(context.Context, string) (map[string]bool, error)) {
 		ComputePatchIDs = orig
 	}(ComputePatchIDs)
-	ComputePatchIDs = func(_ context.Context, _ string) (map[string]bool, error) {
-		callCount++
-		if callCount == 1 {
-			return map[string]bool{fakeSHA: true}, nil
+	ComputePatchIDs = func(_ context.Context, diff string) (map[string]bool, error) {
+		if diff == fakeLog {
+			return nil, errors.New("patch-id failed on mergeRef")
 		}
-		return nil, errors.New("patch-id failed on mergeRef")
+		return map[string]bool{fakeSHA: true}, nil
 	}
 
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			switch args[0] {
-			case cmdMergeBase:
+			case CmdMergeBase:
 				return fakeSHA, nil
 			case cmdRevParse:
 				return fakeTip, nil
-			case cmdDiff:
+			case CmdDiff:
 				return fakeDiff, nil
-			case cmdLog:
+			case CmdLog:
 				return fakeLog, nil
 			}
 			return "", errors.New("unexpected call: " + args[0])
@@ -881,7 +877,7 @@ func TestIsSquashMergedMergeBaseEqualsTip(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			switch args[0] {
-			case cmdMergeBase:
+			case CmdMergeBase:
 				return fakeSHA, nil
 			case cmdRevParse:
 				return fakeSHA, nil // same SHA = empty branch

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -17,9 +17,9 @@ const (
 	cmdRevParse     = "rev-parse"
 	flagVerify      = "--verify"
 	cmdConfig       = "config"
-	cmdMergeBase    = "merge-base"
-	cmdDiff         = "diff"
-	cmdLog          = "log"
+	CmdMergeBase    = "merge-base"
+	CmdDiff         = "diff"
+	CmdLog          = "log"
 )
 
 // RepoRoot returns the absolute path to the repository root.

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -16,11 +16,7 @@ const (
 	refsHeadsPrefix = "refs/heads/"
 	cmdRevParse     = "rev-parse"
 	flagVerify      = "--verify"
-	cmdCommitTree   = "commit-tree"
-	cmdCherry       = "cherry"
 	cmdConfig       = "config"
-	treeSuffix      = "^{tree}"
-	cherryMerged    = "- "
 )
 
 // RepoRoot returns the absolute path to the repository root.

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -17,6 +17,9 @@ const (
 	cmdRevParse     = "rev-parse"
 	flagVerify      = "--verify"
 	cmdConfig       = "config"
+	cmdMergeBase    = "merge-base"
+	cmdDiff         = "diff"
+	cmdLog          = "log"
 )
 
 // RepoRoot returns the absolute path to the repository root.

--- a/internal/git/sync.go
+++ b/internal/git/sync.go
@@ -34,13 +34,13 @@ func AbortRebase(r Runner, dir string) error {
 
 // MergeBase returns the merge-base commit of two refs.
 func MergeBase(ctx context.Context, r Runner, ref1, ref2 string) (string, error) {
-	return r.Run(ctx, "merge-base", ref1, ref2)
+	return r.Run(ctx, cmdMergeBase, ref1, ref2)
 }
 
 // IsMergeBaseAncestor checks if ancestor is an ancestor of descendant
 // using `git merge-base --is-ancestor`.
 func IsMergeBaseAncestor(ctx context.Context, r Runner, ancestor, descendant string) bool {
-	_, err := r.Run(ctx, "merge-base", "--is-ancestor", ancestor, descendant)
+	_, err := r.Run(ctx, cmdMergeBase, "--is-ancestor", ancestor, descendant)
 	return err == nil
 }
 

--- a/internal/git/sync.go
+++ b/internal/git/sync.go
@@ -34,13 +34,13 @@ func AbortRebase(r Runner, dir string) error {
 
 // MergeBase returns the merge-base commit of two refs.
 func MergeBase(ctx context.Context, r Runner, ref1, ref2 string) (string, error) {
-	return r.Run(ctx, cmdMergeBase, ref1, ref2)
+	return r.Run(ctx, CmdMergeBase, ref1, ref2)
 }
 
 // IsMergeBaseAncestor checks if ancestor is an ancestor of descendant
 // using `git merge-base --is-ancestor`.
 func IsMergeBaseAncestor(ctx context.Context, r Runner, ancestor, descendant string) bool {
-	_, err := r.Run(ctx, cmdMergeBase, "--is-ancestor", ancestor, descendant)
+	_, err := r.Run(ctx, CmdMergeBase, "--is-ancestor", ancestor, descendant)
 	return err == nil
 }
 

--- a/internal/git/sync_test.go
+++ b/internal/git/sync_test.go
@@ -134,7 +134,7 @@ func TestAbortRebase(t *testing.T) {
 func TestMergeBase(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
-			if len(args) == 3 && args[0] == cmdMergeBase {
+			if len(args) == 3 && args[0] == CmdMergeBase {
 				return fakeSHA, nil
 			}
 			return "", errors.New("unexpected")

--- a/internal/git/sync_test.go
+++ b/internal/git/sync_test.go
@@ -134,7 +134,7 @@ func TestAbortRebase(t *testing.T) {
 func TestMergeBase(t *testing.T) {
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
-			if len(args) == 3 && args[0] == "merge-base" {
+			if len(args) == 3 && args[0] == cmdMergeBase {
 				return fakeSHA, nil
 			}
 			return "", errors.New("unexpected")

--- a/internal/operations/clean_test.go
+++ b/internal/operations/clean_test.go
@@ -89,16 +89,16 @@ func TestFindMergedCandidatesSquashMerge(t *testing.T) {
 				return wt, nil
 			}
 			// IsSquashMerged: merge-base → rev-parse → diff → log
-			if len(args) > 0 && args[0] == "merge-base" {
+			if len(args) > 0 && args[0] == git.CmdMergeBase {
 				return "base123", nil
 			}
 			if len(args) > 0 && args[0] == "rev-parse" {
 				return "tip456", nil
 			}
-			if len(args) > 0 && args[0] == "diff" {
+			if len(args) > 0 && args[0] == git.CmdDiff {
 				return "fake diff", nil
 			}
-			if len(args) > 0 && args[0] == "log" {
+			if len(args) > 0 && args[0] == git.CmdLog {
 				return "fake log", nil
 			}
 			return "", nil

--- a/internal/operations/clean_test.go
+++ b/internal/operations/clean_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/progress"
 )
 
@@ -67,6 +68,13 @@ func TestFindMergedCandidatesNormalMerge(t *testing.T) {
 }
 
 func TestFindMergedCandidatesSquashMerge(t *testing.T) {
+	defer func(orig func(context.Context, string) (map[string]bool, error)) {
+		git.ComputePatchIDs = orig
+	}(git.ComputePatchIDs)
+	git.ComputePatchIDs = func(_ context.Context, _ string) (map[string]bool, error) {
+		return map[string]bool{"fakePID": true}, nil
+	}
+
 	wt := porcelainEntries(
 		struct{ path, branch string }{"/repo", "main"},
 		struct{ path, branch string }{"/wt/squashed", "feature/squashed"},
@@ -80,18 +88,18 @@ func TestFindMergedCandidatesSquashMerge(t *testing.T) {
 			if len(args) > 0 && args[0] == gitCmdWorktree {
 				return wt, nil
 			}
-			// IsSquashMerged: merge-base → rev-parse → commit-tree → cherry
+			// IsSquashMerged: merge-base → rev-parse → diff → log
 			if len(args) > 0 && args[0] == "merge-base" {
 				return "base123", nil
 			}
 			if len(args) > 0 && args[0] == "rev-parse" {
-				return "tree123", nil
+				return "tip456", nil
 			}
-			if len(args) > 0 && args[0] == "commit-tree" {
-				return "temp123", nil
+			if len(args) > 0 && args[0] == "diff" {
+				return "fake diff", nil
 			}
-			if len(args) > 0 && args[0] == "cherry" {
-				return "- temp123", nil // "- " prefix = already merged
+			if len(args) > 0 && args[0] == "log" {
+				return "fake log", nil
 			}
 			return "", nil
 		},


### PR DESCRIPTION
## Summary

- Replace `IsSquashMerged`'s `git commit-tree` + `git cherry` technique with a `git diff` + `git patch-id --stable` approach
- The old technique leaked unreferenced loose commit objects on every call, creating GC pressure for repos with many worktrees and frequent `clean --merged` runs
- The new approach computes patch-ids from the branch diff and the mergeRef's commit diffs, then checks for a match — zero loose objects created
- Extract `ComputePatchIDs` as a test-overridable package-level variable to handle the stdin piping requirement without changing the `Runner` interface
- Add empty-branch edge case handling (merge-base == branch tip → not squash-merged)

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

## Issue

Closes #300
