### PR TITLE
[chore] Add rimba context rules for Cline, Windsurf, and Gemini AI agents

### DIFF
--- a/.clinerules/rimba.md
+++ b/.clinerules/rimba.md
@@ -1,0 +1,19 @@
+# rimba — Git Worktree Manager
+
+rimba manages parallel git worktrees so you can work on multiple tasks simultaneously.
+It is optional and detected via `.rimba/settings.toml` in the repo root.
+
+## Prerequisites
+
+Run `rimba version` to check if rimba is installed.
+If not found, **ask the user** before installing. Never install automatically.
+
+## Top Commands
+
+1. `rimba add <task>` — create worktree + branch
+2. `rimba list` — list all worktrees
+3. `rimba status` — health overview
+4. `rimba merge <task>` — merge into main and auto-clean up
+5. `rimba clean --merged` — remove merged worktrees
+6. `rimba sync [task]` — rebase onto main
+7. `rimba mcp` — start MCP server for AI tool integration

--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ custom-gcl
 .env
 
 # Rimba config (local to each repo)
-.rimba/settings.local.toml
 
 # Editor/IDE
 # .idea/
@@ -55,3 +54,4 @@ local.properties
 
 # macOS
 .DS_Store
+.rimba/*.local.toml

--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,6 @@ custom-gcl
 # env file
 .env
 
-# Rimba config (local to each repo)
-
 # Editor/IDE
 # .idea/
 # .vscode/
@@ -54,4 +52,6 @@ local.properties
 
 # macOS
 .DS_Store
+
+# Rimba config (local to each repo)
 .rimba/*.local.toml

--- a/.windsurf/rules/rimba.md
+++ b/.windsurf/rules/rimba.md
@@ -1,0 +1,19 @@
+# rimba — Git Worktree Manager
+
+rimba manages parallel git worktrees so you can work on multiple tasks simultaneously.
+It is optional and detected via `.rimba/settings.toml` in the repo root.
+
+## Prerequisites
+
+Run `rimba version` to check if rimba is installed.
+If not found, **ask the user** before installing. Never install automatically.
+
+## Top Commands
+
+1. `rimba add <task>` — create worktree + branch
+2. `rimba list` — list all worktrees
+3. `rimba status` — health overview
+4. `rimba merge <task>` — merge into main and auto-clean up
+5. `rimba clean --merged` — remove merged worktrees
+6. `rimba sync [task]` — rebase onto main
+7. `rimba mcp` — start MCP server for AI tool integration

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,25 @@
+<!-- BEGIN RIMBA -->
+<!-- Managed by rimba — do not edit this block manually -->
+
+# rimba — Git Worktree Manager
+
+rimba manages parallel git worktrees so you can work on multiple tasks simultaneously.
+It is optional and detected via `.rimba/settings.toml` in the repo root.
+
+## Prerequisites
+
+Run `rimba version` to check if rimba is installed.
+If not found, **ask the user** before installing. Never install automatically.
+
+## Command Reference
+
+| Concern | Commands |
+|---------|----------|
+| Create & navigate | `rimba add <task>`, `rimba add pr:<num>` (from a GitHub PR), `rimba open <task>` |
+| Inspect | `rimba list` (`--full` adds PR/CI columns), `rimba status` (`--detail` adds disk/velocity) |
+| Sync & merge | `rimba sync [task]`, `rimba merge <task>` |
+| Clean up | `rimba clean --merged`, `rimba archive <task>`, `rimba remove <task>` |
+| Cross-cutting | `rimba exec <cmd>`, `rimba conflict-check` |
+| AI integration | `rimba mcp` (MCP server for AI coding agents) |
+
+<!-- END RIMBA -->


### PR DESCRIPTION
N/A — ad-hoc tooling addition, no backing issue

## Summary

- Add `.clinerules/rimba.md` and `.windsurf/rules/rimba.md` with managed rimba command reference blocks for Cline and Windsurf AI coding agents
- Add `GEMINI.md` with rimba context for Gemini CLI, matching the existing `CLAUDE.md` pattern
- Broaden `.gitignore` glob from `settings.local.toml` to `*.local.toml` to cover any future local override files

## Test Plan

- [ ] Verify `.clinerules/rimba.md`, `.windsurf/rules/rimba.md`, and `GEMINI.md` are present and contain the correct managed block
- [ ] Verify `.gitignore` ignores `*.local.toml` files (e.g. `settings.local.toml`, `custom.local.toml`)