### PR TITLE
[feat] merge auto-cleanup deletes the merged remote branch (#277)

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -107,6 +107,13 @@ var mergeCmd = &cobra.Command{
 			fmt.Fprintf(cmd.OutOrStdout(), "Merged successfully but failed to remove worktree: %v\nTo remove manually: rimba remove %s\n", result.RemoveError, sourceTask)
 		}
 
+		if result.RemoteDeleted {
+			fmt.Fprintf(cmd.OutOrStdout(), "Deleted remote branch: %s/%s\n", git.DefaultRemote, result.SourceBranch)
+		} else if result.RemoteError != nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "Failed to delete remote branch %s/%s\nTo delete remote: git push %s --delete %s\n",
+				git.DefaultRemote, result.SourceBranch, git.DefaultRemote, result.SourceBranch)
+		}
+
 		return nil
 	},
 }

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -110,8 +110,8 @@ var mergeCmd = &cobra.Command{
 		if result.RemoteDeleted {
 			fmt.Fprintf(cmd.OutOrStdout(), "Deleted remote branch: %s/%s\n", git.DefaultRemote, result.SourceBranch)
 		} else if result.RemoteError != nil {
-			fmt.Fprintf(cmd.OutOrStdout(), "Failed to delete remote branch %s/%s\nTo delete remote: git push %s --delete %s\n",
-				git.DefaultRemote, result.SourceBranch, git.DefaultRemote, result.SourceBranch)
+			fmt.Fprintf(cmd.OutOrStdout(), "Failed to delete remote branch %s/%s: %v\nTo delete remote: git push %s --delete %s\n",
+				git.DefaultRemote, result.SourceBranch, result.RemoteError, git.DefaultRemote, result.SourceBranch)
 		}
 
 		return nil

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/lugassawan/rimba/internal/config"
 )
 
-const mergeWorktreeOut = "worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /wt/feature-login\nHEAD def456\nbranch refs/heads/feature/login\n\nworktree /wt/feature-dashboard\nHEAD ghi789\nbranch refs/heads/feature/dashboard\n"
+const (
+	mergeWorktreeOut = "worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /wt/feature-login\nHEAD def456\nbranch refs/heads/feature/login\n\nworktree /wt/feature-dashboard\nHEAD ghi789\nbranch refs/heads/feature/dashboard\n"
+	gitCmdPush       = "push" // first arg of "git push <remote> ..." — distinct from gitSubcmdStashPush which is args[1] of "git stash push"
+)
 
 func mergeTestRunner(mergeErr error) *mockRunner {
 	return &mockRunner{
@@ -510,7 +513,10 @@ func TestMergeRemoteDeleteFailedOutput(t *testing.T) {
 			if len(args) >= 2 && args[1] == cmdShowToplevel {
 				return repoPath, nil
 			}
-			if len(args) >= 1 && args[0] == gitSubcmdStashPush {
+			if len(args) >= 1 && args[0] == "remote" {
+				return "https://github.com/lugassawan/rimba.git", nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdPush {
 				return "", errors.New("connection refused")
 			}
 			return mergeWorktreeOut, nil
@@ -541,6 +547,9 @@ func TestMergeRemoteDeleteFailedOutput(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "Failed to delete remote branch") {
 		t.Errorf("output = %q, want 'Failed to delete remote branch'", out)
+	}
+	if !strings.Contains(out, "connection refused") {
+		t.Errorf("output = %q, want remote error reason 'connection refused'", out)
 	}
 	if !strings.Contains(out, "git push origin --delete") {
 		t.Errorf("output = %q, want manual hint with 'git push origin --delete'", out)

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -479,3 +479,70 @@ func TestMergeWithNoFF(t *testing.T) {
 		t.Errorf("merge args = %v, want --no-ff to be present", mergeArgs)
 	}
 }
+
+func TestMergeRemoteDeletedOutput(t *testing.T) {
+	cfg := &config.Config{DefaultSource: branchMain, WorktreeDir: defaultRelativeWtDir}
+	// mergeTestRunner returns ("", nil) for unmatched run calls → origin present, push succeeds.
+	r := mergeTestRunner(nil)
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().String(flagInto, "", "")
+	cmd.Flags().Bool(flagNoFF, false, "")
+	cmd.Flags().Bool(flagKeep, false, "")
+	cmd.Flags().Bool(flagDelete, false, "")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	if err := mergeCmd.RunE(cmd, []string{"login"}); err != nil {
+		t.Fatalf(fatalMergeRunE, err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Deleted remote branch: origin/feature/login") {
+		t.Errorf("output = %q, want 'Deleted remote branch: origin/feature/login'", out)
+	}
+}
+
+func TestMergeRemoteDeleteFailedOutput(t *testing.T) {
+	cfg := &config.Config{DefaultSource: branchMain, WorktreeDir: defaultRelativeWtDir}
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == cmdShowToplevel {
+				return repoPath, nil
+			}
+			if len(args) >= 1 && args[0] == gitSubcmdStashPush {
+				return "", errors.New("connection refused")
+			}
+			return mergeWorktreeOut, nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == cmdStatus {
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == flagSyncMerge {
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, buf := newTestCmd()
+	cmd.Flags().String(flagInto, "", "")
+	cmd.Flags().Bool(flagNoFF, false, "")
+	cmd.Flags().Bool(flagKeep, false, "")
+	cmd.Flags().Bool(flagDelete, false, "")
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+
+	if err := mergeCmd.RunE(cmd, []string{"login"}); err != nil {
+		t.Fatalf(fatalMergeRunE, err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Failed to delete remote branch") {
+		t.Errorf("output = %q, want 'Failed to delete remote branch'", out)
+	}
+	if !strings.Contains(out, "git push origin --delete") {
+		t.Errorf("output = %q, want manual hint with 'git push origin --delete'", out)
+	}
+}

--- a/internal/mcp/tool_merge.go
+++ b/internal/mcp/tool_merge.go
@@ -70,6 +70,7 @@ func handleMerge(hctx *HandlerContext) server.ToolHandlerFunc {
 			Source:        result.SourceBranch,
 			Into:          result.TargetLabel,
 			SourceRemoved: result.SourceRemoved,
+			RemoteDeleted: result.RemoteDeleted,
 		})
 	}
 }

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -61,6 +61,7 @@ type mergeResult struct {
 	Source        string `json:"source"`
 	Into          string `json:"into"`
 	SourceRemoved bool   `json:"source_removed"`
+	RemoteDeleted bool   `json:"remote_deleted,omitempty"`
 }
 
 // syncResult holds the outcome of a sync operation.

--- a/internal/operations/merge.go
+++ b/internal/operations/merge.go
@@ -34,6 +34,8 @@ type MergeResult struct {
 	SourceRemoved   bool  // true only if both worktree removed and branch deleted
 	WorktreeRemoved bool  // true if worktree was removed (branch may still exist)
 	RemoveError     error // non-nil if cleanup failed
+	RemoteDeleted   bool  // true if the remote branch was deleted (parity with clean --merged, #231)
+	RemoteError     error // non-nil if remote-branch deletion was attempted and failed
 	Plan            *Plan // always non-nil on a successful return; records steps that were (or would be) executed
 }
 
@@ -121,9 +123,32 @@ func MergeWorktree(ctx context.Context, r git.Runner, params MergeParams, onProg
 		if rmErr != nil {
 			result.RemoveError = rmErr
 		}
+
+		// Delete the merged remote branch (best-effort, parity with clean --merged, #231).
+		deleteMergedRemote(ctx, r, plan, source.Branch, &result, params.DryRun, wtRemoved)
 	}
 
 	return result, nil
+}
+
+// deleteMergedRemote deletes the remote tracking branch after a merge cleanup.
+// It is a no-op when the remote is absent or when the worktree was not actually
+// removed. Failures are captured in result.RemoteError and never abort the merge.
+func deleteMergedRemote(ctx context.Context, r git.Runner, plan *Plan, branch string, result *MergeResult, dryRun, wtRemoved bool) {
+	if !dryRun && !wtRemoved {
+		return
+	}
+	if !git.RemoteExists(ctx, r, git.DefaultRemote) {
+		return
+	}
+	_ = plan.Do("delete remote branch: "+git.DefaultRemote+"/"+branch, func() error {
+		var remoteErr error
+		if remoteErr = git.DeleteRemoteBranch(ctx, r, git.DefaultRemote, branch); remoteErr == nil {
+			result.RemoteDeleted = true
+		}
+		result.RemoteError = remoteErr
+		return nil // best-effort: never abort the merge
+	})
 }
 
 // abortFailedMerge attempts to roll back a failed merge in targetDir.

--- a/internal/operations/merge.go
+++ b/internal/operations/merge.go
@@ -125,6 +125,8 @@ func MergeWorktree(ctx context.Context, r git.Runner, params MergeParams, onProg
 		}
 
 		// Delete the merged remote branch (best-effort, parity with clean --merged, #231).
+		// Gated on wtRemoved (not brDeleted) so that a partial failure — branch deleted but
+		// worktree still on disk — defers remote cleanup to a later `rimba clean --merged` run.
 		deleteMergedRemote(ctx, r, plan, source.Branch, &result, params.DryRun, wtRemoved)
 	}
 

--- a/internal/operations/merge_test.go
+++ b/internal/operations/merge_test.go
@@ -562,6 +562,233 @@ func TestMergeWorktreeCleanupBranchDeleteFails(t *testing.T) {
 	}
 }
 
+func TestMergeWorktreeRemoteDeleteSuccess(t *testing.T) {
+	wt := mergeWorktreeList()
+	pushCalled := false
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == gitCmdWorktree {
+				return wt, nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdPush {
+				pushCalled = true
+				return "", nil
+			}
+			return "", nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitCmdStatus {
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdMerge {
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
+		SourceTask: "login",
+		RepoRoot:   "/repo",
+		MainBranch: "main",
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.RemoteDeleted {
+		t.Error("expected RemoteDeleted=true")
+	}
+	if result.RemoteError != nil {
+		t.Errorf("expected nil RemoteError, got: %v", result.RemoteError)
+	}
+	if !pushCalled {
+		t.Error("expected git push --delete to be called")
+	}
+}
+
+func TestMergeWorktreeRemoteDeleteFailureNonFatal(t *testing.T) {
+	wt := mergeWorktreeList()
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == gitCmdWorktree {
+				return wt, nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdPush {
+				return "", errors.New("connection refused")
+			}
+			return "", nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitCmdStatus {
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdMerge {
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
+		SourceTask: "login",
+		RepoRoot:   "/repo",
+		MainBranch: "main",
+	}, nil)
+	if err != nil {
+		t.Fatalf("expected no fatal error (remote delete is best-effort), got: %v", err)
+	}
+	if result.RemoteDeleted {
+		t.Error("expected RemoteDeleted=false on failure")
+	}
+	if result.RemoteError == nil {
+		t.Error("expected non-nil RemoteError")
+	}
+}
+
+func TestMergeWorktreeNoOriginSkipsRemoteDelete(t *testing.T) {
+	wt := mergeWorktreeList()
+	pushCalled := false
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == gitCmdWorktree {
+				return wt, nil
+			}
+			if len(args) >= 2 && args[0] == "remote" && args[1] == "get-url" {
+				return "", errors.New("no such remote")
+			}
+			if len(args) >= 1 && args[0] == gitCmdPush {
+				pushCalled = true
+				return "", nil
+			}
+			return "", nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitCmdStatus {
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdMerge {
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
+		SourceTask: "login",
+		RepoRoot:   "/repo",
+		MainBranch: "main",
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RemoteDeleted {
+		t.Error("expected RemoteDeleted=false when no origin")
+	}
+	if pushCalled {
+		t.Error("expected no push call when no origin")
+	}
+}
+
+func TestMergeWorktreeKeepSuppressesRemoteDelete(t *testing.T) {
+	wt := mergeWorktreeList()
+	remoteChecked := false
+	pushCalled := false
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == gitCmdWorktree {
+				return wt, nil
+			}
+			if len(args) >= 1 && args[0] == "remote" {
+				remoteChecked = true
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdPush {
+				pushCalled = true
+				return "", nil
+			}
+			return "", nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitCmdStatus {
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdMerge {
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
+		SourceTask: "login",
+		RepoRoot:   "/repo",
+		MainBranch: "main",
+		Keep:       true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RemoteDeleted {
+		t.Error("expected RemoteDeleted=false with --keep")
+	}
+	if remoteChecked {
+		t.Error("expected no remote check when --keep suppresses cleanup")
+	}
+	if pushCalled {
+		t.Error("expected no push when --keep suppresses cleanup")
+	}
+}
+
+func TestMergeWorktreeDryRunIncludesRemoteStep(t *testing.T) {
+	wt := mergeWorktreeList()
+	pushCalled := false
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == gitCmdWorktree {
+				return wt, nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdPush {
+				pushCalled = true
+				return "", nil
+			}
+			// remote get-url succeeds → origin present
+			return "", nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitCmdStatus {
+				return "", nil
+			}
+			if len(args) >= 1 && args[0] == gitCmdMerge {
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+
+	result, err := MergeWorktree(context.Background(), r, MergeParams{
+		SourceTask: "login",
+		RepoRoot:   "/repo",
+		MainBranch: "main",
+		DryRun:     true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hasRemoteStep := false
+	for _, s := range result.Plan.Steps {
+		if strings.Contains(s, "delete remote branch") && strings.Contains(s, "origin/"+branchFeatureLogin) {
+			hasRemoteStep = true
+			break
+		}
+	}
+	if !hasRemoteStep {
+		t.Errorf("expected remote step in plan, got: %v", result.Plan.Steps)
+	}
+	if pushCalled {
+		t.Error("expected no push in dry-run mode")
+	}
+}
+
 func TestMergeWorktreeTargetDirtyToWorktree(t *testing.T) {
 	wt := mergeWorktreeList()
 	r := &mockRunner{

--- a/internal/operations/merge_test.go
+++ b/internal/operations/merge_test.go
@@ -3,6 +3,7 @@ package operations
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 
@@ -564,14 +565,14 @@ func TestMergeWorktreeCleanupBranchDeleteFails(t *testing.T) {
 
 func TestMergeWorktreeRemoteDeleteSuccess(t *testing.T) {
 	wt := mergeWorktreeList()
-	pushCalled := false
+	var pushArgs []string
 	r := &mockRunner{
 		run: func(args ...string) (string, error) {
 			if len(args) >= 2 && args[0] == gitCmdWorktree {
 				return wt, nil
 			}
 			if len(args) >= 1 && args[0] == gitCmdPush {
-				pushCalled = true
+				pushArgs = args
 				return "", nil
 			}
 			return "", nil
@@ -601,8 +602,11 @@ func TestMergeWorktreeRemoteDeleteSuccess(t *testing.T) {
 	if result.RemoteError != nil {
 		t.Errorf("expected nil RemoteError, got: %v", result.RemoteError)
 	}
-	if !pushCalled {
+	if len(pushArgs) == 0 {
 		t.Error("expected git push --delete to be called")
+	}
+	if !slices.Contains(pushArgs, "--delete") {
+		t.Errorf("expected --delete flag in push args, got: %v", pushArgs)
 	}
 }
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -57,10 +57,12 @@ const (
 	secretContent = "SECRET=test"
 
 	// Merge test constants.
-	taskMergeMain   = "merge-main"
-	taskMergeKeep   = "merge-keep"
-	taskMergeSrc    = "merge-src"
-	taskMergeDelSrc = "merge-del-src"
+	taskMergeMain       = "merge-main"
+	taskMergeKeep       = "merge-keep"
+	taskMergeSrc        = "merge-src"
+	taskMergeDelSrc     = "merge-del-src"
+	taskMergeRemote     = "merge-remote"
+	taskMergeRemoteKeep = "merge-remote-keep"
 
 	// Conflict-check and merge-plan test constants.
 	taskConflictA = "cc-task-a"

--- a/tests/e2e/merge_test.go
+++ b/tests/e2e/merge_test.go
@@ -218,6 +218,66 @@ func TestMergeTargetNotFound(t *testing.T) {
 	assertContains(t, r.Stderr, "not found")
 }
 
+func TestMergeDeletesRemoteBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, _ := setupRepoWithBareOrigin(t)
+	wtPath := mergeSetup(t, repo, taskMergeRemote, flagSkipHooksE2E)
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.BranchName(defaultPrefix, taskMergeRemote)
+	_ = resolver.WorktreePath(wtDir, branch)
+
+	// Push the feature branch to origin before merging.
+	testutil.GitCmd(t, wtPath, "push", "-u", "origin", branch)
+
+	// Verify branch exists on remote before merge.
+	out := testutil.GitCmd(t, repo, "branch", "-r")
+	if !strings.Contains(out, "origin/"+branch) {
+		t.Fatalf("expected origin/%s to exist before merge, got: %s", branch, out)
+	}
+
+	r := rimbaSuccess(t, repo, "merge", taskMergeRemote)
+	assertContains(t, r.Stdout, "Merged")
+	assertContains(t, r.Stdout, "Deleted remote branch: origin/"+branch)
+
+	// Fetch to update remote-tracking refs, then verify origin/<branch> is gone.
+	testutil.GitCmd(t, repo, "fetch", "--prune", "origin")
+	out = testutil.GitCmd(t, repo, "branch", "-r")
+	if strings.Contains(out, "origin/"+branch) {
+		t.Errorf("expected origin/%s to be gone after merge, got: %s", branch, out)
+	}
+}
+
+func TestMergeKeepDoesNotDeleteRemoteBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip(skipE2E)
+	}
+
+	repo, _ := setupRepoWithBareOrigin(t)
+	wtPath := mergeSetup(t, repo, taskMergeRemoteKeep, flagSkipHooksE2E)
+
+	cfg := loadConfig(t, repo)
+	wtDir := filepath.Join(repo, cfg.WorktreeDir)
+	branch := resolver.BranchName(defaultPrefix, taskMergeRemoteKeep)
+	_ = resolver.WorktreePath(wtDir, branch)
+
+	testutil.GitCmd(t, wtPath, "push", "-u", "origin", branch)
+
+	r := rimbaSuccess(t, repo, "merge", taskMergeRemoteKeep, "--keep")
+	assertContains(t, r.Stdout, "Merged")
+	assertNotContains(t, r.Stdout, "Deleted remote branch")
+
+	// Remote branch must still exist.
+	out := testutil.GitCmd(t, repo, "branch", "-r")
+	if !strings.Contains(out, "origin/"+branch) {
+		t.Errorf("expected origin/%s to still exist after --keep merge, got: %s", branch, out)
+	}
+}
+
 func TestMergeDryRun(t *testing.T) {
 	if testing.Short() {
 		t.Skip(skipE2E)

--- a/tests/e2e/merge_test.go
+++ b/tests/e2e/merge_test.go
@@ -226,10 +226,7 @@ func TestMergeDeletesRemoteBranch(t *testing.T) {
 	repo, _ := setupRepoWithBareOrigin(t)
 	wtPath := mergeSetup(t, repo, taskMergeRemote, flagSkipHooksE2E)
 
-	cfg := loadConfig(t, repo)
-	wtDir := filepath.Join(repo, cfg.WorktreeDir)
 	branch := resolver.BranchName(defaultPrefix, taskMergeRemote)
-	_ = resolver.WorktreePath(wtDir, branch)
 
 	// Push the feature branch to origin before merging.
 	testutil.GitCmd(t, wtPath, "push", "-u", "origin", branch)
@@ -260,10 +257,7 @@ func TestMergeKeepDoesNotDeleteRemoteBranch(t *testing.T) {
 	repo, _ := setupRepoWithBareOrigin(t)
 	wtPath := mergeSetup(t, repo, taskMergeRemoteKeep, flagSkipHooksE2E)
 
-	cfg := loadConfig(t, repo)
-	wtDir := filepath.Join(repo, cfg.WorktreeDir)
 	branch := resolver.BranchName(defaultPrefix, taskMergeRemoteKeep)
-	_ = resolver.WorktreePath(wtDir, branch)
 
 	testutil.GitCmd(t, wtPath, "push", "-u", "origin", branch)
 


### PR DESCRIPTION
## Summary
- `rimba merge` auto-cleanup now deletes the remote branch (`origin/<branch>`) after removing the worktree, reaching behavioural parity with `rimba clean --merged` (#231)
- Remote deletion is best-effort: failure is reported in CLI output and MCP `remote_deleted` field but never aborts the merge
- Skipped when no `origin` remote is configured (graceful no-op), suppressed by `--keep`/`--delete`, and previewed under `--dry-run`
- New `RemoteDeleted bool` + `RemoteError error` fields on `MergeResult`; `remote_deleted` added to MCP `mergeResult` JSON

## Test Plan
- [x] Unit tests pass (`make test`) — 5 new unit tests in `internal/operations/merge_test.go` (success, failure non-fatal, no origin, keep suppression, dry-run step)
- [x] CLI output tests pass (`cmd/merge_test.go`) — 2 new tests for `Deleted remote branch` and `Failed to delete remote branch` output lines
- [x] E2E tests pass (`make test-e2e`) — 2 new bare-origin E2E tests: remote branch deleted after `rimba merge`, remote branch survives with `--keep`
- [x] Linter passes (`make lint`) — 0 issues
- [x] Coverage ≥ 97% (`make test-coverage`) — 97.2%

## Issue

Closes #277