### PR TITLE
[feat] MCP add tool: pr/branch parity with the CLI

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/git"
 	mcppkg "github.com/lugassawan/rimba/internal/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -40,6 +41,7 @@ rimba commands with structured parameters and typed responses.`,
 
 		hctx := &mcppkg.HandlerContext{
 			Runner:   r,
+			GH:       gh.Default(),
 			Config:   cfg,
 			RepoRoot: repoRoot,
 			Version:  version,

--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"github.com/lugassawan/rimba/internal/config"
+	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/git"
 )
 
@@ -9,6 +10,7 @@ import (
 // Created once in cmd/mcp.go, captured by handler closures.
 type HandlerContext struct {
 	Runner   git.Runner
+	GH       gh.Runner      // nil for non-PR tools; set to gh.Default() in production
 	Config   *config.Config // may be nil if not in a rimba-initialized repo
 	RepoRoot string
 	Version  string

--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -10,7 +10,7 @@ import (
 // Created once in cmd/mcp.go, captured by handler closures.
 type HandlerContext struct {
 	Runner   git.Runner
-	GH       gh.Runner      // nil for non-PR tools; set to gh.Default() in production
+	GH       gh.Runner      // nil unless PR operations are in scope; set to gh.Default() in production
 	Config   *config.Config // may be nil if not in a rimba-initialized repo
 	RepoRoot string
 	Version  string

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -19,9 +19,19 @@ const (
 	gitStatus      = "status"
 	gitList        = "list"
 	gitWorktreeAdd = "add"
+	flagVerify     = "--verify"
 	revListEven    = "0\t0"
 	dirtyOutput    = " M dirty.go\n"
 )
+
+// mockGhRunner implements gh.Runner for MCP unit tests.
+type mockGhRunner struct {
+	run func(ctx context.Context, args ...string) ([]byte, error)
+}
+
+func (m *mockGhRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	return m.run(ctx, args...)
+}
 
 // mockRunner implements git.Runner for unit tests.
 type mockRunner struct {
@@ -41,6 +51,19 @@ func (m *mockRunner) RunInDir(_ context.Context, dir string, args ...string) (st
 		return "", nil
 	}
 	return m.runInDir(dir, args...)
+}
+
+// newGhAuthOK returns a mockGhRunner that answers auth → "Logged in" and
+// all other calls with prJSON.
+func newGhAuthOK(prJSON string) *mockGhRunner {
+	return &mockGhRunner{
+		run: func(_ context.Context, args ...string) ([]byte, error) {
+			if len(args) > 0 && args[0] == "auth" {
+				return []byte("Logged in"), nil
+			}
+			return []byte(prJSON), nil
+		},
+	}
 }
 
 // testConfig returns a minimal config suitable for testing.

--- a/internal/mcp/tool_add.go
+++ b/internal/mcp/tool_add.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/errhint"
@@ -17,10 +18,15 @@ import (
 
 func registerAddTool(s *server.MCPServer, hctx *HandlerContext) {
 	tool := mcp.NewTool("add",
-		mcp.WithDescription("Create a new worktree for a task (supports 'service/task' for monorepo)"),
+		mcp.WithDescription("Create a new worktree for a task, a GitHub PR review, or promote an existing local branch"),
 		mcp.WithString("task",
-			mcp.Description("Task identifier (e.g. 'my-feature', 'JIRA-123', or 'auth-api/my-feature' for monorepo)"),
-			mcp.Required(),
+			mcp.Description("Task identifier (e.g. 'my-feature', 'JIRA-123', or 'auth-api/my-feature' for monorepo); required for normal add, optional as PR name override when pr is set"),
+		),
+		mcp.WithString("pr",
+			mcp.Description("GitHub PR number to open a review worktree from (branch review/<num>-<slug>); requires gh authenticated"),
+		),
+		mcp.WithString("branch",
+			mcp.Description("Existing, currently checked-out local branch to promote into its own worktree (stash-transfers dirty state)"),
 		),
 		mcp.WithString("type",
 			mcp.Description("Prefix type (default: feature)"),
@@ -41,70 +47,147 @@ func registerAddTool(s *server.MCPServer, hctx *HandlerContext) {
 
 func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		task := req.GetString("task", "")
-		if task == "" {
-			return errorResult(errhint.WithFix(errors.New("task is required"),
-				`provide the task argument, e.g. add { task: "my-feature" }`)), nil
-		}
+		prStr := req.GetString("pr", "")
+		branch := req.GetString("branch", "")
 
-		service, task := operations.ResolveTaskInput(task, hctx.RepoRoot)
-
-		prefixType := req.GetString("type", "feature")
-
-		cfg, cfgErr := hctx.requireConfig()
-		if cfgErr != nil {
-			return errorResult(cfgErr), nil
-		}
-
-		if err := trust.GateNonInteractive(hctx.RepoRoot, cfg); err != nil {
-			return errorResult(err), nil
-		}
-
-		if !resolver.ValidPrefixType(prefixType) {
+		if prStr != "" && branch != "" {
 			return errorResult(errhint.WithFix(
-				fmt.Errorf("invalid type %q", prefixType),
-				"use one of: feature, bugfix, hotfix, docs, test, chore (or omit to default to feature)",
+				errors.New("pr and branch are mutually exclusive"),
+				"provide either pr or branch, not both",
 			)), nil
 		}
 
-		prefix, _ := resolver.PrefixString(resolver.PrefixType(prefixType))
-
-		source := req.GetString("source", "")
-		if source == "" {
-			source = cfg.DefaultSource
+		switch {
+		case prStr != "":
+			return handleAddPR(ctx, hctx, req, prStr)
+		case branch != "":
+			return handleAddBranch(ctx, hctx, req, branch)
+		default:
+			return handleAddTask(ctx, hctx, req)
 		}
+	}
+}
 
-		var configModules []config.ModuleConfig
-		if cfg.Deps != nil {
-			configModules = cfg.Deps.Modules
-		}
+func handleAddTask(ctx context.Context, hctx *HandlerContext, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	task := req.GetString("task", "")
+	if task == "" {
+		return errorResult(errhint.WithFix(errors.New("task is required"),
+			`provide the task argument, e.g. add { task: "my-feature" }`)), nil
+	}
 
-		result, err := operations.AddWorktree(ctx, hctx.Runner, operations.AddParams{
-			Task:    task,
-			Service: service,
-			Prefix:  prefix,
-			Source:  source,
-			PostCreateOptions: operations.PostCreateOptions{
-				RepoRoot:      hctx.RepoRoot,
-				WorktreeDir:   filepath.Join(hctx.RepoRoot, cfg.WorktreeDir),
-				CopyFiles:     cfg.CopyFiles,
-				SkipDeps:      req.GetBool("skip_deps", false),
-				AutoDetect:    cfg.IsAutoDetectDeps(),
-				ConfigModules: configModules,
-				SkipHooks:     req.GetBool("skip_hooks", false),
-				PostCreate:    cfg.PostCreate,
-				Concurrency:   cfg.DepsConcurrency(),
-			},
-		}, nil)
-		if err != nil {
-			return errorResult(err), nil
-		}
+	service, task := operations.ResolveTaskInput(task, hctx.RepoRoot)
 
-		return marshalResult(addResult{
-			Task:   result.Task,
-			Branch: result.Branch,
-			Path:   result.Path,
-			Source: result.Source,
-		})
+	prefixType := req.GetString("type", "feature")
+
+	cfg, cfgErr := hctx.requireConfig()
+	if cfgErr != nil {
+		return errorResult(cfgErr), nil
+	}
+
+	if err := trust.GateNonInteractive(hctx.RepoRoot, cfg); err != nil {
+		return errorResult(err), nil
+	}
+
+	if !resolver.ValidPrefixType(prefixType) {
+		return errorResult(errhint.WithFix(
+			fmt.Errorf("invalid type %q", prefixType),
+			"use one of: feature, bugfix, hotfix, docs, test, chore (or omit to default to feature)",
+		)), nil
+	}
+
+	prefix, _ := resolver.PrefixString(resolver.PrefixType(prefixType))
+
+	source := req.GetString("source", "")
+	if source == "" {
+		source = cfg.DefaultSource
+	}
+
+	result, err := operations.AddWorktree(ctx, hctx.Runner, operations.AddParams{
+		Task:              task,
+		Service:           service,
+		Prefix:            prefix,
+		Source:            source,
+		PostCreateOptions: buildPostCreateOptions(hctx, cfg, req),
+	}, nil)
+	if err != nil {
+		return errorResult(err), nil
+	}
+
+	return marshalResult(addResult{
+		Task:   result.Task,
+		Branch: result.Branch,
+		Path:   result.Path,
+		Source: result.Source,
+	})
+}
+
+func handleAddPR(ctx context.Context, hctx *HandlerContext, req mcp.CallToolRequest, prStr string) (*mcp.CallToolResult, error) {
+	prNum, _ := strconv.Atoi(prStr)
+	if prNum <= 0 {
+		return errorResult(errhint.WithFix(
+			fmt.Errorf("invalid pr number %q", prStr),
+			"provide a positive integer, e.g. add { pr: \"42\" }",
+		)), nil
+	}
+
+	cfg, cfgErr := hctx.requireConfig()
+	if cfgErr != nil {
+		return errorResult(cfgErr), nil
+	}
+
+	if err := trust.GateNonInteractive(hctx.RepoRoot, cfg); err != nil {
+		return errorResult(err), nil
+	}
+
+	result, err := operations.AddPRWorktree(ctx, hctx.Runner, hctx.GH, operations.AddPRParams{
+		PRNumber:          prNum,
+		TaskOverride:      req.GetString("task", ""),
+		PostCreateOptions: buildPostCreateOptions(hctx, cfg, req),
+	}, nil)
+	if err != nil {
+		return errorResult(err), nil
+	}
+
+	return marshalResult(addResult{
+		Task:   result.Task,
+		Branch: result.Branch,
+		Path:   result.Path,
+		Source: result.Source,
+	})
+}
+
+func handleAddBranch(ctx context.Context, hctx *HandlerContext, _ mcp.CallToolRequest, branch string) (*mcp.CallToolResult, error) {
+	cfg, cfgErr := hctx.requireConfig()
+	if cfgErr != nil {
+		return errorResult(cfgErr), nil
+	}
+
+	wtDir := filepath.Join(hctx.RepoRoot, cfg.WorktreeDir)
+	path, err := operations.PromoteBranch(ctx, wtDir, hctx.Runner, hctx.RepoRoot, branch)
+	if err != nil {
+		return errorResult(err), nil
+	}
+
+	return marshalResult(addResult{
+		Branch: branch,
+		Path:   path,
+	})
+}
+
+func buildPostCreateOptions(hctx *HandlerContext, cfg *config.Config, req mcp.CallToolRequest) operations.PostCreateOptions {
+	var configModules []config.ModuleConfig
+	if cfg.Deps != nil {
+		configModules = cfg.Deps.Modules
+	}
+	return operations.PostCreateOptions{
+		RepoRoot:      hctx.RepoRoot,
+		WorktreeDir:   filepath.Join(hctx.RepoRoot, cfg.WorktreeDir),
+		CopyFiles:     cfg.CopyFiles,
+		SkipDeps:      req.GetBool("skip_deps", false),
+		AutoDetect:    cfg.IsAutoDetectDeps(),
+		ConfigModules: configModules,
+		SkipHooks:     req.GetBool("skip_hooks", false),
+		PostCreate:    cfg.PostCreate,
+		Concurrency:   cfg.DepsConcurrency(),
 	}
 }

--- a/internal/mcp/tool_add.go
+++ b/internal/mcp/tool_add.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strconv"
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/errhint"
@@ -22,7 +21,7 @@ func registerAddTool(s *server.MCPServer, hctx *HandlerContext) {
 		mcp.WithString("task",
 			mcp.Description("Task identifier (e.g. 'my-feature', 'JIRA-123', or 'auth-api/my-feature' for monorepo); required for normal add, optional as PR name override when pr is set"),
 		),
-		mcp.WithString("pr",
+		mcp.WithInteger("pr",
 			mcp.Description("GitHub PR number to open a review worktree from (branch review/<num>-<slug>); requires gh authenticated"),
 		),
 		mcp.WithString("branch",
@@ -33,13 +32,13 @@ func registerAddTool(s *server.MCPServer, hctx *HandlerContext) {
 			mcp.Enum("feature", "bugfix", "hotfix", "docs", "test", "chore"),
 		),
 		mcp.WithString("source",
-			mcp.Description("Source branch to create worktree from (default from config)"),
+			mcp.Description("Source branch to create worktree from (default from config); applies to task and pr modes"),
 		),
 		mcp.WithBoolean("skip_deps",
-			mcp.Description("Skip dependency installation"),
+			mcp.Description("Skip dependency installation (applies to task and pr modes)"),
 		),
 		mcp.WithBoolean("skip_hooks",
-			mcp.Description("Skip post-create hooks"),
+			mcp.Description("Skip post-create hooks (applies to task and pr modes)"),
 		),
 	)
 	s.AddTool(tool, handleAdd(hctx))
@@ -47,10 +46,10 @@ func registerAddTool(s *server.MCPServer, hctx *HandlerContext) {
 
 func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		prStr := req.GetString("pr", "")
+		prNum := req.GetInt("pr", 0)
 		branch := req.GetString("branch", "")
 
-		if prStr != "" && branch != "" {
+		if prNum != 0 && branch != "" {
 			return errorResult(errhint.WithFix(
 				errors.New("pr and branch are mutually exclusive"),
 				"provide either pr or branch, not both",
@@ -58,8 +57,8 @@ func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 		}
 
 		switch {
-		case prStr != "":
-			return handleAddPR(ctx, hctx, req, prStr)
+		case prNum != 0:
+			return handleAddPR(ctx, hctx, req, prNum)
 		case branch != "":
 			return handleAddBranch(ctx, hctx, req, branch)
 		default:
@@ -121,12 +120,11 @@ func handleAddTask(ctx context.Context, hctx *HandlerContext, req mcp.CallToolRe
 	})
 }
 
-func handleAddPR(ctx context.Context, hctx *HandlerContext, req mcp.CallToolRequest, prStr string) (*mcp.CallToolResult, error) {
-	prNum, _ := strconv.Atoi(prStr)
+func handleAddPR(ctx context.Context, hctx *HandlerContext, req mcp.CallToolRequest, prNum int) (*mcp.CallToolResult, error) {
 	if prNum <= 0 {
 		return errorResult(errhint.WithFix(
-			fmt.Errorf("invalid pr number %q", prStr),
-			"provide a positive integer, e.g. add { pr: \"42\" }",
+			fmt.Errorf("invalid pr number %d", prNum),
+			"provide a positive integer, e.g. add { \"pr\": 42 }",
 		)), nil
 	}
 
@@ -137,6 +135,10 @@ func handleAddPR(ctx context.Context, hctx *HandlerContext, req mcp.CallToolRequ
 
 	if err := trust.GateNonInteractive(hctx.RepoRoot, cfg); err != nil {
 		return errorResult(err), nil
+	}
+
+	if hctx.GH == nil {
+		return errorResult(errors.New("gh runner not configured; this is a server startup bug")), nil
 	}
 
 	result, err := operations.AddPRWorktree(ctx, hctx.Runner, hctx.GH, operations.AddPRParams{
@@ -162,6 +164,7 @@ func handleAddBranch(ctx context.Context, hctx *HandlerContext, _ mcp.CallToolRe
 		return errorResult(cfgErr), nil
 	}
 
+	// No trust gate: PromoteBranch runs no post-create hooks, matching CLI branch: mode.
 	wtDir := filepath.Join(hctx.RepoRoot, cfg.WorktreeDir)
 	path, err := operations.PromoteBranch(ctx, wtDir, hctx.Runner, hctx.RepoRoot, branch)
 	if err != nil {

--- a/internal/mcp/tool_add.go
+++ b/internal/mcp/tool_add.go
@@ -32,7 +32,7 @@ func registerAddTool(s *server.MCPServer, hctx *HandlerContext) {
 			mcp.Enum("feature", "bugfix", "hotfix", "docs", "test", "chore"),
 		),
 		mcp.WithString("source",
-			mcp.Description("Source branch to create worktree from (default from config); applies to task and pr modes"),
+			mcp.Description("Source branch to create worktree from (default from config); applies to task mode only"),
 		),
 		mcp.WithBoolean("skip_deps",
 			mcp.Description("Skip dependency installation (applies to task and pr modes)"),
@@ -57,10 +57,12 @@ func handleAdd(hctx *HandlerContext) server.ToolHandlerFunc {
 		}
 
 		switch {
+		// prNum != 0 intentionally routes negative values to handleAddPR,
+		// which validates prNum > 0 and returns a clear "invalid pr number" error.
 		case prNum != 0:
 			return handleAddPR(ctx, hctx, req, prNum)
 		case branch != "":
-			return handleAddBranch(ctx, hctx, req, branch)
+			return handleAddBranch(ctx, hctx, branch)
 		default:
 			return handleAddTask(ctx, hctx, req)
 		}
@@ -158,7 +160,7 @@ func handleAddPR(ctx context.Context, hctx *HandlerContext, req mcp.CallToolRequ
 	})
 }
 
-func handleAddBranch(ctx context.Context, hctx *HandlerContext, _ mcp.CallToolRequest, branch string) (*mcp.CallToolResult, error) {
+func handleAddBranch(ctx context.Context, hctx *HandlerContext, branch string) (*mcp.CallToolResult, error) {
 	cfg, cfgErr := hctx.requireConfig()
 	if cfgErr != nil {
 		return errorResult(cfgErr), nil

--- a/internal/mcp/tool_add.go
+++ b/internal/mcp/tool_add.go
@@ -19,7 +19,7 @@ func registerAddTool(s *server.MCPServer, hctx *HandlerContext) {
 	tool := mcp.NewTool("add",
 		mcp.WithDescription("Create a new worktree for a task, a GitHub PR review, or promote an existing local branch"),
 		mcp.WithString("task",
-			mcp.Description("Task identifier (e.g. 'my-feature', 'JIRA-123', or 'auth-api/my-feature' for monorepo); required for normal add, optional as PR name override when pr is set"),
+			mcp.Description("Task identifier (e.g. 'my-feature', 'JIRA-123', or 'auth-api/my-feature' for monorepo); required for normal add, optional as PR name override when pr is set; ignored in branch mode"),
 		),
 		mcp.WithInteger("pr",
 			mcp.Description("GitHub PR number to open a review worktree from (branch review/<num>-<slug>); requires gh authenticated"),

--- a/internal/mcp/tool_add_test.go
+++ b/internal/mcp/tool_add_test.go
@@ -661,7 +661,7 @@ func TestAddPRToolFetchError(t *testing.T) {
 	}
 	handler := handleAdd(hctx)
 
-	result := callTool(t, handler, map[string]any{"pr": "999", "skip_deps": true, "skip_hooks": true})
+	result := callTool(t, handler, map[string]any{"pr": 999, "skip_deps": true, "skip_hooks": true})
 	errText := resultError(t, result)
 	if !strings.Contains(errText, "verify PR number") {
 		t.Errorf("expected 'verify PR number' hint, got: %s", errText)

--- a/internal/mcp/tool_add_test.go
+++ b/internal/mcp/tool_add_test.go
@@ -588,7 +588,13 @@ func TestAddPRToolSuccess(t *testing.T) {
 }
 
 func TestAddPRToolNegativeNumber(t *testing.T) {
-	hctx := testContext(&mockRunner{})
+	hctx := &HandlerContext{
+		Runner:   &mockRunner{},
+		GH:       newGhAuthOK(""),
+		Config:   testConfig(),
+		RepoRoot: "/repo",
+		Version:  "test",
+	}
 	handler := handleAdd(hctx)
 
 	result := callTool(t, handler, map[string]any{"pr": -1})

--- a/internal/mcp/tool_add_test.go
+++ b/internal/mcp/tool_add_test.go
@@ -531,7 +531,7 @@ func TestAddToolPRBranchMutuallyExclusive(t *testing.T) {
 	hctx := testContext(&mockRunner{})
 	handler := handleAdd(hctx)
 
-	result := callTool(t, handler, map[string]any{"pr": "42", "branch": "feature/x"})
+	result := callTool(t, handler, map[string]any{"pr": 42, "branch": "feature/x"})
 	errText := resultError(t, result)
 	if !strings.Contains(errText, "mutually exclusive") {
 		t.Errorf("expected 'mutually exclusive' error, got: %s", errText)
@@ -574,7 +574,7 @@ func TestAddPRToolSuccess(t *testing.T) {
 	handler := handleAdd(hctx)
 
 	result := callTool(t, handler, map[string]any{
-		"pr":         "42",
+		"pr":         42,
 		"skip_deps":  true,
 		"skip_hooks": true,
 	})
@@ -587,25 +587,56 @@ func TestAddPRToolSuccess(t *testing.T) {
 	}
 }
 
-func TestAddPRToolInvalidNumber(t *testing.T) {
+func TestAddPRToolNegativeNumber(t *testing.T) {
 	hctx := testContext(&mockRunner{})
 	handler := handleAdd(hctx)
 
-	result := callTool(t, handler, map[string]any{"pr": "abc"})
+	result := callTool(t, handler, map[string]any{"pr": -1})
 	errText := resultError(t, result)
 	if !strings.Contains(errText, "invalid pr number") {
 		t.Errorf("expected 'invalid pr number' error, got: %s", errText)
 	}
 }
 
-func TestAddPRToolZeroNumber(t *testing.T) {
-	hctx := testContext(&mockRunner{})
+func TestAddPRToolNilGHRunner(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := testConfig()
+	cfg.CopyFiles = nil
+	hctx := &HandlerContext{
+		Runner:   &mockRunner{},
+		GH:       nil, // intentionally unset
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
 	handler := handleAdd(hctx)
 
-	result := callTool(t, handler, map[string]any{"pr": "0"})
+	result := callTool(t, handler, map[string]any{"pr": 42})
 	errText := resultError(t, result)
-	if !strings.Contains(errText, "invalid pr number") {
-		t.Errorf("expected 'invalid pr number' error for 0, got: %s", errText)
+	if !strings.Contains(errText, "server startup bug") {
+		t.Errorf("expected startup bug error for nil GH, got: %s", errText)
+	}
+}
+
+func TestAddPRToolUntrustedRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	prJSON := testutil.LoadFixture(t, "../gh/testdata/same_repo_pr.json")
+	cfg := testConfig()
+	cfg.CopyFiles = nil
+	cfg.PostCreate = []string{"make install"}
+	hctx := &HandlerContext{
+		Runner:   &mockRunner{},
+		GH:       newGhAuthOK(prJSON),
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"pr": 42})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "rimba trust") {
+		t.Errorf("untrusted PR add error should mention 'rimba trust', got: %s", errText)
 	}
 }
 
@@ -653,7 +684,7 @@ func TestAddPRToolTaskOverride(t *testing.T) {
 	handler := handleAdd(hctx)
 
 	result := callTool(t, handler, map[string]any{
-		"pr":         "42",
+		"pr":         42,
 		"task":       "my-review",
 		"skip_deps":  true,
 		"skip_hooks": true,
@@ -755,6 +786,33 @@ func TestAddBranchToolValidationError(t *testing.T) {
 	errText := resultError(t, result)
 	if !strings.Contains(errText, "does not exist") {
 		t.Errorf("expected 'does not exist' error, got: %s", errText)
+	}
+}
+
+func TestAddBranchToolPathAlreadyExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	branch := "feature/promote-me"
+
+	// Pre-create the expected worktree path so PromoteBranch returns "already exists".
+	wtPath := filepath.Join(tmpDir, ".worktrees", "feature-promote-me")
+	if err := os.MkdirAll(wtPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := testConfig()
+	cfg.CopyFiles = nil
+	hctx := &HandlerContext{
+		Runner:   makePromoteRunner(tmpDir, branch),
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"branch": branch})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "already exists") {
+		t.Errorf("expected 'already exists' error, got: %s", errText)
 	}
 }
 

--- a/internal/mcp/tool_add_test.go
+++ b/internal/mcp/tool_add_test.go
@@ -841,7 +841,7 @@ func TestAddPRToolRequiresConfig(t *testing.T) {
 	}
 	handler := handleAdd(hctx)
 
-	result := callTool(t, handler, map[string]any{"pr": "42"})
+	result := callTool(t, handler, map[string]any{"pr": 42})
 	errText := resultError(t, result)
 	if !strings.Contains(errText, "not initialized") {
 		t.Errorf("expected config error, got: %s", errText)

--- a/internal/mcp/tool_add_test.go
+++ b/internal/mcp/tool_add_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/lugassawan/rimba/internal/trust"
+	"github.com/lugassawan/rimba/testutil"
 )
 
 const (
@@ -520,5 +522,270 @@ func TestAddToolTrustGateEnvEscapeHatch(t *testing.T) {
 	data := unmarshalJSON[addResult](t, result)
 	if data.Task != "env-bypass" {
 		t.Errorf("RIMBA_TRUST_YES add should succeed, task = %q", data.Task)
+	}
+}
+
+// ── Dispatcher guard ─────────────────────────────────────────────────────────
+
+func TestAddToolPRBranchMutuallyExclusive(t *testing.T) {
+	hctx := testContext(&mockRunner{})
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"pr": "42", "branch": "feature/x"})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "mutually exclusive") {
+		t.Errorf("expected 'mutually exclusive' error, got: %s", errText)
+	}
+}
+
+// ── PR mode ──────────────────────────────────────────────────────────────────
+
+// makePRGitRunner returns a mockRunner for the happy-path PR add.
+// It simulates: fetch succeeds, BranchExists=false, worktree add succeeds.
+func makePRGitRunner() *mockRunner {
+	return &mockRunner{
+		run: func(args ...string) (string, error) {
+			switch {
+			case len(args) > 0 && args[0] == "fetch":
+				return "", nil
+			case len(args) > 1 && args[0] == gitRevParse && args[1] == flagVerify:
+				return "", errors.New("not found") // branch doesn't exist
+			case len(args) > 1 && args[0] == gitWorktree && args[1] == gitWorktreeAdd:
+				return "", nil
+			}
+			return "", nil
+		},
+	}
+}
+
+func TestAddPRToolSuccess(t *testing.T) {
+	prJSON := testutil.LoadFixture(t, "../gh/testdata/same_repo_pr.json")
+	tmpDir := t.TempDir()
+
+	cfg := testConfig()
+	cfg.CopyFiles = nil
+	hctx := &HandlerContext{
+		Runner:   makePRGitRunner(),
+		GH:       newGhAuthOK(prJSON),
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{
+		"pr":         "42",
+		"skip_deps":  true,
+		"skip_hooks": true,
+	})
+	data := unmarshalJSON[addResult](t, result)
+	if data.Branch != "review/42-fix-login-redirect" {
+		t.Errorf("branch = %q, want %q", data.Branch, "review/42-fix-login-redirect")
+	}
+	if !strings.Contains(data.Path, ".worktrees") {
+		t.Errorf("path = %q, expected to contain worktree dir", data.Path)
+	}
+}
+
+func TestAddPRToolInvalidNumber(t *testing.T) {
+	hctx := testContext(&mockRunner{})
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"pr": "abc"})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "invalid pr number") {
+		t.Errorf("expected 'invalid pr number' error, got: %s", errText)
+	}
+}
+
+func TestAddPRToolZeroNumber(t *testing.T) {
+	hctx := testContext(&mockRunner{})
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"pr": "0"})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "invalid pr number") {
+		t.Errorf("expected 'invalid pr number' error for 0, got: %s", errText)
+	}
+}
+
+func TestAddPRToolFetchError(t *testing.T) {
+	ghR := &mockGhRunner{
+		run: func(_ context.Context, args ...string) ([]byte, error) {
+			if len(args) > 0 && args[0] == "auth" {
+				return []byte("Logged in"), nil
+			}
+			return nil, errors.New("HTTP 404: Not Found")
+		},
+	}
+	tmpDir := t.TempDir()
+	cfg := testConfig()
+	cfg.CopyFiles = nil
+	hctx := &HandlerContext{
+		Runner:   &mockRunner{},
+		GH:       ghR,
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"pr": "999", "skip_deps": true, "skip_hooks": true})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "verify PR number") {
+		t.Errorf("expected 'verify PR number' hint, got: %s", errText)
+	}
+}
+
+func TestAddPRToolTaskOverride(t *testing.T) {
+	prJSON := testutil.LoadFixture(t, "../gh/testdata/same_repo_pr.json")
+	tmpDir := t.TempDir()
+
+	cfg := testConfig()
+	cfg.CopyFiles = nil
+	hctx := &HandlerContext{
+		Runner:   makePRGitRunner(),
+		GH:       newGhAuthOK(prJSON),
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{
+		"pr":         "42",
+		"task":       "my-review",
+		"skip_deps":  true,
+		"skip_hooks": true,
+	})
+	data := unmarshalJSON[addResult](t, result)
+	if data.Branch != "my-review" {
+		t.Errorf("branch with task override = %q, want %q", data.Branch, "my-review")
+	}
+}
+
+// ── Branch promotion mode ─────────────────────────────────────────────────────
+
+// makePromoteRunner returns a mockRunner for the happy-path branch promotion.
+// It simulates: default branch resolves to main, branch exists, not in other
+// worktrees, HEAD is the target branch, working tree clean, checkout and
+// worktree add both succeed.
+// Matching on first arg only keeps cyclomatic complexity well under the 15 limit.
+func makePromoteRunner(repoRoot, branch string) *mockRunner {
+	porcelain := "worktree " + repoRoot + "\nHEAD abc\nbranch refs/heads/main\n\n"
+	return &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) == 0 {
+				return "", nil
+			}
+			switch args[0] {
+			case gitSymbolicRef:
+				return refsOriginMain, nil
+			case gitRevParse:
+				return "", nil // BranchExists → true (nil error)
+			case gitWorktree:
+				return porcelain, nil // covers list --porcelain and add
+			}
+			return "", nil
+		},
+		runInDir: func(_ string, args ...string) (string, error) {
+			if len(args) == 0 {
+				return "", nil
+			}
+			switch args[0] {
+			case gitSymbolicRef:
+				return branch, nil // CurrentBranch via symbolic-ref --short HEAD
+			case gitStatus:
+				return "", nil // IsDirty → clean
+			}
+			return "", nil // Checkout (switch -- main) and anything else
+		},
+	}
+}
+
+func TestAddBranchToolSuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+	branch := "feature/promote-me"
+
+	cfg := testConfig()
+	cfg.CopyFiles = nil
+	hctx := &HandlerContext{
+		Runner:   makePromoteRunner(tmpDir, branch),
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"branch": branch})
+	data := unmarshalJSON[addResult](t, result)
+	if data.Branch != branch {
+		t.Errorf("branch = %q, want %q", data.Branch, branch)
+	}
+	if !strings.Contains(data.Path, ".worktrees") {
+		t.Errorf("path = %q, expected to contain worktree dir", data.Path)
+	}
+}
+
+func TestAddBranchToolValidationError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// BranchExists returns false → validateForPromotion errors with "does not exist"
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			if len(args) >= 1 && args[0] == gitSymbolicRef {
+				return refsOriginMain, nil // DefaultBranch → "main"
+			}
+			if len(args) >= 2 && args[0] == gitRevParse && args[1] == flagVerify {
+				return "", errors.New("not found") // BranchExists → false
+			}
+			return "", nil
+		},
+	}
+	cfg := testConfig()
+	hctx := &HandlerContext{
+		Runner:   r,
+		Config:   cfg,
+		RepoRoot: tmpDir,
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"branch": "feature/no-such"})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "does not exist") {
+		t.Errorf("expected 'does not exist' error, got: %s", errText)
+	}
+}
+
+func TestAddBranchToolRequiresConfig(t *testing.T) {
+	hctx := &HandlerContext{
+		Runner:   &mockRunner{},
+		Config:   nil,
+		RepoRoot: "/repo",
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"branch": "feature/x"})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "not initialized") {
+		t.Errorf("expected config error, got: %s", errText)
+	}
+}
+
+func TestAddPRToolRequiresConfig(t *testing.T) {
+	hctx := &HandlerContext{
+		Runner:   &mockRunner{},
+		Config:   nil,
+		RepoRoot: "/repo",
+		Version:  "test",
+	}
+	handler := handleAdd(hctx)
+
+	result := callTool(t, handler, map[string]any{"pr": "42"})
+	errText := resultError(t, result)
+	if !strings.Contains(errText, "not initialized") {
+		t.Errorf("expected config error, got: %s", errText)
 	}
 }

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -42,10 +42,10 @@ type dryMergeItem struct {
 
 // addResult holds the outcome of a worktree add.
 type addResult struct {
-	Task   string `json:"task"`
+	Task   string `json:"task,omitempty"`
 	Branch string `json:"branch"`
 	Path   string `json:"path"`
-	Source string `json:"source"`
+	Source string `json:"source,omitempty"`
 }
 
 // removeResult holds the outcome of a worktree removal.


### PR DESCRIPTION
## Summary

- Add `pr` (integer) and `branch` (string) fields to the MCP `add` tool so agents can open PR review worktrees and promote local branches without falling back to raw shell commands
- `pr: 42` → fetches PR metadata via `gh`, creates `review/42-<slug>` worktree (delegates to `operations.AddPRWorktree`)
- `branch: "feature/x"` → promotes the currently checked-out branch into its own worktree, stash-transferring dirty state (delegates to `operations.PromoteBranch`)
- `pr` + `branch` together → "mutually exclusive" error; `task` is optional as a PR name override when `pr` is set
- PR mode runs `trust.GateNonInteractive`; branch promotion intentionally does not (mirrors CLI)
- Add `GH gh.Runner` to `HandlerContext`, wired to `gh.Default()` in `cmd/mcp.go`
- Extract `buildPostCreateOptions` shared by task and PR modes to eliminate duplication
- Add `omitempty` to `addResult.Task`/`Source`; branch promotion now returns clean `{"branch":"…","path":"…"}` without empty fields
- Add `TestAddPRTool*`, `TestAddBranchTool*`, mutual-exclusion guard, nil-GH guard, and trust-gate tests

## Test Plan

- [x] Unit tests pass (`make test`) — 2150 tests, 27 packages
- [x] Linter passes (`make lint`) — 0 issues
- [x] E2E tests pass (`make test-e2e`)

## Issue

Closes #268