### PR TITLE
[docs] Split command reference into per-command pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             CHANGED=$(git diff --name-only "origin/${BASE_REF}"...HEAD)
           else
             CHANGED=$(git diff --name-only "${BEFORE_SHA}" HEAD 2>/dev/null \
-              || git diff --name-only HEAD~1 HEAD)
+              || git diff --name-only HEAD~1 HEAD)  # fallback: BEFORE_SHA is "0000..." on first push
           fi
           if echo "$CHANGED" | grep -qvE '^docs/'; then
             echo "go=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,42 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only "origin/${BASE_REF}"...HEAD)
+          else
+            CHANGED=$(git diff --name-only "${BEFORE_SHA}" HEAD 2>/dev/null \
+              || git diff --name-only HEAD~1 HEAD)
+          fi
+          if echo "$CHANGED" | grep -qvE '^docs/'; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
+    needs: [changes]
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -31,6 +55,8 @@ jobs:
       - run: make lint
 
   coverage:
+    needs: [changes]
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -52,6 +78,8 @@ jobs:
           fi
 
   build:
+    needs: [changes]
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -63,6 +91,8 @@ jobs:
       - run: make build
 
   e2e:
+    needs: [changes]
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -74,6 +104,8 @@ jobs:
       - run: make test-e2e
 
   race:
+    needs: [changes]
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -85,6 +117,8 @@ jobs:
       - run: make test-race
 
   build-cross:
+    needs: [changes]
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -100,6 +134,8 @@ jobs:
       - run: CGO_ENABLED=0 GOOS=darwin  GOARCH=arm64 go build ./...
 
   vuln:
+    needs: [changes]
+    if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
 
 permissions:
   contents: read

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,652 +1,111 @@
 ---
 title: Command Reference
 nav_order: 2
+has_children: true
 ---
 
 # Command Reference
 
 > See also: [Configuration](configuration.md)
 
+Browse the full list of rimba commands below. Each command has its own page with synopsis, examples, common workflows, flags, and related commands.
+
 ---
 
 ## Global Flags
 
-These flags are available on every command via the root `rimba` command:
+These flags are available on every command:
 
 | Flag | Description |
 |------|-------------|
 | `--json` | Output in JSON format (supported by `list`, `status`, `deps status`, `conflict-check`, `exec`) |
 | `--no-color` | Disable colored output (also respects `NO_COLOR` env var) |
 | `--debug` | Log git commands and timings to stderr (also respects `RIMBA_DEBUG=1`) |
+| `--yes` | Approve committed shell commands without prompting (see `rimba trust`; also respects `RIMBA_TRUST_YES=1`) |
 
 ---
 
 ## Setup
 
-### rimba init
-
-Initialize rimba in the current repository. Detects the repo root, creates the `.rimba/` config directory with `settings.toml` (team-shared) and `settings.local.toml` (personal overrides), and sets up the worktree directory.
-
-Agent files (`AGENTS.md`, `.github/copilot-instructions.md`, `.cursor/rules/rimba.mdc`, `.claude/skills/rimba/SKILL.md`) are installed at three tiers:
-
-- `--agents` — project-team level (committed to git)
-- `--agents --local` — project-personal level (gitignored)
-- `-g` / `--global` — user level (`~/`) — works outside a git repository
-
-When agent files are installed (`--agents` or `-g`), rimba also registers itself as an MCP server (server name: `rimba`, command: `rimba mcp`) in the corresponding client config files (`.mcp.json`, `.cursor/mcp.json`, `~/.claude.json`, `~/.codex/config.toml`, `~/.gemini/settings.json`, `~/.codeium/windsurf/mcp_config.json`, `~/.roo/mcp.json`). Use `--uninstall` with the same flags to remove.
-
-If `.rimba/` already exists, config creation is skipped but agent files are still installed or updated. If a legacy `.rimba.toml` exists, it is migrated into the new directory layout.
-
-```sh
-rimba init                        # Initialize config and worktree directory
-rimba init --agents               # Also install agent files at project level (committed)
-rimba init --agents --local       # Install agent files gitignored (personal)
-rimba init -g                     # Install agent files at user level (~/)
-rimba init -g --uninstall         # Remove user-level agent files and MCP registration
-rimba init --agents --uninstall   # Remove project-team agent files and MCP registration
-```
-
-{: .warning }
-> - `--local` is not allowed with `-g`.
-> - `--local` without `--agents` errors with: `--local requires --agents`.
-> - `--uninstall` requires `-g` or `--agents`.
-> - `-g` / `--global` and `--agents` are mutually exclusive.
-
-| Flag | Description |
-|------|-------------|
-| `--agents` | Install AI agent instruction files at project level |
-| `-g`, `--global` | Install agent files at user level (`~/`) — works outside a git repo |
-| `--local` | Install agent files gitignored (personal overrides; requires `--agents`) |
-| `--uninstall` | Remove agent files and MCP registration (requires `-g` or `--agents`) |
-| `--personal` | Gitignore the entire `.rimba/` directory instead of the `.rimba/*.local.toml` glob |
+| Command | Description |
+|---------|-------------|
+| [rimba init](commands/init) | Initialize rimba config, worktree directory, and optional AI agent files |
 
 ---
 
 ## Worktree Lifecycle
 
-### rimba add
-
-Create a new worktree with a branch named `<prefix><task>` and copy dotfiles from the repo root. In monorepos, prefix the task with a service directory name to create service-scoped branches. Use `pr:<num>` to create a worktree from a GitHub PR's head branch. Use `branch:<branch>` to promote the currently checked-out branch into its own worktree.
-
-```sh
-rimba add my-feature
-rimba add my-feature --bugfix        # Use bugfix/ prefix instead of feature/
-rimba add my-feature -s develop      # Branch from a different source
-rimba add auth-api/my-feature        # Monorepo: branch auth-api/feature/my-feature
-rimba add auth-api/my-feature --bugfix  # Monorepo: branch auth-api/bugfix/my-feature
-rimba add pr:123                     # Create worktree from PR #123's head branch
-rimba add pr:123 --task review/auth-tweak  # Override auto-derived task name
-rimba add branch:feature/my-feature  # Promote current branch to its own worktree
-```
-
-{: .note }
-> **Monorepo:** If the first segment before `/` matches a directory in the repo root, rimba treats it as a service scope. The branch uses a 3-segment pattern: `<service>/<prefix>/<task>`. No configuration needed — detection is automatic.
-
-{: .note }
-> **PR mode:** `pr:<num>` requires `gh` to be installed and authenticated. For cross-fork PRs, rimba adds a `gh-fork-<owner>` remote automatically. Without `--task`, the task name is derived as `review/<num>-<slug>`.
-
-{: .note }
-> **Branch mode:** `branch:<branch>` requires that `<branch>` is the currently checked-out branch in the main repo and is not the default branch. Any uncommitted changes are transferred to the new worktree via `git stash`. `--source` is not valid in `branch:` mode. `--skip-deps` and `--skip-hooks` are accepted by the parser but have no effect in `branch:` mode; promote does not run dependency installation or post-create hooks.
-
-| Flag | Description |
-|------|-------------|
-| `--bugfix` | Use `bugfix/` branch prefix |
-| `--hotfix` | Use `hotfix/` branch prefix |
-| `--docs` | Use `docs/` branch prefix |
-| `--test` | Use `test/` branch prefix |
-| `--chore` | Use `chore/` branch prefix |
-| `-s`, `--source` | Source branch to create worktree from (default from config) |
-| `--task` | Override auto-derived task name (`pr:<num>` mode only) |
-| `--skip-deps` | Skip dependency detection and installation |
-| `--skip-hooks` | Skip post-create hooks |
-
-### rimba remove
-
-Remove the worktree for the given task and delete the local branch.
-
-```sh
-rimba remove my-feature
-rimba remove my-feature -k           # Keep the branch after removal
-rimba remove my-feature -f           # Force removal even if dirty
-```
-
-| Flag | Description |
-|------|-------------|
-| `-k`, `--keep-branch` | Keep the local branch after removing the worktree |
-| `-f`, `--force` | Force removal even if the worktree is dirty |
-| `--dry-run` | Preview what would be removed without making changes |
-
-### rimba rename
-
-Rename a worktree's task, branch, and directory.
-
-```sh
-rimba rename old-task new-task
-rimba rename old-task new-task -f  # Force rename even if locked
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f`, `--force` | Force rename even if the worktree is locked |
-| `--skip-deps` | Skip dependency refresh after rename |
-| `--skip-hooks` | Skip post-rename hooks |
-
-### rimba duplicate
-
-Create a new worktree from an existing worktree, inheriting its branch prefix. Auto-generates a `-1`, `-2`, etc. suffix unless `--as` is provided.
-
-```sh
-rimba duplicate auth              # Creates feature/auth-1 from feature/auth
-rimba duplicate auth --as auth-v2 # Creates feature/auth-v2 from feature/auth
-```
-
-| Flag | Description |
-|------|-------------|
-| `--as` | Custom name for the duplicate worktree (instead of auto-suffix) |
-| `--skip-deps` | Skip dependency detection and installation |
-| `--skip-hooks` | Skip post-create hooks |
-| `--dry-run` | Preview what would be duplicated without making changes |
-
-### rimba archive
-
-Archive a worktree by removing its directory but preserving the local branch for later restoration with `rimba restore`.
-
-```sh
-rimba archive my-feature
-rimba archive my-feature -f      # Force archival even if dirty
-```
-
-| Flag | Description |
-|------|-------------|
-| `-f`, `--force` | Force archival even if the worktree has uncommitted changes |
-| `--dry-run` | Preview what would be archived without making changes |
-
-{: .note }
-> The branch is preserved locally. Use [`rimba restore`](#rimba-restore) to recreate the worktree from the archived branch.
-
-### rimba restore
-
-Restore an archived worktree by recreating it from a branch that was previously archived with `rimba archive`.
-
-```sh
-rimba restore my-feature
-```
-
-| Flag | Description |
-|------|-------------|
-| `--skip-deps` | Skip dependency detection and installation |
-| `--skip-hooks` | Skip post-create hooks |
-
-{: .note }
-> Restoring copies dotfiles, installs dependencies, and runs post-create hooks — just like `rimba add`. Use [`rimba archive`](#rimba-archive) to archive a worktree.
+| Command | Description |
+|---------|-------------|
+| [rimba add](commands/add) | Create a new worktree (supports monorepo scoping, PR checkout, branch promotion) |
+| [rimba remove](commands/remove) | Remove a worktree and delete the local branch |
+| [rimba rename](commands/rename) | Rename a worktree's task, branch, and directory |
+| [rimba duplicate](commands/duplicate) | Create a new worktree from an existing one, inheriting its branch prefix |
+| [rimba archive](commands/archive) | Archive a worktree (remove directory, keep branch) |
+| [rimba restore](commands/restore) | Restore an archived worktree from its preserved branch |
 
 ---
 
 ## Inspection
 
-### rimba list
-
-List all worktrees with task, type, and status. Use `--full` to show all columns including branch, path, and (when `gh` is installed and authenticated) PR number and CI rollup. The current worktree is marked with `*`.
-
-```sh
-rimba list
-rimba list --full               # Show all columns (branch, path, PR, CI)
-rimba list --type bugfix        # Show only bugfix worktrees
-rimba list --dirty              # Show only dirty worktrees
-rimba list --behind             # Show only worktrees behind upstream
-rimba list --archived           # Show archived branches (not in any active worktree)
-rimba list --service auth-api   # Show only worktrees for a service (monorepo)
-rimba list --json               # Output as JSON
-```
-
-Example output (compact, default):
-
-```
-TASK            TYPE     STATUS
-* auth-flow     feature  [dirty]
-  fix-login     bugfix   ↑2 ↓1
-  ui-cleanup    chore    ✓
-```
-
-Example output with `--full`:
-
-```
-TASK            TYPE     BRANCH              PATH               STATUS    PR     CI
-* auth-flow     feature  feature/auth-flow   feature-auth-flow  [dirty]   #142   ✓
-  fix-login     bugfix   bugfix/fix-login    bugfix-fix-login   ↑2 ↓1     #138   ●
-  ui-cleanup    chore    chore/ui-cleanup    chore-ui-cleanup   ✓         –      –
-```
-
-{: .note }
-> **PR/CI columns:** Require `gh` installed and authenticated; otherwise a yellow warning is printed and those cells render as `–`. CI symbols: ✓ success · ● pending · ✗ failure · – unknown.
-
-{: .warning }
-> `--archived` is mutually exclusive with `--type`, `--dirty`, `--behind`, and `--full`.
-
-| Flag | Description |
-|------|-------------|
-| `--full` | Show all columns including branch, path, and PR/CI (when `gh` is available) |
-| `--type` | Filter by prefix type (e.g. `feature`, `bugfix`, `hotfix`, `docs`, `test`, `chore`) |
-| `--dirty` | Show only worktrees with uncommitted changes |
-| `--behind` | Show only worktrees behind their upstream branch |
-| `--archived` | Show archived branches not in any active worktree (mutually exclusive with other filters) |
-| `--service` | Filter by service name (monorepo) |
-
-### rimba status
-
-Show a worktree dashboard with summary stats (total, dirty, stale, behind) and per-worktree age information. Use `--detail` to also show disk size, 7-day commit velocity, and a disk-footprint summary line.
-
-```sh
-rimba status
-rimba status --detail           # Add SIZE and 7D columns; sort by disk size (largest first)
-rimba status --stale-days 7     # Consider worktrees stale after 7 days
-rimba status --json             # Output as JSON
-```
-
-Example output:
-
-```
-Worktrees: 4  Dirty: 1  Stale: 1  Behind: 0
-
-TASK          TYPE     BRANCH              STATUS    AGE
-  auth-flow   feature  feature/auth-flow   [dirty]   2d
-  fix-login   bugfix   bugfix/fix-login    ✓         5h
-  ui-cleanup  chore    chore/ui-cleanup    ✓         21d ⚠ stale
-  payments    feature  feature/payments    ✓         3d
-```
-
-Example output with `--detail`:
-
-```
-Worktrees: 4  Dirty: 1  Stale: 1  Behind: 0
-Disk: total 1.2 GB  (main: 480 MB, worktrees: 720 MB)
-
-TASK          TYPE     BRANCH              STATUS    AGE   SIZE    7D
-  auth-flow   feature  feature/auth-flow   [dirty]   2d    310 MB  4
-  payments    feature  feature/payments    ✓         3d    220 MB  1
-  fix-login   bugfix   bugfix/fix-login    ✓         5h    140 MB  6
-  ui-cleanup  chore    chore/ui-cleanup    ✓         21d   50 MB   0  ⚠ stale
-```
-
-{: .note }
-> **Columns:** `SIZE` is the on-disk footprint of the worktree directory. `7D` is the number of commits on the worktree's branch in the last 7 days. `--detail` sorts rows largest-first.
-
-| Flag | Description |
-|------|-------------|
-| `--detail` | Add SIZE and 7D columns; print disk-footprint summary; sort by disk size |
-| `--stale-days` | Number of days after which a worktree is considered stale (default: 14) |
-
-### rimba log
-
-Show the most recent commit from each worktree, sorted from newest to oldest.
-
-```sh
-rimba log
-rimba log --limit 5             # Show only the 5 most recent entries
-rimba log --since 7d            # Show entries from the last 7 days
-```
-
-Example output:
-
-```
-Recent commits across 3 worktree(s):
-
-TASK          TYPE     AGE    COMMIT
-  auth-flow   feature  5h     Add OAuth2 callback handler
-  payments    feature  3d     Implement Stripe webhook endpoint
-  ui-cleanup  chore    21d    Remove deprecated CSS classes
-```
-
-| Flag | Description |
-|------|-------------|
-| `--limit` | Maximum number of entries to show (default: 0 = all) |
-| `--since` | Show entries since duration (e.g. `7d`, `2w`, `3h`) |
-
-### rimba open
-
-Open a worktree or run a command inside it. When called with just a task name, prints the worktree path. When given additional arguments, executes that command inside the worktree directory. Supports configurable shortcuts via the `[open]` config section.
-
-```sh
-rimba open my-task              # Print worktree path
-cd $(rimba open my-task)        # Navigate to worktree
-rimba open my-task --ide        # Run the 'ide' shortcut
-rimba open my-task --agent      # Run the 'agent' shortcut
-rimba open my-task -w test      # Run a named shortcut
-rimba open my-task npm start    # Run an inline command
-```
-
-| Flag | Description |
-|------|-------------|
-| `--ide` | Run the `ide` shortcut from `[open]` config |
-| `--agent` | Run the `agent` shortcut from `[open]` config |
-| `-w`, `--with` | Run any named shortcut from `[open]` config |
-
-{: .warning }
-> `--ide`, `--agent`, and `--with` are mutually exclusive with each other and with inline command arguments. Shortcuts are configured in the `[open]` section of `.rimba/settings.toml` (see [Configuration](configuration.md)).
+| Command | Description |
+|---------|-------------|
+| [rimba list](commands/list) | List all worktrees with task, type, and status |
+| [rimba status](commands/status) | Show a worktree dashboard with summary stats and age information |
+| [rimba log](commands/log) | Show the most recent commit from each worktree |
+| [rimba open](commands/open) | Open a worktree path or run a command inside it |
 
 ---
 
 ## Merging & Syncing
 
-### rimba merge
-
-Merge a worktree's branch into main or another worktree. When merging into main, the source worktree and branch are auto-deleted unless `--keep` is set. When merging between worktrees, the source is kept unless `--delete` is set.
-
-```sh
-rimba merge auth                           # Merge into main, delete source
-rimba merge auth --keep                    # Merge into main, keep source
-rimba merge auth --into dashboard          # Merge into worktree, keep source
-rimba merge auth --into dashboard --delete # Merge into worktree, delete source
-rimba merge auth --no-ff                   # Force merge commit
-rimba merge auth --dry-run                 # Preview merge without making changes
-```
-
-| Flag | Description |
-|------|-------------|
-| `--into` | Target worktree task to merge into (default: main/repo root) |
-| `--no-ff` | Force a merge commit (no fast-forward) |
-| `--keep` | Keep source worktree after merging into main |
-| `--delete` | Delete source worktree after merging into another worktree |
-| `--dry-run` | Preview what would be merged/cleaned up without making changes |
-
-{: .warning }
-> `--keep` and `--delete` are mutually exclusive. Merging to main deletes the source by default; merging to another worktree keeps it by default.
-
-### rimba sync
-
-Sync worktree(s) with the main branch by rebasing (default) or merging. Fetches the latest changes from origin first, then automatically pushes after a successful sync. Use `--no-push` to skip the push step.
-
-```sh
-rimba sync my-feature                # Rebase a single worktree onto main, then push
-rimba sync my-feature --merge        # Use merge instead of rebase
-rimba sync my-feature --no-push      # Sync without pushing
-rimba sync --all                     # Sync all eligible worktrees
-rimba sync --all --include-inherited # Include duplicate worktrees
-```
-
-| Flag | Description |
-|------|-------------|
-| `--all` | Sync all eligible worktrees (skips dirty and inherited by default) |
-| `--merge` | Use merge instead of rebase |
-| `--include-inherited` | Include inherited/duplicate worktrees when using `--all` |
-| `--no-push` | Skip pushing after sync (useful for local-only rebase/merge) |
-| `--dry-run` | Preview what would be synced without making changes |
-
-{: .note }
-> Dirty worktrees are skipped with a warning. On conflict, the rebase is automatically aborted and a recovery hint is printed. After a successful sync, the branch is pushed to origin by default.
-
-### rimba merge-plan
-
-Analyze file overlaps between worktree branches and recommend an optimal merge order that minimizes conflicts.
-
-```sh
-rimba merge-plan
-```
-
-Example output:
-
-```
-ORDER  BRANCH       CONFLICTS
-1      fix-login    0
-2      auth-flow    1
-3      ui-cleanup   2
-
-Merge in this order to minimize conflicts.
-```
-
-### rimba conflict-check
-
-Scan all active worktrees and report files modified in multiple branches, indicating potential merge conflicts. Optionally simulate merges with `git merge-tree`.
-
-```sh
-rimba conflict-check
-rimba conflict-check --dry-merge    # Simulate merges with git merge-tree
-```
-
-Example output:
-
-```
-FILE              BRANCHES              SEVERITY
-src/auth.go       auth-flow, fix-login  high
-src/config.go     auth-flow, payments   medium
-
-2 file overlap(s) found across 3 branches.
-```
-
-| Flag | Description |
-|------|-------------|
-| `--dry-merge` | Simulate merges with `git merge-tree` (requires git 2.38+) |
+| Command | Description |
+|---------|-------------|
+| [rimba merge](commands/merge) | Merge a worktree's branch into main or another worktree |
+| [rimba sync](commands/sync) | Sync worktree(s) with the main branch via rebase or merge |
+| [rimba merge-plan](commands/merge-plan) | Analyze file overlaps and recommend an optimal merge order |
+| [rimba conflict-check](commands/conflict-check) | Scan branches for files modified in multiple worktrees |
 
 ---
 
 ## Bulk Operations
 
-### rimba exec
-
-Run a shell command in parallel across matching worktrees. Requires `--all` or `--type` to select targets.
-
-```sh
-rimba exec "npm test" --all                 # Run in all worktrees
-rimba exec "git status" --type bugfix       # Run in bugfix worktrees only
-rimba exec "npm test" --all --dirty         # Run only in dirty worktrees
-rimba exec "npm test" --all --fail-fast     # Stop after first failure
-rimba exec "npm test" --all --concurrency 4 # Limit to 4 parallel runs
-```
-
-| Flag | Description |
-|------|-------------|
-| `--all` | Run in all eligible worktrees |
-| `--type` | Filter by prefix type (e.g. `feature`, `bugfix`, `hotfix`, `docs`, `test`, `chore`) |
-| `--dirty` | Run only in worktrees with uncommitted changes |
-| `--fail-fast` | Stop execution after the first failure |
-| `--concurrency` | Max parallel executions (default: 0 = unlimited) |
-
-{: .warning }
-> Either `--all` or `--type` is required to select worktrees.
+| Command | Description |
+|---------|-------------|
+| [rimba exec](commands/exec) | Run a shell command in parallel across matching worktrees |
 
 ---
 
 ## Hooks
 
-### rimba hook
-
-Manage Git hooks for worktree workflow automation. Installs two hooks: a `post-merge` hook for automatic cleanup and a `pre-commit` hook that prevents direct commits to main/master.
-
-#### rimba hook install
-
-Install the rimba Git hooks: a `post-merge` hook that automatically runs `rimba clean --merged --force` after `git pull` (only on the default branch), and a `pre-commit` hook that prevents direct commits to main/master.
-
-```sh
-rimba hook install           # Install both hooks
-```
-
-#### rimba hook uninstall
-
-Remove the rimba post-merge and pre-commit hooks. Preserves any other content in the hook files.
-
-```sh
-rimba hook uninstall         # Remove both rimba hooks
-```
-
-#### rimba hook status
-
-Show whether the rimba post-merge and pre-commit hooks are currently installed.
-
-```sh
-rimba hook status            # Check installation status
-```
-
-{: .note }
-> `rimba hook` works with or without `rimba init`. The hooks coexist with existing user-defined hooks in the same hook files.
+| Command | Description |
+|---------|-------------|
+| [rimba hook](commands/hook) | Manage Git hooks for worktree workflow automation |
 
 ---
 
 ## Dependencies
 
-### rimba deps
-
-Manage worktree dependencies — detect lockfiles, clone dependency directories, and install packages.
-
-#### rimba deps status
-
-Show detected dependency modules and lockfile hashes for all worktrees.
-
-```sh
-rimba deps status
-```
-
-Example output:
-
-```
-refs/heads/main (/path/to/repo)
-  node_modules [a1b2c3d4e5f6]
-  vendor [7g8h9i0j1k2l]
-refs/heads/feature/auth (/path/to/worktrees/feature-auth)
-  node_modules [a1b2c3d4e5f6]
-  vendor [7g8h9i0j1k2l]
-```
-
-#### rimba deps install
-
-Detect and install dependencies for a specific worktree. Clones from an existing worktree with a matching lockfile hash, or falls back to the configured install command.
-
-```sh
-rimba deps install my-feature
-```
+| Command | Description |
+|---------|-------------|
+| [rimba deps](commands/deps) | Detect, clone, and install worktree dependencies |
 
 ---
 
 ## AI Integration
 
-### rimba mcp
-
-Start a Model Context Protocol (MCP) server that exposes rimba's worktree management as tools for AI coding agents. The server runs over stdio and follows the MCP specification.
-
-```sh
-rimba mcp    # Start MCP server (stdio transport)
-```
-
-#### Setup
-
-**Claude Code** — add to `.mcp.json` or run:
-
-```sh
-claude mcp add rimba rimba mcp
-```
-
-**Cursor** — add to `.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "rimba": {
-      "command": "rimba",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-#### MCP Tools
-
-| Tool | Description | Required Parameters |
-|------|-------------|---------------------|
-| `list` | List all worktrees with branch, path, and status | — |
-| `add` | Create a new worktree for a task (supports `service/task` for monorepos) | `task` |
-| `remove` | Remove a worktree and optionally delete its branch | `task` |
-| `status` | Show worktree dashboard with summary stats and age info | — |
-| `sync` | Sync worktree(s) with the main branch via rebase or merge, then push | `task` or `all` |
-| `merge` | Merge a worktree branch into main or another worktree | `source` |
-| `exec` | Run a shell command across matching worktrees in parallel | `command` |
-| `conflict-check` | Detect file overlaps between worktree branches | — |
-| `clean` | Clean up stale references, merged branches, or stale worktrees | `mode` (prune, merged, stale) |
-
-{: .note }
-> All tools return JSON responses. See `rimba mcp` help output for full parameter details.
+| Command | Description |
+|---------|-------------|
+| [rimba mcp](commands/mcp) | Start an MCP server exposing rimba tools to AI coding agents |
 
 ---
 
 ## Maintenance
 
-### rimba clean
-
-Prune stale worktree references, or detect and remove worktrees whose branches have been merged into main or are stale.
-
-```sh
-rimba clean                              # Prune stale worktree references
-rimba clean --dry-run                    # Preview what would be pruned
-rimba clean --merged                     # Detect and remove merged worktrees (with confirmation)
-rimba clean --merged --force             # Remove merged worktrees without confirmation
-rimba clean --merged --dry-run           # Show merged worktrees without removing
-rimba clean --stale                      # Detect and remove stale worktrees (with confirmation)
-rimba clean --stale --stale-days 7       # Use a 7-day threshold instead of 14
-rimba clean --stale --force              # Remove stale worktrees without confirmation
-rimba clean --stale --dry-run            # Show stale worktrees without removing
-```
-
-| Flag | Description |
-|------|-------------|
-| `--dry-run` | Show what would be pruned/removed without making changes |
-| `--merged` | Detect and remove worktrees whose branches are merged into main |
-| `--stale` | Remove worktrees with no recent commits |
-| `--stale-days` | Number of days to consider a worktree stale (default: 14, used with `--stale`) |
-| `--force` | Skip confirmation prompt when used with `--merged` or `--stale` |
-
-{: .warning }
-> `--merged` and `--stale` are mutually exclusive. `--merged` works with or without `rimba init`. Without a config file, it falls back to auto-detecting the default branch. By default, `rimba clean` prunes stale remote-tracking refs across all configured remotes (not just `origin`).
-
----
-
-### rimba update
-
-Check for the latest release on GitHub and update the binary in place.
-
-```sh
-rimba update             # Check and update to latest
-rimba update --force     # Also works on dev builds
-```
-
-| Flag | Description |
-|------|-------------|
-| `--force` | Update even if running a development build |
-
-{: .note }
-> If the binary cannot be replaced due to file permissions, rimba installs to `~/.local/bin` instead.
-
-{: .tip }
-> After a successful update, rimba prints a one-line tip if agent files are installed at user level (`rimba init -g` to refresh) or in this repo (`rimba init --agents` to refresh). Set `RIMBA_QUIET=1` to suppress.
-
----
-
-### rimba version
-
-Print version, commit, build date, and platform info.
-
-```sh
-rimba version
-```
-
-```
-rimba v<X.Y.Z>
-commit: <sha>
-built:  <iso8601>
-os:     <linux|darwin|windows>
-arch:   <amd64|arm64>
-go:     go<version>
-```
-
----
-
-### rimba completion
-
-Generate shell completion scripts for bash, zsh, fish, or PowerShell.
-
-```sh
-rimba completion bash        # Generate bash completions
-rimba completion zsh         # Generate zsh completions
-rimba completion fish        # Generate fish completions
-rimba completion powershell  # Generate PowerShell completions
-```
-
-{: .note }
-> Follow the printed instructions after generating to install the completions for your shell.
+| Command | Description |
+|---------|-------------|
+| [rimba clean](commands/clean) | Prune stale references or remove merged/stale worktrees |
+| [rimba trust](commands/trust) | Review and approve committed shell commands for this repo |
+| [rimba update](commands/update) | Check for and install the latest rimba release |
+| [rimba version](commands/version) | Print version, commit, build date, and platform info |
+| [rimba completion](commands/completion) | Generate shell completion scripts |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,7 +18,7 @@ These flags are available on every command:
 
 | Flag | Description |
 |------|-------------|
-| `--json` | Output in JSON format (supported by `list`, `status`, `deps status`, `conflict-check`, `exec`) |
+| `--json` | Output in JSON format (supported by `list`, `status`, `deps status`, `conflict-check`, `exec`, `log`) |
 | `--no-color` | Disable colored output (also respects `NO_COLOR` env var) |
 | `--debug` | Log git commands and timings to stderr (also respects `RIMBA_DEBUG=1`) |
 | `--yes` | Approve committed shell commands without prompting (see `rimba trust`; also respects `RIMBA_TRUST_YES=1`) |

--- a/docs/commands/add.md
+++ b/docs/commands/add.md
@@ -1,0 +1,92 @@
+---
+title: rimba add
+parent: Command Reference
+nav_order: 2
+---
+
+# rimba add
+
+Create a new worktree with a branch named `<prefix>/<task>` and copy dotfiles from the repo root. The default prefix is `feature/`; use a prefix flag to override.
+
+In monorepos, prefix the task with a service directory name (`service/task`) to create service-scoped branches. Use `pr:<num>` to create a worktree from a GitHub PR's head branch. Use `branch:<branch>` to promote the currently checked-out branch into its own worktree.
+
+## Synopsis
+
+```sh
+rimba add <task> [flags]
+rimba add pr:<num> [--task <name>] [flags]
+rimba add branch:<branch> [flags]
+```
+
+## Examples
+
+```sh
+rimba add my-feature
+rimba add my-feature --bugfix          # Use bugfix/ prefix instead of feature/
+rimba add my-feature -s develop        # Branch from a different source
+rimba add auth-api/my-feature          # Monorepo: branch auth-api/feature/my-feature
+rimba add auth-api/my-feature --bugfix # Monorepo: branch auth-api/bugfix/my-feature
+rimba add pr:123                       # Create worktree from PR #123's head branch
+rimba add pr:123 --task review/auth-tweak  # Override auto-derived task name
+rimba add branch:feature/my-feature   # Promote current branch to its own worktree
+```
+
+## Common workflows
+
+**Start a new feature**
+```sh
+rimba add payments-refactor
+# Branch: feature/payments-refactor
+# Dotfiles copied, deps installed, post_create hooks run
+```
+
+**Fix a bug on a specific base branch**
+```sh
+rimba add auth-null-check --bugfix -s release/2.x
+# Branch: bugfix/auth-null-check, branched from release/2.x
+```
+
+**Review a pull request**
+```sh
+rimba add pr:456
+# Fetches PR #456's head branch, creates worktree for review
+cd $(rimba open review/456-<slug>)
+```
+
+**Promote a branch you're already on**
+```sh
+# On branch feature/refactor in the main repo:
+rimba add branch:feature/refactor
+# Moves uncommitted changes via git stash into the new worktree
+```
+
+{: .note }
+> **Monorepo:** If the first segment before `/` matches a directory in the repo root, rimba treats it as a service scope. The branch uses a 3-segment pattern: `<service>/<prefix>/<task>`. No configuration needed — detection is automatic.
+
+{: .note }
+> **PR mode:** `pr:<num>` requires `gh` to be installed and authenticated. For cross-fork PRs, rimba adds a `gh-fork-<owner>` remote automatically. Without `--task`, the task name is derived as `review/<num>-<slug>`.
+
+{: .note }
+> **Branch mode:** `branch:<branch>` requires that `<branch>` is the currently checked-out branch in the main repo and is not the default branch. Any uncommitted changes are transferred to the new worktree via `git stash`. `--source` is not valid in `branch:` mode. `--skip-deps` and `--skip-hooks` are accepted but have no effect — branch promotion does not run dependency installation or post-create hooks.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--bugfix` | Use `bugfix/` branch prefix |
+| `--hotfix` | Use `hotfix/` branch prefix |
+| `--docs` | Use `docs/` branch prefix |
+| `--test` | Use `test/` branch prefix |
+| `--chore` | Use `chore/` branch prefix |
+| `-s`, `--source` | Source branch to create worktree from (default from config) |
+| `--task` | Override auto-derived task name (`pr:<num>` mode only) |
+| `--skip-deps` | Skip dependency detection and installation |
+| `--skip-hooks` | Skip post-create hooks |
+
+## Related commands
+
+- [rimba remove](remove) · remove a worktree
+- [rimba rename](rename) · rename a worktree
+- [rimba duplicate](duplicate) · create another worktree from an existing one
+- [rimba archive](archive) · archive a worktree for later
+- [rimba trust](trust) · approve post-create shell commands

--- a/docs/commands/archive.md
+++ b/docs/commands/archive.md
@@ -1,0 +1,56 @@
+---
+title: rimba archive
+parent: Command Reference
+nav_order: 6
+---
+
+# rimba archive
+
+Archive a worktree by removing its directory but preserving the local branch. The branch can later be restored with [`rimba restore`](restore).
+
+Archiving is useful when you need to pause a task and reclaim disk space without losing work.
+
+## Synopsis
+
+```sh
+rimba archive <task> [flags]
+```
+
+## Examples
+
+```sh
+rimba archive my-feature
+rimba archive my-feature -f      # Force archival even if dirty
+rimba archive my-feature --dry-run
+```
+
+## Common workflows
+
+**Pause a task to free disk space**
+```sh
+rimba archive big-refactor
+# Worktree directory removed; branch preserved locally
+# Use 'rimba list --archived' to see archived branches
+```
+
+**Force-archive a dirty worktree**
+```sh
+rimba archive wip-spike --force
+# Commits are preserved in the branch; uncommitted changes are lost
+```
+
+{: .note }
+> The branch is preserved locally. Use [`rimba restore`](restore) to recreate the worktree from the archived branch.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Force archival even if the worktree has uncommitted changes |
+| `--dry-run` | Preview what would be archived without making changes |
+
+## Related commands
+
+- [rimba restore](restore) · recreate a worktree from an archived branch
+- [rimba remove](remove) · remove both worktree and branch permanently
+- [rimba list](list) · use `--archived` to see archived branches

--- a/docs/commands/clean.md
+++ b/docs/commands/clean.md
@@ -1,0 +1,69 @@
+---
+title: rimba clean
+parent: Command Reference
+nav_order: 20
+---
+
+# rimba clean
+
+Prune stale worktree references, or detect and remove worktrees whose branches have been merged into main or are stale (no recent commits).
+
+Running `rimba clean` without any mode flags prunes stale remote-tracking refs across all configured remotes.
+
+## Synopsis
+
+```sh
+rimba clean [--merged | --stale] [flags]
+```
+
+## Examples
+
+```sh
+rimba clean                              # Prune stale worktree references
+rimba clean --dry-run                    # Preview what would be pruned
+rimba clean --merged                     # Detect and remove merged worktrees (with confirmation)
+rimba clean --merged --force             # Remove merged worktrees without confirmation
+rimba clean --merged --dry-run           # Show merged worktrees without removing
+rimba clean --stale                      # Detect and remove stale worktrees (with confirmation)
+rimba clean --stale --stale-days 7       # Use a 7-day threshold instead of 14
+rimba clean --stale --force              # Remove stale worktrees without confirmation
+rimba clean --stale --dry-run            # Show stale worktrees without removing
+```
+
+## Common workflows
+
+**After a busy sprint: remove all merged branches**
+```sh
+rimba clean --merged --dry-run   # Preview first
+rimba clean --merged --force     # Then remove
+```
+
+**Remove dormant worktrees**
+```sh
+rimba clean --stale --stale-days 7   # More aggressive: 7-day threshold
+```
+
+**Automated cleanup via Git hook**
+```sh
+rimba hook install
+# Installs a post-merge hook that runs 'rimba clean --merged --force' on git pull
+```
+
+{: .warning }
+> `--merged` and `--stale` are mutually exclusive. `--merged` works with or without `rimba init`. Without a config file, it falls back to auto-detecting the default branch. By default, `rimba clean` prunes stale remote-tracking refs across all configured remotes (not just `origin`).
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show what would be pruned/removed without making changes |
+| `--merged` | Detect and remove worktrees whose branches are merged into main |
+| `--stale` | Remove worktrees with no recent commits |
+| `--stale-days` | Number of days to consider a worktree stale (default: 14, used with `--stale`) |
+| `--force` | Skip confirmation prompt when used with `--merged` or `--stale` |
+
+## Related commands
+
+- [rimba hook](hook) · automate `clean --merged --force` via a post-merge hook
+- [rimba remove](remove) · remove a single named worktree
+- [rimba status](status) · use `--stale-days` to spot stale worktrees

--- a/docs/commands/completion.md
+++ b/docs/commands/completion.md
@@ -1,0 +1,54 @@
+---
+title: rimba completion
+parent: Command Reference
+nav_order: 24
+---
+
+# rimba completion
+
+Generate shell completion scripts for bash, zsh, fish, or PowerShell.
+
+## Synopsis
+
+```sh
+rimba completion <shell>
+```
+
+Supported shells: `bash`, `zsh`, `fish`, `powershell`.
+
+## Examples
+
+```sh
+rimba completion bash        # Generate bash completions
+rimba completion zsh         # Generate zsh completions
+rimba completion fish        # Generate fish completions
+rimba completion powershell  # Generate PowerShell completions
+```
+
+## Common workflows
+
+**Install completions for zsh**
+```sh
+rimba completion zsh > "${fpath[1]}/_rimba"
+# Then restart your shell or run: autoload -U compinit && compinit
+```
+
+**Install completions for bash**
+```sh
+rimba completion bash > /etc/bash_completion.d/rimba
+# Or for a single user:
+rimba completion bash >> ~/.bash_completion
+```
+
+**Install completions for fish**
+```sh
+rimba completion fish > ~/.config/fish/completions/rimba.fish
+```
+
+{: .note }
+> Follow the printed instructions after generating to install the completions for your shell.
+
+## Related commands
+
+- [rimba version](version) · check your rimba version
+- [rimba update](update) · upgrade to the latest release

--- a/docs/commands/conflict-check.md
+++ b/docs/commands/conflict-check.md
@@ -1,0 +1,60 @@
+---
+title: rimba conflict-check
+parent: Command Reference
+nav_order: 15
+---
+
+# rimba conflict-check
+
+Scan all active worktrees and report files modified in multiple branches, indicating potential merge conflicts. Optionally simulate merges with `git merge-tree` to confirm whether conflicts are real.
+
+## Synopsis
+
+```sh
+rimba conflict-check [flags]
+```
+
+## Examples
+
+```sh
+rimba conflict-check
+rimba conflict-check --dry-merge    # Simulate merges with git merge-tree
+rimba conflict-check --json         # Output as JSON
+```
+
+## Common workflows
+
+**Pre-merge scan**
+```sh
+rimba conflict-check
+```
+```
+FILE              BRANCHES              SEVERITY
+src/auth.go       auth-flow, fix-login  high
+src/config.go     auth-flow, payments   medium
+
+2 file overlap(s) found across 3 branches.
+```
+
+**Confirm actual conflicts (not just overlaps)**
+```sh
+rimba conflict-check --dry-merge
+# Runs git merge-tree per branch pair; requires git 2.38+
+```
+
+**Feed into a script**
+```sh
+rimba conflict-check --json | jq '.overlaps[] | select(.severity == "high")'
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--dry-merge` | Simulate merges with `git merge-tree` (requires git 2.38+) |
+
+## Related commands
+
+- [rimba merge-plan](merge-plan) · optimal merge order based on overlap analysis
+- [rimba sync](sync) · sync branches with main before merging
+- [rimba merge](merge) · merge a branch into main

--- a/docs/commands/deps.md
+++ b/docs/commands/deps.md
@@ -1,0 +1,84 @@
+---
+title: rimba deps
+parent: Command Reference
+nav_order: 18
+---
+
+# rimba deps
+
+Manage worktree dependencies — detect lockfiles, clone dependency directories from existing worktrees with matching lockfile hashes, and install packages.
+
+The `deps` command has two subcommands: `status` and `install`.
+
+---
+
+## rimba deps status
+
+Show detected dependency modules and lockfile hashes for all worktrees.
+
+### Synopsis
+
+```sh
+rimba deps status [--json]
+```
+
+### Examples
+
+```sh
+rimba deps status
+```
+
+```
+refs/heads/main (/path/to/repo)
+  node_modules [a1b2c3d4e5f6]
+  vendor [7g8h9i0j1k2l]
+refs/heads/feature/auth (/path/to/worktrees/feature-auth)
+  node_modules [a1b2c3d4e5f6]
+  vendor [7g8h9i0j1k2l]
+```
+
+---
+
+## rimba deps install
+
+Detect and install dependencies for a specific worktree. Clones from an existing worktree with a matching lockfile hash, or falls back to the configured install command.
+
+### Synopsis
+
+```sh
+rimba deps install <task>
+```
+
+### Examples
+
+```sh
+rimba deps install my-feature
+```
+
+---
+
+## Common workflows
+
+**Check dependency state across worktrees**
+```sh
+rimba deps status
+# Matching hashes means deps were cloned (fast); different hashes mean a fresh install ran
+```
+
+**Manually reinstall deps after lockfile change**
+```sh
+rimba deps install my-feature
+```
+
+**Skip auto-install during add, install manually later**
+```sh
+rimba add my-feature --skip-deps
+# ... modify lockfile ...
+rimba deps install my-feature
+```
+
+## Related commands
+
+- [rimba add](add) · use `--skip-deps` to defer installation
+- [rimba restore](restore) · use `--skip-deps` to defer installation
+- [rimba trust](trust) · approve `deps.modules[].install` shell commands

--- a/docs/commands/duplicate.md
+++ b/docs/commands/duplicate.md
@@ -50,3 +50,4 @@ rimba duplicate login-flow --as login-flow-approach-b
 - [rimba add](add) · create a worktree from scratch
 - [rimba rename](rename) · rename an existing worktree
 - [rimba remove](remove) · remove a worktree when done
+- [rimba trust](trust) · approve post-create shell commands that run after duplication

--- a/docs/commands/duplicate.md
+++ b/docs/commands/duplicate.md
@@ -1,0 +1,52 @@
+---
+title: rimba duplicate
+parent: Command Reference
+nav_order: 5
+---
+
+# rimba duplicate
+
+Create a new worktree from an existing worktree, inheriting its branch prefix. Auto-generates a `-1`, `-2`, etc. suffix unless `--as` is provided. Useful for running a parallel experiment on the same base work.
+
+## Synopsis
+
+```sh
+rimba duplicate <task> [flags]
+```
+
+## Examples
+
+```sh
+rimba duplicate auth              # Creates feature/auth-1 from feature/auth
+rimba duplicate auth --as auth-v2 # Creates feature/auth-v2 from feature/auth
+rimba duplicate auth --dry-run    # Preview without making changes
+```
+
+## Common workflows
+
+**Parallel exploration from the same base**
+```sh
+rimba duplicate payments
+# Creates feature/payments-1 alongside feature/payments
+# Both share the same history; diverge independently
+```
+
+**Named duplicate for an A/B approach**
+```sh
+rimba duplicate login-flow --as login-flow-approach-b
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--as` | Custom name for the duplicate worktree (instead of auto-suffix) |
+| `--skip-deps` | Skip dependency detection and installation |
+| `--skip-hooks` | Skip post-create hooks |
+| `--dry-run` | Preview what would be duplicated without making changes |
+
+## Related commands
+
+- [rimba add](add) · create a worktree from scratch
+- [rimba rename](rename) · rename an existing worktree
+- [rimba remove](remove) · remove a worktree when done

--- a/docs/commands/exec.md
+++ b/docs/commands/exec.md
@@ -1,0 +1,67 @@
+---
+title: rimba exec
+parent: Command Reference
+nav_order: 16
+---
+
+# rimba exec
+
+Run a shell command in parallel across matching worktrees. Requires `--all` or `--type` to select targets. Output from each worktree is labeled so you can tell results apart.
+
+## Synopsis
+
+```sh
+rimba exec "<command>" --all [flags]
+rimba exec "<command>" --type <prefix> [flags]
+```
+
+## Examples
+
+```sh
+rimba exec "npm test" --all                  # Run in all worktrees
+rimba exec "git status" --type bugfix        # Run in bugfix worktrees only
+rimba exec "npm test" --all --dirty          # Run only in dirty worktrees
+rimba exec "npm test" --all --fail-fast      # Stop after first failure
+rimba exec "npm test" --all --concurrency 4  # Limit to 4 parallel runs
+rimba exec "npm test" --all --json           # Output as JSON
+```
+
+## Common workflows
+
+**Run the test suite across every branch**
+```sh
+rimba exec "npm test" --all
+```
+
+**Check git status across all open work**
+```sh
+rimba exec "git status --short" --all
+```
+
+**Lint only feature branches in parallel**
+```sh
+rimba exec "npm run lint" --type feature
+```
+
+**CI-style: fail fast, limited parallelism**
+```sh
+rimba exec "make test" --all --fail-fast --concurrency 2
+```
+
+{: .warning }
+> Either `--all` or `--type` is required to select worktrees.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Run in all eligible worktrees |
+| `--type` | Filter by prefix type (e.g. `feature`, `bugfix`, `hotfix`, `docs`, `test`, `chore`) |
+| `--dirty` | Run only in worktrees with uncommitted changes |
+| `--fail-fast` | Stop execution after the first failure |
+| `--concurrency` | Max parallel executions (default: 0 = unlimited) |
+
+## Related commands
+
+- [rimba open](open) · run a command in a single worktree
+- [rimba list](list) · inspect which worktrees would be targeted

--- a/docs/commands/hook.md
+++ b/docs/commands/hook.md
@@ -1,0 +1,96 @@
+---
+title: rimba hook
+parent: Command Reference
+nav_order: 17
+---
+
+# rimba hook
+
+Manage Git hooks for worktree workflow automation. Installs two hooks: a `post-merge` hook that automatically cleans up merged worktrees after `git pull`, and a `pre-commit` hook that prevents direct commits to main/master.
+
+The `hook` command has three subcommands: `install`, `uninstall`, and `status`.
+
+{: .note }
+> `rimba hook` works with or without `rimba init`. The hooks coexist with existing user-defined hooks in the same hook files.
+
+---
+
+## rimba hook install
+
+Install the rimba Git hooks:
+- **`post-merge`** — runs `rimba clean --merged --force` automatically after `git pull` on the default branch.
+- **`pre-commit`** — prevents direct commits to main/master.
+
+### Synopsis
+
+```sh
+rimba hook install
+```
+
+### Examples
+
+```sh
+rimba hook install           # Install both hooks
+```
+
+---
+
+## rimba hook uninstall
+
+Remove the rimba `post-merge` and `pre-commit` hooks. Preserves any other content in the hook files.
+
+### Synopsis
+
+```sh
+rimba hook uninstall
+```
+
+### Examples
+
+```sh
+rimba hook uninstall         # Remove both rimba hooks
+```
+
+---
+
+## rimba hook status
+
+Show whether the rimba `post-merge` and `pre-commit` hooks are currently installed.
+
+### Synopsis
+
+```sh
+rimba hook status
+```
+
+### Examples
+
+```sh
+rimba hook status            # Check installation status
+```
+
+---
+
+## Common workflows
+
+**Set up hooks once after cloning**
+```sh
+rimba hook install
+# Now: git pull on main auto-cleans merged worktrees
+# Now: git commit on main/master is blocked
+```
+
+**Verify hooks are installed**
+```sh
+rimba hook status
+```
+
+**Remove hooks before uninstalling rimba**
+```sh
+rimba hook uninstall
+```
+
+## Related commands
+
+- [rimba init](init) · initialize rimba config (hook install is separate)
+- [rimba clean](clean) · the command the post-merge hook calls

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -1,0 +1,83 @@
+---
+title: rimba init
+parent: Command Reference
+nav_order: 1
+---
+
+# rimba init
+
+Initialize rimba in the current repository. Detects the repo root, creates the `.rimba/` config directory with `settings.toml` (team-shared) and `settings.local.toml` (personal overrides), and sets up the worktree directory.
+
+Agent files (`AGENTS.md`, `.github/copilot-instructions.md`, `.cursor/rules/rimba.mdc`, `.claude/skills/rimba/SKILL.md`) can be installed at three tiers:
+
+- `--agents` — project-team level (committed to git)
+- `--agents --local` — project-personal level (gitignored)
+- `-g` / `--global` — user level (`~/`) — works outside a git repository
+
+When agent files are installed, rimba also registers itself as an MCP server (`rimba mcp`) in client config files: `.mcp.json`, `.cursor/mcp.json`, `~/.claude.json`, `~/.codex/config.toml`, `~/.gemini/settings.json`, `~/.codeium/windsurf/mcp_config.json`, `~/.roo/mcp.json`. Use `--uninstall` with the same flags to remove.
+
+If `.rimba/` already exists, config creation is skipped but agent files are still installed or updated. If a legacy `.rimba.toml` exists, it is migrated into the new directory layout.
+
+## Synopsis
+
+```sh
+rimba init [flags]
+```
+
+## Examples
+
+```sh
+rimba init                        # Initialize config and worktree directory
+rimba init --agents               # Also install agent files at project level (committed)
+rimba init --agents --local       # Install agent files gitignored (personal)
+rimba init -g                     # Install agent files at user level (~/)
+rimba init -g --uninstall         # Remove user-level agent files and MCP registration
+rimba init --agents --uninstall   # Remove project-team agent files and MCP registration
+```
+
+## Common workflows
+
+**First-time setup for a team repo**
+```sh
+rimba init
+rimba init --agents   # Commit agent files so teammates get AI context
+git add .rimba/ .github/copilot-instructions.md AGENTS.md
+git commit -m "chore: add rimba config and agent files"
+```
+
+**Personal setup without affecting teammates**
+```sh
+rimba init --agents --local   # Agent files are gitignored
+```
+
+**Global user-level install (works in any repo)**
+```sh
+rimba init -g   # Installs to ~/ and registers MCP globally
+```
+
+**Migrate from legacy .rimba.toml**
+```sh
+rimba init   # Detects .rimba.toml and migrates to .rimba/ layout automatically
+```
+
+{: .warning }
+> - `--local` is not allowed with `-g`.
+> - `--local` without `--agents` errors with: `--local requires --agents`.
+> - `--uninstall` requires `-g` or `--agents`.
+> - `-g` / `--global` and `--agents` are mutually exclusive.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--agents` | Install AI agent instruction files at project level |
+| `-g`, `--global` | Install agent files at user level (`~/`) — works outside a git repo |
+| `--local` | Install agent files gitignored (personal overrides; requires `--agents`) |
+| `--uninstall` | Remove agent files and MCP registration (requires `-g` or `--agents`) |
+| `--personal` | Gitignore the entire `.rimba/` directory instead of the `.rimba/*.local.toml` glob |
+
+## Related commands
+
+- [rimba trust](trust) · approve committed shell commands after editing `settings.toml`
+- [rimba hook](hook) · install Git hooks for automated cleanup
+- [rimba add](add) · create your first worktree

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -1,0 +1,87 @@
+---
+title: rimba list
+parent: Command Reference
+nav_order: 8
+---
+
+# rimba list
+
+List all worktrees with task, type, and status. The current worktree is marked with `*`. Use `--full` to show branch, path, and (when `gh` is installed and authenticated) PR number and CI rollup.
+
+## Synopsis
+
+```sh
+rimba list [flags]
+```
+
+## Examples
+
+```sh
+rimba list
+rimba list --full               # Show all columns (branch, path, PR, CI)
+rimba list --type bugfix        # Show only bugfix worktrees
+rimba list --dirty              # Show only dirty worktrees
+rimba list --behind             # Show only worktrees behind upstream
+rimba list --archived           # Show archived branches (not in any active worktree)
+rimba list --service auth-api   # Show only worktrees for a service (monorepo)
+rimba list --json               # Output as JSON
+```
+
+## Common workflows
+
+**Quick overview**
+```sh
+rimba list
+```
+```
+TASK            TYPE     STATUS
+* auth-flow     feature  [dirty]
+  fix-login     bugfix   ↑2 ↓1
+  ui-cleanup    chore    ✓
+```
+
+**Full view with PR and CI status**
+```sh
+rimba list --full
+```
+```
+TASK            TYPE     BRANCH              PATH               STATUS    PR     CI
+* auth-flow     feature  feature/auth-flow   feature-auth-flow  [dirty]   #142   ✓
+  fix-login     bugfix   bugfix/fix-login    bugfix-fix-login   ↑2 ↓1     #138   ●
+  ui-cleanup    chore    chore/ui-cleanup    chore-ui-cleanup   ✓         –      –
+```
+
+**Find worktrees that need attention**
+```sh
+rimba list --dirty     # Uncommitted changes
+rimba list --behind    # Behind upstream — need sync
+```
+
+**See what can be restored**
+```sh
+rimba list --archived
+```
+
+{: .note }
+> **PR/CI columns:** Require `gh` installed and authenticated; otherwise a yellow warning is printed and those cells render as `–`. CI symbols: ✓ success · ● pending · ✗ failure · – unknown.
+
+{: .warning }
+> `--archived` is mutually exclusive with `--type`, `--dirty`, `--behind`, and `--full`.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--full` | Show all columns including branch, path, and PR/CI (when `gh` is available) |
+| `--type` | Filter by prefix type (e.g. `feature`, `bugfix`, `hotfix`, `docs`, `test`, `chore`) |
+| `--dirty` | Show only worktrees with uncommitted changes |
+| `--behind` | Show only worktrees behind their upstream branch |
+| `--archived` | Show archived branches not in any active worktree (mutually exclusive with other filters) |
+| `--service` | Filter by service name (monorepo) |
+
+## Related commands
+
+- [rimba status](status) · dashboard view with summary stats and age
+- [rimba log](log) · most recent commit per worktree
+- [rimba archive](archive) · archive a worktree (shows in `--archived`)
+- [rimba clean](clean) · remove merged or stale worktrees in bulk

--- a/docs/commands/log.md
+++ b/docs/commands/log.md
@@ -53,6 +53,7 @@ rimba log --limit 3
 |------|-------------|
 | `--limit` | Maximum number of entries to show (default: 0 = all) |
 | `--since` | Show entries since duration (e.g. `7d`, `2w`, `3h`) |
+| `--json` | Output as JSON |
 
 ## Related commands
 

--- a/docs/commands/log.md
+++ b/docs/commands/log.md
@@ -1,0 +1,60 @@
+---
+title: rimba log
+parent: Command Reference
+nav_order: 10
+---
+
+# rimba log
+
+Show the most recent commit from each worktree, sorted from newest to oldest. Useful for a quick snapshot of where each parallel branch stands.
+
+## Synopsis
+
+```sh
+rimba log [flags]
+```
+
+## Examples
+
+```sh
+rimba log
+rimba log --limit 5             # Show only the 5 most recent entries
+rimba log --since 7d            # Show entries from the last 7 days
+```
+
+## Common workflows
+
+**Morning standup: what did each branch last do?**
+```sh
+rimba log
+```
+```
+Recent commits across 3 worktree(s):
+
+TASK          TYPE     AGE    COMMIT
+  auth-flow   feature  5h     Add OAuth2 callback handler
+  payments    feature  3d     Implement Stripe webhook endpoint
+  ui-cleanup  chore    21d    Remove deprecated CSS classes
+```
+
+**See only recent activity**
+```sh
+rimba log --since 2d    # Only worktrees with commits in the last 2 days
+```
+
+**Cap output for a quick glance**
+```sh
+rimba log --limit 3
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--limit` | Maximum number of entries to show (default: 0 = all) |
+| `--since` | Show entries since duration (e.g. `7d`, `2w`, `3h`) |
+
+## Related commands
+
+- [rimba list](list) · full worktree listing with status
+- [rimba status](status) · dashboard with stats and age

--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -1,0 +1,85 @@
+---
+title: rimba mcp
+parent: Command Reference
+nav_order: 19
+---
+
+# rimba mcp
+
+Start a Model Context Protocol (MCP) server that exposes rimba's worktree management as tools for AI coding agents. The server runs over stdio and follows the MCP specification.
+
+{: .note }
+> All MCP tools return JSON responses. See `rimba mcp` help output for full parameter details. The easiest way to register this server is `rimba init --agents`, which writes the MCP config alongside the agent instruction files.
+
+## Synopsis
+
+```sh
+rimba mcp
+```
+
+## Examples
+
+```sh
+rimba mcp    # Start MCP server (stdio transport)
+```
+
+## Setup
+
+**Claude Code** — add to `.mcp.json` or run:
+
+```sh
+claude mcp add rimba rimba mcp
+```
+
+**Cursor** — add to `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rimba": {
+      "command": "rimba",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+**Auto-register with agent files:**
+
+```sh
+rimba init --agents    # Writes agent files + MCP config simultaneously
+```
+
+## MCP Tools
+
+| Tool | Description | Required Parameters |
+|------|-------------|---------------------|
+| `list` | List all worktrees with branch, path, and status | — |
+| `add` | Create a new worktree for a task (supports `service/task` for monorepos) | `task` |
+| `remove` | Remove a worktree and optionally delete its branch | `task` |
+| `status` | Show worktree dashboard with summary stats and age info | — |
+| `sync` | Sync worktree(s) with the main branch via rebase or merge, then push | `task` or `all` |
+| `merge` | Merge a worktree branch into main or another worktree | `source` |
+| `exec` | Run a shell command across matching worktrees in parallel | `command` |
+| `conflict-check` | Detect file overlaps between worktree branches | — |
+| `clean` | Clean up stale references, merged branches, or stale worktrees | `mode` (prune, merged, stale) |
+
+## Common workflows
+
+**Register once, use everywhere**
+```sh
+rimba init --agents
+# MCP config written to .mcp.json (Claude Code) and .cursor/mcp.json (Cursor)
+# Agent instruction files written alongside
+```
+
+**Ask your AI agent to create a worktree**
+```
+"Create a worktree for the login-refactor task"
+# Agent calls rimba MCP tool: add(task="login-refactor")
+```
+
+## Related commands
+
+- [rimba init](init) · `--agents` flag registers the MCP server automatically
+- [rimba list](list) · equivalent of the MCP `list` tool

--- a/docs/commands/merge-plan.md
+++ b/docs/commands/merge-plan.md
@@ -1,0 +1,53 @@
+---
+title: rimba merge-plan
+parent: Command Reference
+nav_order: 14
+---
+
+# rimba merge-plan
+
+Analyze file overlaps between worktree branches and recommend an optimal merge order that minimizes conflicts. Run this before a multi-branch merge to sequence merges in the safest order.
+
+## Synopsis
+
+```sh
+rimba merge-plan
+```
+
+## Examples
+
+```sh
+rimba merge-plan
+```
+
+```
+ORDER  BRANCH       CONFLICTS
+1      fix-login    0
+2      auth-flow    1
+3      ui-cleanup   2
+
+Merge in this order to minimize conflicts.
+```
+
+## Common workflows
+
+**Plan a sprint landing**
+```sh
+rimba merge-plan
+# Merge branches in the printed order to minimize conflicts:
+rimba merge fix-login
+rimba merge auth-flow
+rimba merge ui-cleanup
+```
+
+**Combine with conflict-check for a full picture**
+```sh
+rimba conflict-check   # Which files overlap?
+rimba merge-plan       # In what order should I merge?
+```
+
+## Related commands
+
+- [rimba conflict-check](conflict-check) · list files changed in multiple branches
+- [rimba merge](merge) · merge a single branch into main
+- [rimba sync](sync) · bring branches up to date with main before merging

--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -1,0 +1,70 @@
+---
+title: rimba merge
+parent: Command Reference
+nav_order: 12
+---
+
+# rimba merge
+
+Merge a worktree's branch into main or another worktree. When merging into main, the source worktree and branch are auto-deleted unless `--keep` is set. When merging between worktrees, the source is kept unless `--delete` is set.
+
+## Synopsis
+
+```sh
+rimba merge <task> [flags]
+```
+
+## Examples
+
+```sh
+rimba merge auth                           # Merge into main, delete source
+rimba merge auth --keep                    # Merge into main, keep source
+rimba merge auth --into dashboard          # Merge into worktree, keep source
+rimba merge auth --into dashboard --delete # Merge into worktree, delete source
+rimba merge auth --no-ff                   # Force merge commit
+rimba merge auth --dry-run                 # Preview without making changes
+```
+
+## Common workflows
+
+**Standard merge to main and clean up**
+```sh
+rimba merge my-feature
+# Merges feature/my-feature → main, removes worktree and branch
+```
+
+**Merge to main but keep the branch for tagging or reference**
+```sh
+rimba merge my-feature --keep
+```
+
+**Cross-worktree merge (e.g. integrate a shared utility)**
+```sh
+rimba merge shared-utils --into my-feature
+# Merges shared-utils' branch into my-feature's worktree; both are kept
+```
+
+**Preview before merging**
+```sh
+rimba merge my-feature --dry-run
+```
+
+{: .warning }
+> `--keep` and `--delete` are mutually exclusive. Merging to main deletes the source by default; merging to another worktree keeps it by default.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--into` | Target worktree task to merge into (default: main/repo root) |
+| `--no-ff` | Force a merge commit (no fast-forward) |
+| `--keep` | Keep source worktree after merging into main |
+| `--delete` | Delete source worktree after merging into another worktree |
+| `--dry-run` | Preview what would be merged/cleaned up without making changes |
+
+## Related commands
+
+- [rimba sync](sync) · rebase/merge with the main branch (not into main)
+- [rimba merge-plan](merge-plan) · plan the optimal merge order
+- [rimba conflict-check](conflict-check) · detect file overlaps before merging
+- [rimba remove](remove) · manually remove a worktree after merging via GitHub

--- a/docs/commands/open.md
+++ b/docs/commands/open.md
@@ -1,0 +1,71 @@
+---
+title: rimba open
+parent: Command Reference
+nav_order: 11
+---
+
+# rimba open
+
+Open a worktree or run a command inside it. When called with just a task name, prints the worktree path to stdout. When given additional arguments, executes that command inside the worktree directory. Supports configurable shortcuts via the `[open]` config section.
+
+## Synopsis
+
+```sh
+rimba open <task> [command...] [flags]
+```
+
+## Examples
+
+```sh
+rimba open my-task              # Print worktree path
+cd $(rimba open my-task)        # Navigate to worktree
+rimba open my-task --ide        # Run the 'ide' shortcut
+rimba open my-task --agent      # Run the 'agent' shortcut
+rimba open my-task -w test      # Run a named shortcut
+rimba open my-task npm start    # Run an inline command
+```
+
+## Common workflows
+
+**Navigate into a worktree**
+```sh
+cd $(rimba open my-feature)
+```
+
+**Open in your IDE (configured shortcut)**
+```sh
+# In .rimba/settings.toml:
+# [open]
+# ide = "code ."
+rimba open my-feature --ide
+```
+
+**Launch an AI agent in the worktree**
+```sh
+# In .rimba/settings.toml:
+# [open]
+# agent = "claude --dangerously-skip-permissions"
+rimba open my-feature --agent
+```
+
+**Run a one-off command without cd**
+```sh
+rimba open my-feature git log --oneline -5
+rimba open my-feature npm run lint
+```
+
+{: .warning }
+> `--ide`, `--agent`, and `--with` are mutually exclusive with each other and with inline command arguments. Shortcuts are configured in the `[open]` section of `.rimba/settings.toml` — see [Configuration](../configuration.md).
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--ide` | Run the `ide` shortcut from `[open]` config |
+| `--agent` | Run the `agent` shortcut from `[open]` config |
+| `-w`, `--with` | Run any named shortcut from `[open]` config |
+
+## Related commands
+
+- [rimba list](list) · find task names to open
+- [rimba exec](exec) · run a command across multiple worktrees at once

--- a/docs/commands/remove.md
+++ b/docs/commands/remove.md
@@ -1,0 +1,59 @@
+---
+title: rimba remove
+parent: Command Reference
+nav_order: 3
+---
+
+# rimba remove
+
+Remove the worktree for the given task and delete its local branch. By default the branch is deleted and the worktree must be clean; use flags to override.
+
+## Synopsis
+
+```sh
+rimba remove <task> [flags]
+```
+
+## Examples
+
+```sh
+rimba remove my-feature
+rimba remove my-feature -k           # Keep the branch after removal
+rimba remove my-feature -f           # Force removal even if dirty
+rimba remove my-feature --dry-run    # Preview what would be removed
+```
+
+## Common workflows
+
+**Clean up after merging**
+```sh
+rimba merge my-feature    # merge deletes automatically by default
+# If you merged externally (e.g. via GitHub), clean up manually:
+rimba remove my-feature
+```
+
+**Keep the branch for future reference**
+```sh
+rimba remove my-feature --keep-branch
+# Worktree removed; branch preserved for later checkout or restore
+```
+
+**Discard a dirty worktree you no longer need**
+```sh
+rimba remove my-feature --force
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-k`, `--keep-branch` | Keep the local branch after removing the worktree |
+| `-f`, `--force` | Force removal even if the worktree is dirty |
+| `--dry-run` | Preview what would be removed without making changes |
+
+## Related commands
+
+- [rimba add](add) · create a worktree
+- [rimba archive](archive) · keep the branch but remove the worktree directory
+- [rimba merge](merge) · merge into main (auto-removes by default)
+- [rimba clean](clean) · batch-remove merged or stale worktrees

--- a/docs/commands/rename.md
+++ b/docs/commands/rename.md
@@ -1,0 +1,51 @@
+---
+title: rimba rename
+parent: Command Reference
+nav_order: 4
+---
+
+# rimba rename
+
+Rename a worktree's task, branch, and directory. The branch is renamed to `<prefix>/<new-task>`, where the prefix is inherited from the current branch.
+
+## Synopsis
+
+```sh
+rimba rename <old-task> <new-task> [flags]
+```
+
+## Examples
+
+```sh
+rimba rename old-task new-task
+rimba rename old-task new-task -f       # Force rename even if locked
+rimba rename old-task new-task --skip-deps   # Skip dep refresh
+```
+
+## Common workflows
+
+**Rename after refining scope**
+```sh
+rimba rename auth-changes auth-jwt-migration
+# Branch: feature/auth-changes → feature/auth-jwt-migration
+# Directory renamed to match
+```
+
+**Rename without re-running hooks**
+```sh
+rimba rename my-task my-task-v2 --skip-hooks
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-f`, `--force` | Force rename even if the worktree is locked |
+| `--skip-deps` | Skip dependency refresh after rename |
+| `--skip-hooks` | Skip post-rename hooks |
+
+## Related commands
+
+- [rimba add](add) · create a worktree
+- [rimba duplicate](duplicate) · create a copy with a new name
+- [rimba trust](trust) · approve post-rename shell commands

--- a/docs/commands/restore.md
+++ b/docs/commands/restore.md
@@ -1,0 +1,53 @@
+---
+title: rimba restore
+parent: Command Reference
+nav_order: 7
+---
+
+# rimba restore
+
+Restore an archived worktree by recreating its directory from a branch that was previously archived with [`rimba archive`](archive). Copies dotfiles, installs dependencies, and runs post-create hooks — just like `rimba add`.
+
+## Synopsis
+
+```sh
+rimba restore <task> [flags]
+```
+
+## Examples
+
+```sh
+rimba restore my-feature
+rimba restore my-feature --skip-deps
+rimba restore my-feature --skip-hooks
+```
+
+## Common workflows
+
+**Resume paused work**
+```sh
+rimba list --archived          # Check archived branches
+rimba restore big-refactor     # Recreate the worktree
+cd $(rimba open big-refactor)  # Navigate into it
+```
+
+**Fast restore (skip slow steps)**
+```sh
+rimba restore my-feature --skip-deps --skip-hooks
+```
+
+{: .note }
+> Restoring copies dotfiles, installs dependencies, and runs post-create hooks — just like `rimba add`. Use [`rimba archive`](archive) to archive a worktree.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--skip-deps` | Skip dependency detection and installation |
+| `--skip-hooks` | Skip post-create hooks |
+
+## Related commands
+
+- [rimba archive](archive) · archive a worktree (remove directory, keep branch)
+- [rimba list](list) · use `--archived` to see restorable branches
+- [rimba add](add) · create a brand-new worktree

--- a/docs/commands/restore.md
+++ b/docs/commands/restore.md
@@ -51,3 +51,4 @@ rimba restore my-feature --skip-deps --skip-hooks
 - [rimba archive](archive) · archive a worktree (remove directory, keep branch)
 - [rimba list](list) · use `--archived` to see restorable branches
 - [rimba add](add) · create a brand-new worktree
+- [rimba trust](trust) · approve post-create shell commands that run on restore

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -1,0 +1,76 @@
+---
+title: rimba status
+parent: Command Reference
+nav_order: 9
+---
+
+# rimba status
+
+Show a worktree dashboard with summary stats (total, dirty, stale, behind) and per-worktree age information. Use `--detail` to also show disk size, 7-day commit velocity, and a disk-footprint summary line.
+
+## Synopsis
+
+```sh
+rimba status [flags]
+```
+
+## Examples
+
+```sh
+rimba status
+rimba status --detail           # Add SIZE and 7D columns; sort by disk size (largest first)
+rimba status --stale-days 7     # Consider worktrees stale after 7 days
+rimba status --json             # Output as JSON
+```
+
+## Common workflows
+
+**Daily health check**
+```sh
+rimba status
+```
+```
+Worktrees: 4  Dirty: 1  Stale: 1  Behind: 0
+
+TASK          TYPE     BRANCH              STATUS    AGE
+  auth-flow   feature  feature/auth-flow   [dirty]   2d
+  fix-login   bugfix   bugfix/fix-login    ✓         5h
+  ui-cleanup  chore    chore/ui-cleanup    ✓         21d ⚠ stale
+  payments    feature  feature/payments    ✓         3d
+```
+
+**Disk usage audit before a machine wipe**
+```sh
+rimba status --detail
+```
+```
+Worktrees: 4  Dirty: 1  Stale: 1  Behind: 0
+Disk: total 1.2 GB  (main: 480 MB, worktrees: 720 MB)
+
+TASK          TYPE     BRANCH              STATUS    AGE   SIZE    7D
+  auth-flow   feature  feature/auth-flow   [dirty]   2d    310 MB  4
+  payments    feature  feature/payments    ✓         3d    220 MB  1
+  fix-login   bugfix   bugfix/fix-login    ✓         5h    140 MB  6
+  ui-cleanup  chore    chore/ui-cleanup    ✓         21d   50 MB   0  ⚠ stale
+```
+
+**Tighten the stale threshold**
+```sh
+rimba status --stale-days 7   # Flag anything untouched for a week
+```
+
+{: .note }
+> **Columns:** `SIZE` is the on-disk footprint of the worktree directory. `7D` is the number of commits on the worktree's branch in the last 7 days. `--detail` sorts rows largest-first.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--detail` | Add SIZE and 7D columns; print disk-footprint summary; sort by disk size |
+| `--stale-days` | Number of days after which a worktree is considered stale (default: 14) |
+
+## Related commands
+
+- [rimba list](list) · compact listing with filter options
+- [rimba log](log) · most recent commit per worktree
+- [rimba clean](clean) · remove stale worktrees

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -1,0 +1,72 @@
+---
+title: rimba sync
+parent: Command Reference
+nav_order: 13
+---
+
+# rimba sync
+
+Sync worktree(s) with the main branch by rebasing (default) or merging. Fetches the latest changes from origin first, then automatically pushes after a successful sync. Use `--no-push` to skip the push step.
+
+## Synopsis
+
+```sh
+rimba sync <task> [flags]
+rimba sync --all [flags]
+```
+
+## Examples
+
+```sh
+rimba sync my-feature                # Rebase a single worktree onto main, then push
+rimba sync my-feature --merge        # Use merge instead of rebase
+rimba sync my-feature --no-push      # Sync without pushing
+rimba sync --all                     # Sync all eligible worktrees
+rimba sync --all --include-inherited # Include duplicate worktrees
+```
+
+## Common workflows
+
+**Keep a feature branch up to date**
+```sh
+rimba sync my-feature
+# 1. git fetch origin
+# 2. git rebase origin/main
+# 3. git push (if no conflicts)
+```
+
+**Prefer merge over rebase (e.g. for shared branches)**
+```sh
+rimba sync my-feature --merge
+```
+
+**Sync everything at once (CI / morning ritual)**
+```sh
+rimba sync --all
+# Skips dirty worktrees with a warning
+# On conflict: rebase is aborted, recovery hint printed
+```
+
+**Sync without pushing (local only)**
+```sh
+rimba sync --all --no-push
+```
+
+{: .note }
+> Dirty worktrees are skipped with a warning. On conflict, the rebase is automatically aborted and a recovery hint is printed. After a successful sync, the branch is pushed to origin by default.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Sync all eligible worktrees (skips dirty and inherited by default) |
+| `--merge` | Use merge instead of rebase |
+| `--include-inherited` | Include inherited/duplicate worktrees when using `--all` |
+| `--no-push` | Skip pushing after sync |
+| `--dry-run` | Preview what would be synced without making changes |
+
+## Related commands
+
+- [rimba merge](merge) · merge a branch into main (finished work)
+- [rimba conflict-check](conflict-check) · detect overlaps before syncing
+- [rimba list](list) · use `--behind` to see which worktrees need syncing

--- a/docs/commands/trust.md
+++ b/docs/commands/trust.md
@@ -28,12 +28,12 @@ rimba trust --yes     # Approve without prompting (e.g. in CI)
 
 ## How it works
 
-When rimba encounters unapproved shell commands during `add`, `rename`, or dependency installation, it:
+When rimba encounters unapproved shell commands during `add`, `rename`, `duplicate`, `restore`, or dependency installation, it:
 
 1. Displays the configured commands.
 2. Prompts: `Run these commands? [y/N]`
 3. On approval, records the hash in `.rimba/trust.local.toml`.
-4. On decline (or non-interactive stdin), exits with an error and a remediation hint.
+4. On decline (or non-interactive stdin), the invoking command exits with an error and a remediation hint. (`rimba trust` itself exits 0 on decline.)
 
 Once approved, rimba runs the commands without prompting — until the command set changes.
 
@@ -86,4 +86,6 @@ rimba trust   # Hash changed; re-prompts for approval
 - [rimba init](init) · set up `.rimba/settings.toml` where shell commands are configured
 - [rimba add](add) · triggers the trust gate when `post_create` hooks are configured
 - [rimba rename](rename) · triggers the trust gate when `post_rename` hooks are configured
+- [rimba duplicate](duplicate) · triggers the trust gate when `post_create` hooks are configured
+- [rimba restore](restore) · triggers the trust gate when `post_create` hooks are configured
 - [rimba deps](deps) · triggers the trust gate when `deps.modules[].install` is configured

--- a/docs/commands/trust.md
+++ b/docs/commands/trust.md
@@ -1,0 +1,89 @@
+---
+title: rimba trust
+parent: Command Reference
+nav_order: 21
+---
+
+# rimba trust
+
+Review and approve the shell commands configured in `.rimba/settings.toml`.
+
+rimba will not automatically run committed `post_create`, `post_rename`, or `deps.modules[].install` shell commands until you explicitly approve them. This prevents a malicious or accidental settings change from running arbitrary code on your machine without your knowledge.
+
+Approval is stored locally in `.rimba/trust.local.toml` (gitignored) and is keyed by a **hash of the current command set**. Changing any shell command in `settings.toml` automatically re-arms the consent gate — you will be prompted to approve again.
+
+## Synopsis
+
+```sh
+rimba trust [flags]
+```
+
+## Examples
+
+```sh
+rimba trust           # Review commands and approve interactively
+rimba trust --show    # Inspect commands and approval status without prompting
+rimba trust --yes     # Approve without prompting (e.g. in CI)
+```
+
+## How it works
+
+When rimba encounters unapproved shell commands during `add`, `rename`, or dependency installation, it:
+
+1. Displays the configured commands.
+2. Prompts: `Run these commands? [y/N]`
+3. On approval, records the hash in `.rimba/trust.local.toml`.
+4. On decline (or non-interactive stdin), exits with an error and a remediation hint.
+
+Once approved, rimba runs the commands without prompting — until the command set changes.
+
+## Common workflows
+
+**Approve commands after cloning a repo**
+```sh
+rimba trust
+# Shows commands from settings.toml; prompts for approval
+```
+
+**Inspect without approving**
+```sh
+rimba trust --show
+```
+```
+Configured shell commands:
+  npm install
+  npx prisma generate
+
+Hash: a1b2c3d4...
+Status: not trusted — run 'rimba trust' to approve
+```
+
+**Approve in CI without a prompt**
+```sh
+rimba trust --yes
+# Or set RIMBA_TRUST_YES=1 in your CI environment
+```
+
+**Re-approve after a settings change**
+```sh
+# A teammate updated post_create in settings.toml
+git pull
+rimba trust   # Hash changed; re-prompts for approval
+```
+
+{: .note }
+> `.rimba/trust.local.toml` is gitignored — approval is per-machine, not shared. Every developer on the team must approve independently. This is intentional: trust is a local consent decision.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--show` | Display configured commands and approval status without prompting |
+| `--yes` | Approve committed shell commands without prompting (also: `RIMBA_TRUST_YES=1`) |
+
+## Related commands
+
+- [rimba init](init) · set up `.rimba/settings.toml` where shell commands are configured
+- [rimba add](add) · triggers the trust gate when `post_create` hooks are configured
+- [rimba rename](rename) · triggers the trust gate when `post_rename` hooks are configured
+- [rimba deps](deps) · triggers the trust gate when `deps.modules[].install` is configured

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -1,0 +1,54 @@
+---
+title: rimba update
+parent: Command Reference
+nav_order: 22
+---
+
+# rimba update
+
+Check for the latest release on GitHub and update the binary in place. If the binary cannot be replaced due to file permissions, rimba installs to `~/.local/bin` instead.
+
+## Synopsis
+
+```sh
+rimba update [flags]
+```
+
+## Examples
+
+```sh
+rimba update             # Check and update to latest
+rimba update --force     # Also works on dev builds
+```
+
+## Common workflows
+
+**Check and apply update**
+```sh
+rimba update
+# Compares current version against latest GitHub release
+# Downloads and replaces binary if newer version found
+```
+
+**Update a dev build**
+```sh
+rimba update --force
+# Dev builds are otherwise skipped (version string differs from release tags)
+```
+
+{: .tip }
+> After a successful update, rimba prints a one-line tip if agent files are installed at user level (`rimba init -g` to refresh) or in this repo (`rimba init --agents` to refresh). Set `RIMBA_QUIET=1` to suppress.
+
+{: .note }
+> If the binary cannot be replaced due to file permissions, rimba installs to `~/.local/bin` instead.
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Update even if running a development build |
+
+## Related commands
+
+- [rimba version](version) · print the current version
+- [rimba init](init) · refresh agent files after updating (`-g` or `--agents`)

--- a/docs/commands/version.md
+++ b/docs/commands/version.md
@@ -1,0 +1,48 @@
+---
+title: rimba version
+parent: Command Reference
+nav_order: 23
+---
+
+# rimba version
+
+Print version, commit hash, build date, and platform info.
+
+## Synopsis
+
+```sh
+rimba version
+```
+
+## Examples
+
+```sh
+rimba version
+```
+
+```
+rimba v1.9.5
+commit: 18f05da
+built:  2026-06-11T02:10:10Z
+os:     darwin
+arch:   arm64
+go:     go1.26.4
+```
+
+## Common workflows
+
+**Include in a bug report**
+```sh
+rimba version
+# Copy the full output for accurate reproduction info
+```
+
+**Check before running rimba update**
+```sh
+rimba version   # Note current version
+rimba update    # Check for newer release
+```
+
+## Related commands
+
+- [rimba update](update) · upgrade to the latest release


### PR DESCRIPTION
## Summary

- Converts \`docs/commands.md\` from a 635-line monolith into a just-the-docs parent/child hierarchy with \`has_children: true\`
- Creates 24 child pages under \`docs/commands/<cmd>.md\` — one per top-level command — each with synopsis, examples, common workflows, flags table, and related-command links
- Authors the \`rimba trust\` page from scratch (\`cmd/trust.go\` + \`cmd/trust_gate.go\`), closing the documentation gap for the trust gate feature
- Parent \`commands.md\` becomes a navigable index with category-grouped tables and a Global Flags table (including the previously undocumented \`--yes\` flag)
- Fixes CI hanging on docs-only PRs: replaces workflow-level \`paths-ignore\` with a \`changes\` detection job + per-job \`if:\` conditions so required checks complete as "skipped" rather than hanging in pending

## Test Plan

- [ ] Unit tests pass (\`make test\`) — N/A: docs-only change, no Go sources modified
- [ ] Linter passes (\`make lint\`) — N/A: docs-only change
- [ ] E2E tests pass (\`make test-e2e\`) — N/A: docs-only change
- [x] CI triggered and PR Validation passed; Go jobs skip cleanly for docs-only diff
- [x] Jekyll build: \`cd docs && bundle exec jekyll build --baseurl /rimba\` — clean (pre-existing local SCSS env issue on main unrelated to this PR; CI uses pinned Gemfile.lock gems)
- [x] Link audit: \`grep -rn '](#rimba-' docs/commands.md docs/commands/\` — 0 stale same-page anchors
- [x] All 24 parent index links verified to resolve to existing child page files
- [x] All sibling relative links in child pages verified (no broken links)
- [x] Flags accuracy spot-check: \`add\`, \`trust\`, \`hook\`, \`deps\`, \`merge\`, \`list\` — all match \`cmd/*.go\` source definitions

## Issue

Closes #319