### PR TITLE
[chore] Apply errhint.WithFix in internal/mcp/ tool handlers (#271)

### DIFF
--- a/internal/mcp/errhint_test.go
+++ b/internal/mcp/errhint_test.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/lugassawan/rimba/internal/errhint"
+)
+
+// TestInlineValidationHints verifies that every MCP handler returns a "To fix:" hint
+// when its own inline validation fires (before any git runner call).
+func TestInlineValidationHints(t *testing.T) {
+	hctx := testContext(&mockRunner{})
+
+	tests := []struct {
+		name    string
+		handler func(ctx context.Context, req mcplib.CallToolRequest) (*mcplib.CallToolResult, error)
+		args    map[string]any
+		wantErr string
+	}{
+		{
+			name:    "add: task is required",
+			handler: handleAdd(hctx),
+			args:    nil,
+			wantErr: "task is required",
+		},
+		{
+			name:    "add: invalid type",
+			handler: handleAdd(hctx),
+			args:    map[string]any{"task": "foo", "type": "invalid-xyz"},
+			wantErr: "invalid type",
+		},
+		{
+			name:    "clean: mode is required",
+			handler: handleClean(hctx),
+			args:    nil,
+			wantErr: "mode is required",
+		},
+		{
+			name:    "clean: invalid mode",
+			handler: handleClean(hctx),
+			args:    map[string]any{"mode": "bogus"},
+			wantErr: "invalid mode",
+		},
+		{
+			name:    "exec: command is required",
+			handler: handleExec(hctx),
+			args:    nil,
+			wantErr: "command is required",
+		},
+		{
+			name:    "exec: provide all or type",
+			handler: handleExec(hctx),
+			args:    map[string]any{"command": "echo hi"},
+			wantErr: "provide all=true or type",
+		},
+		{
+			name:    "exec: invalid type",
+			handler: handleExec(hctx),
+			args:    map[string]any{"command": "echo hi", "type": "invalid-xyz"},
+			wantErr: "invalid type",
+		},
+		{
+			name:    "list: invalid type",
+			handler: handleList(hctx),
+			args:    map[string]any{"type": "invalid-xyz"},
+			wantErr: "invalid type",
+		},
+		{
+			name:    "merge: source is required",
+			handler: handleMerge(hctx),
+			args:    nil,
+			wantErr: "source is required",
+		},
+		{
+			name:    "remove: task is required",
+			handler: handleRemove(hctx),
+			args:    nil,
+			wantErr: "task is required",
+		},
+		{
+			name:    "sync: provide task or all",
+			handler: handleSync(hctx),
+			args:    nil,
+			wantErr: "provide a task name or set all=true",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := callTool(t, tc.handler, tc.args)
+			errText := resultError(t, result)
+			if !strings.Contains(errText, "To fix:") {
+				t.Errorf("expected 'To fix:' hint in error, got: %q", errText)
+			}
+			if !strings.Contains(errText, tc.wantErr) {
+				t.Errorf("expected %q in error text, got: %q", tc.wantErr, errText)
+			}
+		})
+	}
+}
+
+// TestSyncWorktreeNotFoundHint verifies that the "worktree not found" path in sync
+// carries a "To fix:" hint. Requires a runner that provides a real worktree list.
+func TestSyncWorktreeNotFoundHint(t *testing.T) {
+	porcelain := worktreePorcelain(
+		struct{ path, branch string }{"/repo", "main"},
+	)
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) > 0 && args[0] == gitFetch {
+				return "", nil
+			}
+			return porcelain, nil
+		},
+	}
+	hctx := testContext(r)
+	handler := handleSync(hctx)
+
+	result := callTool(t, handler, map[string]any{"task": "nonexistent"})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "To fix:") {
+		t.Errorf("expected 'To fix:' hint in error, got: %q", errText)
+	}
+	if !strings.Contains(errText, "nonexistent") {
+		t.Errorf("expected task name in error, got: %q", errText)
+	}
+}
+
+// TestPassThroughHintPreserved verifies that operation-layer errors already carrying
+// an errhint "To fix:" suffix are not stripped when routed through errorResult.
+func TestPassThroughHintPreserved(t *testing.T) {
+	hintedErr := errhint.WithFix(errors.New("worktree list failed"), "run git worktree prune to repair refs")
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			return "", hintedErr
+		},
+	}
+	hctx := testContext(r)
+	handler := handleRemove(hctx)
+
+	result := callTool(t, handler, map[string]any{"task": "my-task"})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "To fix:") {
+		t.Errorf("expected pass-through 'To fix:' hint to be preserved, got: %q", errText)
+	}
+	if !strings.Contains(errText, "git worktree prune") {
+		t.Errorf("expected hint text to be preserved, got: %q", errText)
+	}
+}

--- a/internal/mcp/result.go
+++ b/internal/mcp/result.go
@@ -1,0 +1,9 @@
+package mcp
+
+import "github.com/mark3labs/mcp-go/mcp"
+
+// errorResult builds an MCP error result from err. When err carries an
+// errhint "To fix:" hint, it is already part of err.Error() and surfaces inline.
+func errorResult(err error) *mcp.CallToolResult {
+	return mcp.NewToolResultError(err.Error())
+}

--- a/internal/mcp/tool_add.go
+++ b/internal/mcp/tool_add.go
@@ -2,10 +2,12 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/resolver"
 	"github.com/lugassawan/rimba/internal/trust"
@@ -41,7 +43,8 @@ func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		task := req.GetString("task", "")
 		if task == "" {
-			return mcp.NewToolResultError("task is required"), nil
+			return errorResult(errhint.WithFix(errors.New("task is required"),
+				`provide the task argument, e.g. add { task: "my-feature" }`)), nil
 		}
 
 		service, task := operations.ResolveTaskInput(task, hctx.RepoRoot)
@@ -50,15 +53,18 @@ func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		cfg, cfgErr := hctx.requireConfig()
 		if cfgErr != nil {
-			return mcp.NewToolResultError(cfgErr.Error()), nil
+			return errorResult(cfgErr), nil
 		}
 
 		if err := trust.GateNonInteractive(hctx.RepoRoot, cfg); err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		if !resolver.ValidPrefixType(prefixType) {
-			return mcp.NewToolResultError(fmt.Sprintf("invalid type %q; valid types: feature, bugfix, hotfix, docs, test, chore", prefixType)), nil
+			return errorResult(errhint.WithFix(
+				fmt.Errorf("invalid type %q", prefixType),
+				"use one of: feature, bugfix, hotfix, docs, test, chore (or omit to default to feature)",
+			)), nil
 		}
 
 		prefix, _ := resolver.PrefixString(resolver.PrefixType(prefixType))
@@ -91,7 +97,7 @@ func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 			},
 		}, nil)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		return marshalResult(addResult{

--- a/internal/mcp/tool_clean.go
+++ b/internal/mcp/tool_clean.go
@@ -2,8 +2,10 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -35,7 +37,8 @@ func handleClean(hctx *HandlerContext) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		mode := req.GetString("mode", "")
 		if mode == "" {
-			return mcp.NewToolResultError("mode is required"), nil
+			return errorResult(errhint.WithFix(errors.New("mode is required"),
+				"set mode to one of: prune, merged, stale")), nil
 		}
 
 		dryRun := req.GetBool("dry_run", false)
@@ -52,7 +55,10 @@ func handleClean(hctx *HandlerContext) server.ToolHandlerFunc {
 		case "stale":
 			return mcpCleanStale(ctx, r, hctx, dryRun, staleDays, force)
 		default:
-			return mcp.NewToolResultError(fmt.Sprintf("invalid mode %q; use prune, merged, or stale", mode)), nil
+			return errorResult(errhint.WithFix(
+				fmt.Errorf("invalid mode %q", mode),
+				"use mode: prune, merged, or stale",
+			)), nil
 		}
 	}
 }
@@ -60,7 +66,7 @@ func handleClean(hctx *HandlerContext) server.ToolHandlerFunc {
 func mcpCleanPrune(ctx context.Context, r git.Runner, dryRun bool) (*mcp.CallToolResult, error) {
 	output, err := git.Prune(ctx, r, dryRun)
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return errorResult(err), nil
 	}
 
 	var remotePruned []string
@@ -89,20 +95,20 @@ func mcpCleanPrune(ctx context.Context, r git.Runner, dryRun bool) (*mcp.CallToo
 func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dryRun bool, force bool) (*mcp.CallToolResult, error) {
 	mainBranch, err := operations.ResolveMainBranch(ctx, r, configDefault(hctx))
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return errorResult(err), nil
 	}
 
 	// Fetch latest (non-fatal; cancellation propagated as a tool error)
 	mergeRef := mainBranch
 	if fetchWarn, fetchErr := mcpFetchNonFatal(ctx, r, git.FetchArgs{Prune: true}); fetchErr != nil {
-		return mcp.NewToolResultError(fetchErr.Error()), nil
+		return errorResult(fetchErr), nil
 	} else if fetchWarn == "" {
 		mergeRef = git.DefaultRemote + "/" + mainBranch
 	}
 
 	mergedResult, err := operations.FindMergedCandidates(ctx, r, mergeRef, mainBranch)
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return errorResult(err), nil
 	}
 
 	if len(mergedResult.Candidates) == 0 || dryRun {
@@ -140,12 +146,12 @@ func mcpCleanMerged(ctx context.Context, r git.Runner, hctx *HandlerContext, dry
 func mcpCleanStale(ctx context.Context, r git.Runner, hctx *HandlerContext, dryRun bool, staleDays int, force bool) (*mcp.CallToolResult, error) {
 	mainBranch, err := operations.ResolveMainBranch(ctx, r, configDefault(hctx))
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return errorResult(err), nil
 	}
 
 	staleResult, err := operations.FindStaleCandidates(ctx, r, mainBranch, staleDays)
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return errorResult(err), nil
 	}
 
 	if len(staleResult.Candidates) == 0 || dryRun {

--- a/internal/mcp/tool_conflict.go
+++ b/internal/mcp/tool_conflict.go
@@ -26,14 +26,14 @@ func handleConflictCheck(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		cfg, err := hctx.requireConfig()
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		r := hctx.Runner
 
 		worktrees, err := operations.ListWorktreeInfos(ctx, r)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		prefixes := resolver.AllPrefixes()
@@ -48,7 +48,7 @@ func handleConflictCheck(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		diffs, err := conflict.CollectDiffs(ctx, r, cfg.DefaultSource, eligible)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		result := conflict.DetectOverlaps(diffs)
@@ -62,7 +62,7 @@ func handleConflictCheck(hctx *HandlerContext) server.ToolHandlerFunc {
 		if dryMerge {
 			dryResults, err := conflict.DryMergeAll(ctx, r, eligible)
 			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
+				return errorResult(err), nil
 			}
 			data.DryMerges = processDryMerges(dryResults)
 		}

--- a/internal/mcp/tool_exec.go
+++ b/internal/mcp/tool_exec.go
@@ -2,10 +2,12 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/executor"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
@@ -52,7 +54,8 @@ func handleExec(hctx *HandlerContext) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		command := req.GetString("command", "")
 		if command == "" {
-			return mcp.NewToolResultError("command is required"), nil
+			return errorResult(errhint.WithFix(errors.New("command is required"),
+				`provide the command argument, e.g. exec { command: "npm test", all: true }`)), nil
 		}
 
 		all := req.GetBool("all", false)
@@ -63,20 +66,24 @@ func handleExec(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		cfg, cfgErr := hctx.requireConfig()
 		if cfgErr != nil {
-			return mcp.NewToolResultError(cfgErr.Error()), nil
+			return errorResult(cfgErr), nil
 		}
 
 		if !all && typeFilter == "" {
-			return mcp.NewToolResultError("provide all=true or type to select worktrees"), nil
+			return errorResult(errhint.WithFix(errors.New("provide all=true or type to select worktrees"),
+				"set all=true to target every worktree, or pass type=<prefix>")), nil
 		}
 
 		if typeFilter != "" && !resolver.ValidPrefixType(typeFilter) {
-			return mcp.NewToolResultError(fmt.Sprintf("invalid type %q; valid types: feature, bugfix, hotfix, docs, test, chore", typeFilter)), nil
+			return errorResult(errhint.WithFix(
+				fmt.Errorf("invalid type %q", typeFilter),
+				"use one of: feature, bugfix, hotfix, docs, test, chore",
+			)), nil
 		}
 
 		filtered, err := resolveExecTargets(ctx, hctx.Runner, cfg, typeFilter, dirty)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		if len(filtered) == 0 {

--- a/internal/mcp/tool_list.go
+++ b/internal/mcp/tool_list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -48,11 +49,14 @@ func handleList(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		cfg, err := hctx.requireConfig()
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		if typeFilter != "" && !resolver.ValidPrefixType(typeFilter) {
-			return mcp.NewToolResultError(fmt.Sprintf("invalid type %q; valid types: feature, bugfix, hotfix, docs, test, chore", typeFilter)), nil
+			return errorResult(errhint.WithFix(
+				fmt.Errorf("invalid type %q", typeFilter),
+				"use one of: feature, bugfix, hotfix, docs, test, chore",
+			)), nil
 		}
 
 		res, err := operations.ListWorktrees(ctx, r, nil, operations.ListWorktreesRequest{
@@ -62,7 +66,7 @@ func handleList(hctx *HandlerContext) server.ToolHandlerFunc {
 			WorktreeDir: filepath.Join(hctx.RepoRoot, cfg.WorktreeDir),
 		})
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		return marshalResult(detailsToListItems(res.Rows))
@@ -87,12 +91,12 @@ func detailsToListItems(rows []resolver.WorktreeDetail) []listItem {
 func handleListArchived(ctx context.Context, r git.Runner, hctx *HandlerContext) (*mcp.CallToolResult, error) {
 	mainBranch, err := operations.ResolveMainBranch(ctx, r, configDefault(hctx))
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return errorResult(err), nil
 	}
 
 	archived, err := operations.ListArchivedBranches(ctx, r, mainBranch)
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return errorResult(err), nil
 	}
 
 	prefixes := resolver.AllPrefixes()
@@ -115,7 +119,7 @@ func configDefault(hctx *HandlerContext) string {
 func marshalResult(data any) (*mcp.CallToolResult, error) {
 	b, err := json.Marshal(data)
 	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil
+		return errorResult(fmt.Errorf("failed to marshal result: %w", err)), nil
 	}
 	return mcp.NewToolResultText(string(b)), nil
 }

--- a/internal/mcp/tool_merge.go
+++ b/internal/mcp/tool_merge.go
@@ -2,7 +2,9 @@ package mcp
 
 import (
 	"context"
+	"errors"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -35,7 +37,8 @@ func handleMerge(hctx *HandlerContext) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		sourceTask := req.GetString("source", "")
 		if sourceTask == "" {
-			return mcp.NewToolResultError("source is required"), nil
+			return errorResult(errhint.WithFix(errors.New("source is required"),
+				`provide the source argument, e.g. merge { source: "my-feature" }`)), nil
 		}
 
 		sourceService, sourceTask := operations.ResolveTaskInput(sourceTask, hctx.RepoRoot)
@@ -48,7 +51,7 @@ func handleMerge(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		cfg, cfgErr := hctx.requireConfig()
 		if cfgErr != nil {
-			return mcp.NewToolResultError(cfgErr.Error()), nil
+			return errorResult(cfgErr), nil
 		}
 
 		result, err := operations.MergeWorktree(ctx, hctx.Runner, operations.MergeParams{
@@ -63,7 +66,7 @@ func handleMerge(hctx *HandlerContext) server.ToolHandlerFunc {
 			Delete:        req.GetBool("delete", false),
 		}, nil)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		return marshalResult(mergeResult{

--- a/internal/mcp/tool_remove.go
+++ b/internal/mcp/tool_remove.go
@@ -2,7 +2,9 @@ package mcp
 
 import (
 	"context"
+	"errors"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -29,7 +31,8 @@ func handleRemove(hctx *HandlerContext) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		task := req.GetString("task", "")
 		if task == "" {
-			return mcp.NewToolResultError("task is required"), nil
+			return errorResult(errhint.WithFix(errors.New("task is required"),
+				`provide the task argument, e.g. remove { task: "my-task" }`)), nil
 		}
 
 		service, task := operations.ResolveTaskInput(task, hctx.RepoRoot)
@@ -41,12 +44,12 @@ func handleRemove(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		wt, findErr := operations.FindWorktree(ctx, r, service, task)
 		if findErr != nil {
-			return mcp.NewToolResultError(findErr.Error()), nil
+			return errorResult(findErr), nil
 		}
 
 		result, err := operations.RemoveWorktree(ctx, r, wt, task, keepBranch, force, nil)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		return marshalResult(removeResult{

--- a/internal/mcp/tool_status.go
+++ b/internal/mcp/tool_status.go
@@ -37,12 +37,12 @@ func handleStatus(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		mainBranch, err := operations.ResolveMainBranch(ctx, r, configDefault(hctx))
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		entries, err := git.ListWorktrees(ctx, r)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		candidates := git.FilterEntries(entries, mainBranch)

--- a/internal/mcp/tool_sync.go
+++ b/internal/mcp/tool_sync.go
@@ -3,7 +3,9 @@ package mcp
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/parallel"
@@ -52,11 +54,12 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 
 		cfg, cfgErr := hctx.requireConfig()
 		if cfgErr != nil {
-			return mcp.NewToolResultError(cfgErr.Error()), nil
+			return errorResult(cfgErr), nil
 		}
 
 		if !all && task == "" {
-			return mcp.NewToolResultError("provide a task name or set all=true to sync all worktrees"), nil
+			return errorResult(errhint.WithFix(errors.New("provide a task name or set all=true to sync all worktrees"),
+				"pass a task name, or set all=true to sync every worktree")), nil
 		}
 
 		var service string
@@ -69,12 +72,12 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 		// Fetch (non-fatal; cancellation propagated as a tool error)
 		fetchWarning, fetchErr := mcpFetchNonFatal(ctx, r, git.FetchArgs{})
 		if fetchErr != nil {
-			return mcp.NewToolResultError(fetchErr.Error()), nil
+			return errorResult(fetchErr), nil
 		}
 
 		worktrees, err := operations.ListWorktreeInfos(ctx, r)
 		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+			return errorResult(err), nil
 		}
 
 		prefixes := resolver.AllPrefixes()
@@ -95,7 +98,10 @@ func handleSync(hctx *HandlerContext) server.ToolHandlerFunc {
 func syncSingle(ctx context.Context, r git.Runner, service, task string, worktrees []resolver.WorktreeInfo, prefixes []string, opts syncOpts) (*mcp.CallToolResult, error) {
 	wt, found := resolver.FindBranchForTask(service, task, worktrees, prefixes)
 	if !found {
-		return mcp.NewToolResultError("worktree not found for task \"" + task + "\""), nil
+		return errorResult(errhint.WithFix(
+			fmt.Errorf("worktree not found for task %q", task),
+			"run the list tool to see available tasks",
+		)), nil
 	}
 
 	sr := operations.SyncWorktree(ctx, r, opts.mainBranch, wt, opts.useMerge, opts.push)


### PR DESCRIPTION
## Summary

- Add `errorResult(err)` helper in new `result.go` as the single chokepoint for all MCP error results — no more direct `mcp.NewToolResultError` calls outside this file
- Wrap all 12 inline validation errors across 7 handler files with `errhint.WithFix`, providing agents actionable "To fix:" hints for every user-facing validation (required fields, invalid type/mode, missing all-or-type selector, worktree not found)
- Route all pass-through operation errors through `errorResult` — hints already embedded by the operations layer are preserved unchanged
- New `errhint_test.go`: 13 tests (11 table-driven inline validations + `TestSyncWorktreeNotFoundHint` + `TestPassThroughHintPreserved`)

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)

Coverage: 97.3% (threshold: 97%). gocyclo unaffected (helper is 1 line; table test bodies are flat).

## Issue

Closes #271