### PR TITLE
[fix] Hoist docs brand palette so the dark stylesheet compiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       go: ${{ steps.filter.outputs.go }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -34,6 +35,11 @@ jobs:
             echo "go=true" >> "$GITHUB_OUTPUT"
           else
             echo "go=false" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$CHANGED" | grep -qE '^docs/'; then
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs=false" >> "$GITHUB_OUTPUT"
           fi
 
   lint:
@@ -146,3 +152,20 @@ jobs:
           cache: true
       - run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
       - run: govulncheck ./...
+
+  docs-build:
+    needs: [changes]
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: docs
+      - run: bundle exec jekyll build --baseurl "/rimba"
+        working-directory: docs
+        env:
+          JEKYLL_ENV: production

--- a/docs/_sass/color_schemes/rimba.scss
+++ b/docs/_sass/color_schemes/rimba.scss
@@ -1,6 +1,3 @@
-$rimba-green-mid:  #3aaa5e;
-$rimba-green-dark: #218558; // WCAG AA on white (4.60:1)
-
 $link-color: $rimba-green-dark;
 $nav-child-link-color: $rimba-green-dark;
 $btn-primary-color: #1d7a4f; // white-on-green ~5.1:1, WCAG AA

--- a/docs/_sass/custom/setup.scss
+++ b/docs/_sass/custom/setup.scss
@@ -1,0 +1,3 @@
+// Brand palette — scheme-independent, loaded before all color schemes.
+$rimba-green-mid:  #3aaa5e;
+$rimba-green-dark: #218558; // WCAG AA on white (4.60:1)


### PR DESCRIPTION
## Summary

- Hoist `$rimba-green-mid` / `$rimba-green-dark` from `color_schemes/rimba.scss`
  into a new `_sass/custom/setup.scss` — just-the-docs imports `custom/setup` before
  any color scheme in every compilation pass, so the variables are now in scope for
  all stylesheet variants (dark, light, rimba)
- Remove the duplicate raw-hex definitions from `rimba.scss`; all assignments
  (`$link-color`, `$nav-child-link-color`, etc.) remain and resolve correctly
- Add a `docs-build` job to `ci.yml` that runs `bundle exec jekyll build` on PRs
  touching `docs/**`, mirroring the `pages.yml` build step without the deploy; pins
  `setup-ruby` to the same SHA as `pages.yml` so both builds stay in lockstep

## Test Plan

- [ ] `cd docs && bundle exec jekyll build` exits 0 (was `Sass::CompileError` on `main`)
- [ ] `_site/assets/css/just-the-docs-dark.css` generated and contains `#3aaa5e`
- [ ] Linter passes (`make lint`)
- [ ] `docs-build` CI job runs and goes green on this PR (touches `docs/**`)
- [ ] Go jobs also run on this PR (`ci.yml` edit is a non-docs change)

### Type-tailored checks ([fix])

- [ ] Reproduce the failure on `main` before applying: `bundle exec jekyll build` aborts with `Undefined variable`
- [ ] Confirm no `Sass::CompileError` remains after applying: exit 0, only `@import` deprecation warnings

## Issue

Issue: N/A — hotfix for broken Pages deploy on main (undefined Sass variable in `just-the-docs-dark.scss`)
