### PR TITLE
[fix] add: recovery hint when ListWorktrees fails post-create (#278)

### DIFF
--- a/internal/operations/post_create.go
+++ b/internal/operations/post_create.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/deps"
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/fileutil"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/progress"
@@ -46,7 +47,10 @@ func PostCreateSetup(ctx context.Context, r git.Runner, params PostCreateParams,
 	progress.Notify(onProgress, "Copying files...")
 	copied, skippedSymlinks, err := fileutil.CopyEntries(params.RepoRoot, params.WtPath, params.CopyFiles)
 	if err != nil {
-		return result, fmt.Errorf("failed to copy files: %w\nTo retry, manually copy files to: %s\nTo remove the worktree: rimba remove %s", err, params.WtPath, params.Task)
+		return result, errhint.WithFix(
+			fmt.Errorf("failed to copy files: %w\nTo retry, manually copy files to: %s", err, params.WtPath),
+			"rimba remove "+params.Task,
+		)
 	}
 	result.Copied = copied
 	result.Skipped = fileutil.SkippedEntries(params.CopyFiles, copied)
@@ -57,7 +61,10 @@ func PostCreateSetup(ctx context.Context, r git.Runner, params PostCreateParams,
 		progress.Notify(onProgress, "Installing dependencies...")
 		wtEntries, err := git.ListWorktrees(ctx, r)
 		if err != nil {
-			return result, fmt.Errorf("failed to list worktrees for dependency setup: %w", err)
+			return result, errhint.WithFix(
+				fmt.Errorf("failed to list worktrees for dependency setup: %w", err),
+				"rimba remove "+params.Task,
+			)
 		}
 
 		dp := DepsParams{

--- a/internal/operations/post_create_test.go
+++ b/internal/operations/post_create_test.go
@@ -173,6 +173,10 @@ func TestPostCreateSetupCopyFilesErrorIncludesRecoveryHint(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if os.Getuid() == 0 {
+		t.Skip("chmod 000 is ineffective for root; skipping")
+	}
+
 	// Create a file then revoke read permissions to force a copy error.
 	envPath := filepath.Join(tmpDir, ".env")
 	if err := os.WriteFile(envPath, []byte("SECRET=1"), 0o600); err != nil {
@@ -201,6 +205,9 @@ func TestPostCreateSetupCopyFilesErrorIncludesRecoveryHint(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to copy files") {
 		t.Errorf("error = %q, want to contain 'failed to copy files'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "To retry, manually copy files to:") {
+		t.Errorf("error = %q, want 'To retry, manually copy files to:' context", err.Error())
 	}
 	if !strings.Contains(err.Error(), "To fix: rimba remove test-task") {
 		t.Errorf("error = %q, want recovery hint 'To fix: rimba remove test-task'", err.Error())

--- a/internal/operations/post_create_test.go
+++ b/internal/operations/post_create_test.go
@@ -166,6 +166,47 @@ func TestPostCreateSetupProgressCallbacks(t *testing.T) {
 	}
 }
 
+func TestPostCreateSetupCopyFilesErrorIncludesRecoveryHint(t *testing.T) {
+	tmpDir := t.TempDir()
+	wtPath := filepath.Join(tmpDir, "worktree")
+	if err := os.MkdirAll(wtPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a file then revoke read permissions to force a copy error.
+	envPath := filepath.Join(tmpDir, ".env")
+	if err := os.WriteFile(envPath, []byte("SECRET=1"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(envPath, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(envPath, 0o600) })
+
+	r := &mockRunner{
+		run:      func(args ...string) (string, error) { return "", nil },
+		runInDir: noopRunInDir,
+	}
+
+	_, err := PostCreateSetup(context.Background(), r, PostCreateParams{
+		RepoRoot:  tmpDir,
+		WtPath:    wtPath,
+		Task:      "test-task",
+		CopyFiles: []string{".env"},
+		SkipDeps:  true,
+		SkipHooks: true,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error when copying unreadable file")
+	}
+	if !strings.Contains(err.Error(), "failed to copy files") {
+		t.Errorf("error = %q, want to contain 'failed to copy files'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "To fix: rimba remove test-task") {
+		t.Errorf("error = %q, want recovery hint 'To fix: rimba remove test-task'", err.Error())
+	}
+}
+
 func TestPostCreateSetupListWorktreesError(t *testing.T) {
 	tmpDir := t.TempDir()
 	wtPath := filepath.Join(tmpDir, "worktree")
@@ -194,5 +235,8 @@ func TestPostCreateSetupListWorktreesError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to list worktrees") {
 		t.Errorf("error = %q, want to contain 'failed to list worktrees'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "To fix: rimba remove test-task") {
+		t.Errorf("error = %q, want recovery hint 'To fix: rimba remove test-task'", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary
- Normalize both failure paths in `PostCreateSetup` (`internal/operations/post_create.go`) to emit a uniform `To fix: rimba remove <task>` recovery hint via `errhint.WithFix`
- Copy-files path: preserves the rich "To retry, manually copy files to: …" context and now uses `errhint.WithFix` for the cleanup hint (was inline `\nTo remove the worktree:`)
- ListWorktrees path: was a bare `fmt.Errorf` with no recovery guidance; now wrapped with `errhint.WithFix`
- Fixes all three entry points (`add`, `duplicate`, `restore`) as they share `PostCreateSetup`
- Adds symmetric unit assertions for both error paths (chmod-based copy failure + mock ListWorktrees failure)

## Test Plan
- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

## Issue

Closes #278