### PR TITLE
[fix] MCP global registration targets ~/.claude.json so Claude Code reads it

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ agent = 'claude'
 
 > See [docs/configuration.md](docs/configuration.md) for the full field reference, dependency management, and environment variables.
 
-Running `rimba init --agents` or `rimba init -g` additionally creates or patches MCP server config files in client tools (`.mcp.json`, `.cursor/mcp.json`, `~/.claude/settings.json`, and others). See [docs/configuration.md#mcp-server-registration](docs/configuration.md#mcp-server-registration) for the full list of patched files and entry format.
+Running `rimba init --agents` or `rimba init -g` additionally creates or patches MCP server config files in client tools (`.mcp.json`, `.cursor/mcp.json`, `~/.claude.json`, and others). See [docs/configuration.md#mcp-server-registration](docs/configuration.md#mcp-server-registration) for the full list of patched files and entry format.
 
 ## Trust model
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -57,7 +57,7 @@ directory is already personal.
 
 When --agents or -g is used, rimba also registers itself as an MCP server (server name:
 rimba, command: rimba mcp) in client config files (.mcp.json, .cursor/mcp.json,
-~/.claude/settings.json, ~/.codex/config.toml, ~/.gemini/settings.json,
+~/.claude.json, ~/.codex/config.toml, ~/.gemini/settings.json,
 ~/.codeium/windsurf/mcp_config.json, ~/.roo/mcp.json). --agents --local does not
 register MCP — it only updates agent files. Registration is idempotent.`,
 	Annotations: map[string]string{"skipConfig": "true"},
@@ -263,7 +263,7 @@ func runInstall(
 		if err != nil {
 			return errhint.WithFix(
 				fmt.Errorf("mcp servers: %w", err),
-				"check write permissions for MCP client configs (.mcp.json, .cursor/mcp.json, ~/.claude/settings.json)",
+				"check write permissions for MCP client configs (.mcp.json, .cursor/mcp.json, ~/.claude.json)",
 			)
 		}
 	}

--- a/cmd/init_mcp_test.go
+++ b/cmd/init_mcp_test.go
@@ -12,13 +12,9 @@ func TestInitGlobalRegistersMCP(t *testing.T) {
 	home, restore := setupGlobalInit(t)
 	defer restore()
 
-	// Pre-seed .claude/settings.json so MCP registration doesn't skip it
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("{}\n"), 0600); err != nil {
-		t.Fatalf("write settings.json: %v", err)
+	// Pre-seed ~/.claude.json so MCP registration doesn't skip it
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte("{}\n"), 0600); err != nil {
+		t.Fatalf("write .claude.json: %v", err)
 	}
 
 	cmd, buf := newTestCmd()
@@ -34,25 +30,25 @@ func TestInitGlobalRegistersMCP(t *testing.T) {
 	if !strings.Contains(out, "MCP server:") {
 		t.Errorf("output should contain 'MCP server:', got:\n%s", out)
 	}
-	if !strings.Contains(out, filepath.Join(".claude", "settings.json")) {
-		t.Errorf("output should mention settings.json, got:\n%s", out)
+	if !strings.Contains(out, ".claude.json") {
+		t.Errorf("output should mention .claude.json, got:\n%s", out)
 	}
 	if !strings.Contains(out, "registered") {
 		t.Errorf("output should say 'registered', got:\n%s", out)
 	}
 
 	// Verify the file was patched
-	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	data, err := os.ReadFile(filepath.Join(home, ".claude.json"))
 	if err != nil {
-		t.Fatalf("read settings.json: %v", err)
+		t.Fatalf("read .claude.json: %v", err)
 	}
 	var cfg map[string]any
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		t.Fatalf("parse settings.json: %v", err)
+		t.Fatalf("parse .claude.json: %v", err)
 	}
 	servers, ok := cfg["mcpServers"].(map[string]any)
 	if !ok {
-		t.Fatal("mcpServers missing in settings.json")
+		t.Fatal("mcpServers missing in .claude.json")
 	}
 	entry, ok := servers["rimba"].(map[string]any)
 	if !ok {
@@ -83,12 +79,8 @@ func TestInitGlobalUninstallRemovesMCP(t *testing.T) {
 	home, restore := setupGlobalInit(t)
 	defer restore()
 
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("{}\n"), 0600); err != nil {
-		t.Fatalf("write settings.json: %v", err)
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte("{}\n"), 0600); err != nil {
+		t.Fatalf("write .claude.json: %v", err)
 	}
 
 	// Install
@@ -111,8 +103,8 @@ func TestInitGlobalUninstallRemovesMCP(t *testing.T) {
 		t.Errorf("output should say 'unregistered', got:\n%s", out)
 	}
 
-	// rimba key should be gone
-	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	// rimba key should be gone from ~/.claude.json
+	data, err := os.ReadFile(filepath.Join(home, ".claude.json"))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,7 +28,7 @@ Agent files (`AGENTS.md`, `.github/copilot-instructions.md`, `.cursor/rules/rimb
 - `--agents --local` — project-personal level (gitignored)
 - `-g` / `--global` — user level (`~/`) — works outside a git repository
 
-When agent files are installed (`--agents` or `-g`), rimba also registers itself as an MCP server (server name: `rimba`, command: `rimba mcp`) in the corresponding client config files (`.mcp.json`, `.cursor/mcp.json`, `~/.claude/settings.json`, `~/.codex/config.toml`, `~/.gemini/settings.json`, `~/.codeium/windsurf/mcp_config.json`, `~/.roo/mcp.json`). Use `--uninstall` with the same flags to remove.
+When agent files are installed (`--agents` or `-g`), rimba also registers itself as an MCP server (server name: `rimba`, command: `rimba mcp`) in the corresponding client config files (`.mcp.json`, `.cursor/mcp.json`, `~/.claude.json`, `~/.codex/config.toml`, `~/.gemini/settings.json`, `~/.codeium/windsurf/mcp_config.json`, `~/.roo/mcp.json`). Use `--uninstall` with the same flags to remove.
 
 If `.rimba/` already exists, config creation is skipped but agent files are still installed or updated. If a legacy `.rimba.toml` exists, it is migrated into the new directory layout.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,7 +117,7 @@ Patches the following files in your home directory:
 
 | File | Format |
 |------|--------|
-| `~/.claude/settings.json` | JSON (`mcpServers` object) |
+| `~/.claude.json` | JSON (`mcpServers` object) |
 | `~/.codex/config.toml` | TOML (`[[mcp_servers]]` array) |
 | `~/.gemini/settings.json` | JSON (`mcpServers` object) |
 | `~/.codeium/windsurf/mcp_config.json` | JSON (`mcpServers` object) |

--- a/internal/agentfile/mcpreg.go
+++ b/internal/agentfile/mcpreg.go
@@ -41,7 +41,7 @@ type MCPSpec struct {
 // GlobalMCPSpecs returns the MCP config files patched at user level (~/).
 func GlobalMCPSpecs() []MCPSpec {
 	return []MCPSpec{
-		{RelPath: filepath.Join(".claude", "settings.json"), Format: mcpJSON, ContainerKey: "mcpServers"},
+		{RelPath: ".claude.json", Format: mcpJSON, ContainerKey: "mcpServers"},
 		{RelPath: filepath.Join(".cursor", "mcp.json"), Format: mcpJSON, ContainerKey: "mcpServers"},
 		{RelPath: filepath.Join(".codeium", "windsurf", "mcp_config.json"), Format: mcpJSON, ContainerKey: "mcpServers"},
 		{RelPath: filepath.Join(".codex", "config.toml"), Format: mcpTOML, ContainerKey: "mcp_servers"},
@@ -60,13 +60,25 @@ func ProjectMCPSpecs() []MCPSpec {
 }
 
 // RegisterMCPGlobal patches all user-level MCP config files to add the rimba server entry.
+// It also removes the rimba entry from legacy config paths (self-heal for existing installs).
 func RegisterMCPGlobal(homeDir string) ([]Result, error) {
-	return applyMCPSpecs(homeDir, GlobalMCPSpecs(), false)
+	results, err := applyMCPSpecs(homeDir, GlobalMCPSpecs(), false)
+	if err != nil {
+		return results, err
+	}
+	legacy, legacyErr := applyMCPSpecs(homeDir, legacyClaudeSpecs(), true)
+	return append(results, legacy...), legacyErr
 }
 
 // UnregisterMCPGlobal removes the rimba server entry from all user-level MCP config files.
+// It also removes the rimba entry from legacy config paths (self-heal for existing installs).
 func UnregisterMCPGlobal(homeDir string) ([]Result, error) {
-	return applyMCPSpecs(homeDir, GlobalMCPSpecs(), true)
+	results, err := applyMCPSpecs(homeDir, GlobalMCPSpecs(), true)
+	if err != nil {
+		return results, err
+	}
+	legacy, legacyErr := applyMCPSpecs(homeDir, legacyClaudeSpecs(), true)
+	return append(results, legacy...), legacyErr
 }
 
 // RegisterMCPProject patches project-level MCP config files to add the rimba server entry.
@@ -77,6 +89,14 @@ func RegisterMCPProject(repoRoot string) ([]Result, error) {
 // UnregisterMCPProject removes the rimba server entry from project-level MCP config files.
 func UnregisterMCPProject(repoRoot string) ([]Result, error) {
 	return applyMCPSpecs(repoRoot, ProjectMCPSpecs(), true)
+}
+
+// legacyClaudeSpecs returns stale config paths that once held the Claude MCP entry.
+// They are only ever removed (never written) to self-heal existing installations.
+func legacyClaudeSpecs() []MCPSpec {
+	return []MCPSpec{
+		{RelPath: filepath.Join(".claude", "settings.json"), Format: mcpJSON, ContainerKey: "mcpServers"},
+	}
 }
 
 func codecFor(f mcpFormat) mcpCodec {

--- a/internal/agentfile/mcpreg_test.go
+++ b/internal/agentfile/mcpreg_test.go
@@ -303,7 +303,7 @@ func TestPatchMalformedReturnsError(t *testing.T) {
 			wantInErr: "config.toml",
 		},
 		{
-			name:      "malformed JSON",
+			name:      "malformed legacy JSON (settings.json)",
 			dir:       ".claude",
 			file:      "settings.json",
 			content:   "not json {{{",

--- a/internal/agentfile/mcpreg_test.go
+++ b/internal/agentfile/mcpreg_test.go
@@ -14,23 +14,19 @@ import (
 
 func TestRegisterMCPGlobalPatchesExistingJSON(t *testing.T) {
 	home := t.TempDir()
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	seedJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]any{"theme": "dark"})
+	seedJSON(t, filepath.Join(home, ".claude.json"), map[string]any{"theme": "dark"})
 
 	results, err := RegisterMCPGlobal(home)
 	if err != nil {
 		t.Fatalf("RegisterMCPGlobal: %v", err)
 	}
 
-	claudeResult := findResult(t, results, filepath.Join(".claude", "settings.json"))
+	claudeResult := findResult(t, results, ".claude.json")
 	if claudeResult.Action != actionRegistered {
 		t.Errorf("action = %q, want %q", claudeResult.Action, actionRegistered)
 	}
 
-	cfg := readJSONFile(t, filepath.Join(claudeDir, "settings.json"))
+	cfg := readJSONFile(t, filepath.Join(home, ".claude.json"))
 	if cfg["theme"] != "dark" {
 		t.Error("existing 'theme' key was not preserved")
 	}
@@ -45,8 +41,9 @@ func TestRegisterMCPGlobalSkipsAbsentFiles(t *testing.T) {
 		t.Fatalf("RegisterMCPGlobal: %v", err)
 	}
 
-	if len(results) != len(GlobalMCPSpecs()) {
-		t.Fatalf("len(results) = %d, want %d", len(results), len(GlobalMCPSpecs()))
+	wantLen := len(GlobalMCPSpecs()) + len(legacyClaudeSpecs())
+	if len(results) != wantLen {
+		t.Fatalf("len(results) = %d, want %d", len(results), wantLen)
 	}
 	for _, r := range results {
 		if r.Action != actionSkippedNoConfig {
@@ -62,16 +59,12 @@ func TestRegisterMCPGlobalSkipsAbsentFiles(t *testing.T) {
 
 func TestRegisterMCPGlobalIdempotent(t *testing.T) {
 	home := t.TempDir()
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	seedJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]any{})
+	seedJSON(t, filepath.Join(home, ".claude.json"), map[string]any{})
 
 	if _, err := RegisterMCPGlobal(home); err != nil {
 		t.Fatalf("first RegisterMCPGlobal: %v", err)
 	}
-	firstContents, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	firstContents, err := os.ReadFile(filepath.Join(home, ".claude.json"))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -80,12 +73,12 @@ func TestRegisterMCPGlobalIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second RegisterMCPGlobal: %v", err)
 	}
-	claudeResult := findResult(t, results, filepath.Join(".claude", "settings.json"))
+	claudeResult := findResult(t, results, ".claude.json")
 	if claudeResult.Action != actionUnchanged {
 		t.Errorf("second register: action = %q, want %q", claudeResult.Action, actionUnchanged)
 	}
 
-	secondContents, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	secondContents, err := os.ReadFile(filepath.Join(home, ".claude.json"))
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -177,11 +170,7 @@ func TestMCPGlobalTOML(t *testing.T) {
 
 func TestUnregisterMCPGlobalRemovesOnlyRimba(t *testing.T) {
 	home := t.TempDir()
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	seedJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]any{
+	seedJSON(t, filepath.Join(home, ".claude.json"), map[string]any{
 		"mcpServers": map[string]any{
 			mcpServerName: map[string]any{"command": mcpServerName, "args": []any{"mcp"}},
 			"other":       map[string]any{"command": "other-tool", "args": []any{}},
@@ -193,12 +182,12 @@ func TestUnregisterMCPGlobalRemovesOnlyRimba(t *testing.T) {
 		t.Fatalf("UnregisterMCPGlobal: %v", err)
 	}
 
-	claudeResult := findResult(t, results, filepath.Join(".claude", "settings.json"))
+	claudeResult := findResult(t, results, ".claude.json")
 	if claudeResult.Action != actionUnregistered {
 		t.Errorf("action = %q, want %q", claudeResult.Action, actionUnregistered)
 	}
 
-	cfg := readJSONFile(t, filepath.Join(claudeDir, "settings.json"))
+	cfg := readJSONFile(t, filepath.Join(home, ".claude.json"))
 	servers, ok := cfg["mcpServers"].(map[string]any)
 	if !ok {
 		t.Fatal("mcpServers should still be present")
@@ -228,18 +217,14 @@ func TestUnregisterMCPGlobalSkipsAbsent(t *testing.T) {
 
 func TestUnregisterMCPGlobalSkipsWhenKeyMissing(t *testing.T) {
 	home := t.TempDir()
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	seedJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]any{"theme": "dark"})
+	seedJSON(t, filepath.Join(home, ".claude.json"), map[string]any{"theme": "dark"})
 
 	results, err := UnregisterMCPGlobal(home)
 	if err != nil {
 		t.Fatalf("UnregisterMCPGlobal: %v", err)
 	}
 
-	claudeResult := findResult(t, results, filepath.Join(".claude", "settings.json"))
+	claudeResult := findResult(t, results, ".claude.json")
 	if claudeResult.Action != actionUnchanged {
 		t.Errorf("action = %q, want %q", claudeResult.Action, actionUnchanged)
 	}
@@ -387,6 +372,22 @@ func TestUnregisterMCPProjectRemovesRimba(t *testing.T) {
 	}
 }
 
+func TestRegisterMCPGlobalPropagatesPrimaryError(t *testing.T) {
+	home := t.TempDir()
+	// Seed primary Claude target with malformed JSON to trigger a parse error.
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte("not json {{{"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := RegisterMCPGlobal(home)
+	if err == nil {
+		t.Error("expected error for malformed .claude.json, got nil")
+	}
+	if !strings.Contains(err.Error(), ".claude.json") {
+		t.Errorf("error should mention .claude.json, got: %v", err)
+	}
+}
+
 func TestPatchReadErrorReturnsError(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("running as root; chmod 000 has no effect")
@@ -428,6 +429,54 @@ func TestUnregisterMCPGlobalMalformedTOMLReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "config.toml") {
 		t.Errorf("error should mention config.toml, got: %v", err)
+	}
+}
+
+// --- GlobalMCPSpecs target tests ---
+
+func TestRegisterMCPGlobalTargetsClaudeJSON(t *testing.T) {
+	home := t.TempDir()
+	seedJSON(t, filepath.Join(home, ".claude.json"), map[string]any{})
+
+	results, err := RegisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("RegisterMCPGlobal: %v", err)
+	}
+
+	claudeResult := findResult(t, results, ".claude.json")
+	if claudeResult.Action != actionRegistered {
+		t.Errorf("action = %q, want %q", claudeResult.Action, actionRegistered)
+	}
+
+	cfg := readJSONFile(t, filepath.Join(home, ".claude.json"))
+	assertRimbaJSONEntry(t, cfg)
+}
+
+func TestRegisterMCPGlobalRemovesLegacySettingsEntry(t *testing.T) {
+	home := t.TempDir()
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seedJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]any{
+		"theme": "dark",
+		"mcpServers": map[string]any{
+			mcpServerName: map[string]any{"command": mcpServerName, "args": []any{"mcp"}},
+		},
+	})
+
+	_, err := RegisterMCPGlobal(home)
+	if err != nil {
+		t.Fatalf("RegisterMCPGlobal: %v", err)
+	}
+
+	cfg := readJSONFile(t, filepath.Join(claudeDir, "settings.json"))
+	if cfg["theme"] != "dark" {
+		t.Error("existing 'theme' key was not preserved in legacy settings.json")
+	}
+	servers, _ := cfg["mcpServers"].(map[string]any)
+	if _, found := servers[mcpServerName]; found {
+		t.Error("rimba entry should have been removed from legacy settings.json")
 	}
 }
 

--- a/tests/e2e/init_test.go
+++ b/tests/e2e/init_test.go
@@ -426,13 +426,9 @@ func TestInitGlobalWithMCPConfigs(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	// Pre-seed .claude/settings.json and .cursor/mcp.json
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{"theme":"dark"}`+"\n"), 0600); err != nil {
-		t.Fatalf("write settings.json: %v", err)
+	// Pre-seed ~/.claude.json so MCP registration doesn't skip it
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(`{"theme":"dark"}`+"\n"), 0600); err != nil {
+		t.Fatalf("write .claude.json: %v", err)
 	}
 
 	dir := t.TempDir()
@@ -441,21 +437,21 @@ func TestInitGlobalWithMCPConfigs(t *testing.T) {
 	assertContains(t, r.Stdout, "MCP server:")
 	assertContains(t, r.Stdout, "registered")
 
-	// Verify settings.json was patched and existing key preserved
-	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	// Verify ~/.claude.json was patched and existing key preserved
+	data, err := os.ReadFile(filepath.Join(home, ".claude.json"))
 	if err != nil {
-		t.Fatalf("read settings.json: %v", err)
+		t.Fatalf("read .claude.json: %v", err)
 	}
 	var cfg map[string]any
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		t.Fatalf("parse settings.json: %v", err)
+		t.Fatalf("parse .claude.json: %v", err)
 	}
 	if cfg["theme"] != "dark" {
 		t.Error("existing 'theme' key was not preserved")
 	}
 	servers, ok := cfg["mcpServers"].(map[string]any)
 	if !ok {
-		t.Fatal("mcpServers missing in settings.json after init -g")
+		t.Fatal("mcpServers missing in .claude.json after init -g")
 	}
 	entry, ok := servers["rimba"].(map[string]any)
 	if !ok {
@@ -474,12 +470,8 @@ func TestInitGlobalUninstallWithMCP(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	claudeDir := filepath.Join(home, ".claude")
-	if err := os.MkdirAll(claudeDir, 0750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte("{}\n"), 0600); err != nil {
-		t.Fatalf("write settings.json: %v", err)
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte("{}\n"), 0600); err != nil {
+		t.Fatalf("write .claude.json: %v", err)
 	}
 
 	dir := t.TempDir()
@@ -488,13 +480,13 @@ func TestInitGlobalUninstallWithMCP(t *testing.T) {
 
 	assertContains(t, r.Stdout, "unregistered")
 
-	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	data, err := os.ReadFile(filepath.Join(home, ".claude.json"))
 	if err != nil {
-		t.Fatalf("read settings.json: %v", err)
+		t.Fatalf("read .claude.json: %v", err)
 	}
 	var cfg map[string]any
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		t.Fatalf("parse settings.json: %v", err)
+		t.Fatalf("parse .claude.json: %v", err)
 	}
 	if servers, ok := cfg["mcpServers"].(map[string]any); ok {
 		if _, found := servers["rimba"]; found {


### PR DESCRIPTION
## Summary

- `rimba init -g` registered the Claude MCP server in `~/.claude/settings.json`, which Claude Code silently ignores — the server was never visible (`claude mcp list` omitted it, no `mcp__rimba__*` tools loaded in any session).
- Retarget global Claude registration to `~/.claude.json` (the canonical user-scope file written by `claude mcp add -s user`) and self-heal the stale `settings.json` entry on every register/unregister call.
- Fix two stale path references in `cmd/init.go` (help text and error hint).
- Fix docs (`docs/configuration.md`, `docs/commands.md`, `README.md`) that documented the wrong file.

## Root cause

`internal/agentfile/mcpreg.go` `GlobalMCPSpecs()` listed `.claude/settings.json` as the Claude entry. Claude Code reads `mcpServers` from `~/.claude.json` (top-level), not from `~/.claude/settings.json` (`mcpServers` is not a recognised key there).

## Changes

| File | Change |
|------|--------|
| `internal/agentfile/mcpreg.go` | `GlobalMCPSpecs()` → `.claude.json`; add `legacyClaudeSpecs()` (remove-only); update `RegisterMCPGlobal`/`UnregisterMCPGlobal` to append legacy cleanup results |
| `cmd/init.go` | Fix help text and error hint (two stale `~/.claude/settings.json` references) |
| `docs/configuration.md`, `docs/commands.md`, `README.md` | `~/.claude/settings.json` → `~/.claude.json` |
| Tests | New: `TestRegisterMCPGlobalTargetsClaudeJSON` (was RED before fix), `TestRegisterMCPGlobalRemovesLegacySettingsEntry`, `TestRegisterMCPGlobalPropagatesPrimaryError`; updated: existing tests retargeted to `.claude.json` |

## Test Plan

- [x] `TestRegisterMCPGlobalTargetsClaudeJSON` fails before fix, passes after
- [x] `TestRegisterMCPGlobalRemovesLegacySettingsEntry` — legacy `theme` key preserved, `rimba` removed
- [x] `TestRegisterMCPGlobalPropagatesPrimaryError` — parse error on `~/.claude.json` propagates
- [x] `make lint` — 0 issues
- [x] `make test` — 2123 passed, coverage 97.4% (≥ 97% threshold)
- [ ] After `rimba init -g` + session restart, `claude mcp list` shows rimba ✔ and `mcp__rimba__status` responds

Issue: N/A — diagnosed live during MCP connectivity check.