### PR TITLE
[feat] Support `rimba --version` as alias for `rimba version`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,6 +141,8 @@ func CommandName() string {
 
 func Execute() error {
 	updater.SweepOldBinary()
+	rootCmd.Version = versionString()
+	rootCmd.SetVersionTemplate("{{.Version}}")
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	return rootCmd.ExecuteContext(ctx)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,13 +19,7 @@ var versionCmd = &cobra.Command{
 	Example:     "  rimba version",
 	Annotations: map[string]string{"skipConfig": "true"},
 	Run: func(cmd *cobra.Command, args []string) {
-		w := cmd.OutOrStdout()
-		fmt.Fprintf(w, "rimba %s\n", version)
-		fmt.Fprintf(w, "commit: %s\n", commit)
-		fmt.Fprintf(w, "built:  %s\n", date)
-		fmt.Fprintf(w, "os:     %s\n", runtime.GOOS)
-		fmt.Fprintf(w, "arch:   %s\n", runtime.GOARCH)
-		fmt.Fprintf(w, "go:     %s\n", runtime.Version())
+		fmt.Fprint(cmd.OutOrStdout(), versionString())
 	},
 }
 
@@ -34,6 +28,20 @@ func Version() string {
 	return version
 }
 
+// versionString returns the multi-line version block printed by both
+// `rimba version` and `rimba --version`.
+func versionString() string {
+	return fmt.Sprintf(
+		"rimba %s\ncommit: %s\nbuilt:  %s\nos:     %s\narch:   %s\ngo:     %s\n",
+		version, commit, date, runtime.GOOS, runtime.GOARCH, runtime.Version(),
+	)
+}
+
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.Version = versionString()
+	rootCmd.SetVersionTemplate("{{.Version}}")
+	// Pre-register --version without a -v shorthand; this prevents Cobra's
+	// InitDefaultVersionFlag from auto-adding -v when the flag is absent.
+	rootCmd.Flags().Bool("version", false, "version for rimba")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -39,9 +39,8 @@ func versionString() string {
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-	rootCmd.Version = versionString()
-	rootCmd.SetVersionTemplate("{{.Version}}")
 	// Pre-register --version without a -v shorthand; this prevents Cobra's
 	// InitDefaultVersionFlag from auto-adding -v when the flag is absent.
+	// See TestVersionFlagNoShorthand — if this breaks, Cobra changed InitDefaultVersionFlag.
 	rootCmd.Flags().Bool("version", false, "version for rimba")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -28,8 +28,6 @@ func Version() string {
 	return version
 }
 
-// versionString returns the multi-line version block printed by both
-// `rimba version` and `rimba --version`.
 func versionString() string {
 	return fmt.Sprintf(
 		"rimba %s\ncommit: %s\nbuilt:  %s\nos:     %s\narch:   %s\ngo:     %s\n",
@@ -39,8 +37,6 @@ func versionString() string {
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-	// Pre-register --version without a -v shorthand; this prevents Cobra's
-	// InitDefaultVersionFlag from auto-adding -v when the flag is absent.
-	// See TestVersionFlagNoShorthand — if this breaks, Cobra changed InitDefaultVersionFlag.
+	// Pre-register to prevent Cobra's InitDefaultVersionFlag from auto-adding -v; see TestVersionFlagNoShorthand.
 	rootCmd.Flags().Bool("version", false, "version for rimba")
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -13,8 +13,6 @@ func TestVersion(t *testing.T) {
 	}
 }
 
-// TestVersionString tests versionString() in isolation from I/O — it is the
-// canonical format contract, independent of the subcommand or flag path.
 func TestVersionString(t *testing.T) {
 	got := versionString()
 	for _, want := range []string{"rimba", version, "commit:", "built:", "os:", "arch:", "go:"} {
@@ -51,15 +49,16 @@ func TestVersionCmd(t *testing.T) {
 func TestVersionFlagOutput(t *testing.T) {
 	outBuf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
-	// rootCmd.Version is set by Execute() in production; mirror that here since
-	// the test calls rootCmd.Execute() (cobra method) directly, bypassing cmd.Execute().
+	// rootCmd.Execute() (cobra method) bypasses the package-level Execute(); mirror its version wiring.
 	origVersion := rootCmd.Version
 	rootCmd.Version = versionString()
+	rootCmd.SetVersionTemplate("{{.Version}}")
 	rootCmd.SetOut(outBuf)
 	rootCmd.SetErr(errBuf)
 	rootCmd.SetArgs([]string{"--version"})
 	t.Cleanup(func() {
 		rootCmd.Version = origVersion
+		rootCmd.SetVersionTemplate("")
 		rootCmd.SetOut(nil)
 		rootCmd.SetErr(nil)
 		rootCmd.SetArgs(nil)
@@ -78,7 +77,6 @@ func TestVersionFlagOutput(t *testing.T) {
 		t.Errorf("--version output:\ngot  %q\nwant %q", flagOut, want)
 	}
 
-	// Byte-identical to subcommand output
 	subCmd, subBuf := newTestCmd()
 	versionCmd.Run(subCmd, nil)
 	if subBuf.String() != flagOut {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 )
@@ -12,10 +13,22 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+func TestVersionString(t *testing.T) {
+	got := versionString()
+	for _, want := range []string{"rimba", version, "commit:", "built:", "os:", "arch:", "go:"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("versionString() %q does not contain %q", got, want)
+		}
+	}
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	if len(lines) != 6 {
+		t.Errorf("expected 6 lines, got %d: %q", len(lines), got)
+	}
+}
+
 func TestVersionCmd(t *testing.T) {
 	cmd, buf := newTestCmd()
 
-	// The Run func writes to cmd.OutOrStdout()
 	versionCmd.Run(cmd, nil)
 
 	out := buf.String()
@@ -27,5 +40,40 @@ func TestVersionCmd(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 	if len(lines) != 6 {
 		t.Errorf("expected 6 lines, got %d: %q", len(lines), out)
+	}
+}
+
+func TestVersionFlagOutput(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"--version"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("rootCmd.Execute() error: %v", err)
+	}
+
+	flagOut := buf.String()
+	want := versionString()
+	if flagOut != want {
+		t.Errorf("--version output:\ngot  %q\nwant %q", flagOut, want)
+	}
+
+	// Byte-identical to subcommand output
+	subCmd, subBuf := newTestCmd()
+	versionCmd.Run(subCmd, nil)
+	if subBuf.String() != flagOut {
+		t.Errorf("--version != version subcommand:\nflag %q\nsub  %q", flagOut, subBuf.String())
+	}
+}
+
+func TestVersionFlagNoShorthand(t *testing.T) {
+	if f := rootCmd.Flags().ShorthandLookup("v"); f != nil {
+		t.Errorf("expected no -v shorthand, got flag %q", f.Name)
 	}
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -13,6 +13,8 @@ func TestVersion(t *testing.T) {
 	}
 }
 
+// TestVersionString tests versionString() in isolation from I/O — it is the
+// canonical format contract, independent of the subcommand or flag path.
 func TestVersionString(t *testing.T) {
 	got := versionString()
 	for _, want := range []string{"rimba", version, "commit:", "built:", "os:", "arch:", "go:"} {
@@ -23,6 +25,9 @@ func TestVersionString(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(got), "\n")
 	if len(lines) != 6 {
 		t.Errorf("expected 6 lines, got %d: %q", len(lines), got)
+	}
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("versionString() must end with newline; got %q", got)
 	}
 }
 
@@ -44,11 +49,17 @@ func TestVersionCmd(t *testing.T) {
 }
 
 func TestVersionFlagOutput(t *testing.T) {
-	buf := new(bytes.Buffer)
-	rootCmd.SetOut(buf)
-	rootCmd.SetErr(buf)
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	// rootCmd.Version is set by Execute() in production; mirror that here since
+	// the test calls rootCmd.Execute() (cobra method) directly, bypassing cmd.Execute().
+	origVersion := rootCmd.Version
+	rootCmd.Version = versionString()
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
 	rootCmd.SetArgs([]string{"--version"})
 	t.Cleanup(func() {
+		rootCmd.Version = origVersion
 		rootCmd.SetOut(nil)
 		rootCmd.SetErr(nil)
 		rootCmd.SetArgs(nil)
@@ -58,7 +69,10 @@ func TestVersionFlagOutput(t *testing.T) {
 		t.Fatalf("rootCmd.Execute() error: %v", err)
 	}
 
-	flagOut := buf.String()
+	if errBuf.Len() > 0 {
+		t.Errorf("unexpected stderr: %q", errBuf.String())
+	}
+	flagOut := outBuf.String()
 	want := versionString()
 	if flagOut != want {
 		t.Errorf("--version output:\ngot  %q\nwant %q", flagOut, want)


### PR DESCRIPTION
## Summary

- Extract `versionString()` helper in `cmd/version.go` — single source of truth for both the `version` subcommand and the new `--version` flag
- Wire Cobra's native version flag: set `rootCmd.Version = versionString()` and `SetVersionTemplate("{{.Version}}")` so output is byte-identical to the subcommand
- Pre-register a plain `--version` bool flag to suppress Cobra's auto-added `-v` shorthand (as specified in the issue)
- Output works outside a git repo (Cobra short-circuits before `PersistentPreRunE`)

## Test Plan

- [x] `TestVersionString` — unit test for the extracted helper
- [x] `TestVersionFlagOutput` — asserts `rimba --version` output is byte-identical to `rimba version` subcommand output
- [x] `TestVersionFlagNoShorthand` — asserts `rootCmd.Flags().ShorthandLookup("v")` is nil
- [x] All existing `TestVersion` and `TestVersionCmd` tests continue to pass
- [x] `diff <(rimba version) <(rimba --version)` produces `IDENTICAL`
- [x] Works outside a git repo (no config error)

Closes #322