### PR TITLE
[docs] Rename Command Reference to Command + split Troubleshooting into child pages

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -48,3 +48,11 @@
     color: $body-text-color;
   }
 }
+
+a.rimba-feature {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+
+  h2 { color: $link-color; }
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,10 +1,10 @@
 ---
-title: Command Reference
+title: Command
 nav_order: 2
 has_children: true
 ---
 
-# Command Reference
+# Command
 
 > See also: [Configuration](configuration.md)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6,7 +6,7 @@ has_children: true
 
 # Command
 
-> See also: [Configuration](configuration.md)
+> See also: [Configuration]({{ '/configuration' | relative_url }})
 
 Browse the full list of rimba commands below. Each command has its own page with synopsis, examples, common workflows, flags, and related commands.
 {: .fs-6 .fw-300 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9,12 +9,14 @@ has_children: true
 > See also: [Configuration](configuration.md)
 
 Browse the full list of rimba commands below. Each command has its own page with synopsis, examples, common workflows, flags, and related commands.
+{: .fs-6 .fw-300 }
 
 ---
 
 ## Global Flags
 
 These flags are available on every command:
+{: .note }
 
 | Flag | Description |
 |------|-------------|
@@ -27,85 +29,157 @@ These flags are available on every command:
 
 ## Setup
 
-| Command | Description |
-|---------|-------------|
-| [rimba init](commands/init) | Initialize rimba config, worktree directory, and optional AI agent files |
+<div class="rimba-features">
+  <a class="rimba-feature" href="{{ '/commands/init' | relative_url }}">
+    <h2>rimba init</h2>
+    <p>Initialize rimba config, worktree directory, and optional AI agent files</p>
+  </a>
+</div>
 
 ---
 
 ## Worktree Lifecycle
 
-| Command | Description |
-|---------|-------------|
-| [rimba add](commands/add) | Create a new worktree (supports monorepo scoping, PR checkout, branch promotion) |
-| [rimba remove](commands/remove) | Remove a worktree and delete the local branch |
-| [rimba rename](commands/rename) | Rename a worktree's task, branch, and directory |
-| [rimba duplicate](commands/duplicate) | Create a new worktree from an existing one, inheriting its branch prefix |
-| [rimba archive](commands/archive) | Archive a worktree (remove directory, keep branch) |
-| [rimba restore](commands/restore) | Restore an archived worktree from its preserved branch |
+<div class="rimba-features">
+  <a class="rimba-feature" href="{{ '/commands/add' | relative_url }}">
+    <h2>rimba add</h2>
+    <p>Create a new worktree (supports monorepo scoping, PR checkout, branch promotion)</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/remove' | relative_url }}">
+    <h2>rimba remove</h2>
+    <p>Remove a worktree and delete the local branch</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/rename' | relative_url }}">
+    <h2>rimba rename</h2>
+    <p>Rename a worktree's task, branch, and directory</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/duplicate' | relative_url }}">
+    <h2>rimba duplicate</h2>
+    <p>Create a new worktree from an existing one, inheriting its branch prefix</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/archive' | relative_url }}">
+    <h2>rimba archive</h2>
+    <p>Archive a worktree (remove directory, keep branch)</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/restore' | relative_url }}">
+    <h2>rimba restore</h2>
+    <p>Restore an archived worktree from its preserved branch</p>
+  </a>
+</div>
 
 ---
 
 ## Inspection
 
-| Command | Description |
-|---------|-------------|
-| [rimba list](commands/list) | List all worktrees with task, type, and status |
-| [rimba status](commands/status) | Show a worktree dashboard with summary stats and age information |
-| [rimba log](commands/log) | Show the most recent commit from each worktree |
-| [rimba open](commands/open) | Open a worktree path or run a command inside it |
+<div class="rimba-features">
+  <a class="rimba-feature" href="{{ '/commands/list' | relative_url }}">
+    <h2>rimba list</h2>
+    <p>List all worktrees with task, type, and status</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/status' | relative_url }}">
+    <h2>rimba status</h2>
+    <p>Show a worktree dashboard with summary stats and age information</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/log' | relative_url }}">
+    <h2>rimba log</h2>
+    <p>Show the most recent commit from each worktree</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/open' | relative_url }}">
+    <h2>rimba open</h2>
+    <p>Open a worktree path or run a command inside it</p>
+  </a>
+</div>
 
 ---
 
 ## Merging & Syncing
 
-| Command | Description |
-|---------|-------------|
-| [rimba merge](commands/merge) | Merge a worktree's branch into main or another worktree |
-| [rimba sync](commands/sync) | Sync worktree(s) with the main branch via rebase or merge |
-| [rimba merge-plan](commands/merge-plan) | Analyze file overlaps and recommend an optimal merge order |
-| [rimba conflict-check](commands/conflict-check) | Scan branches for files modified in multiple worktrees |
+<div class="rimba-features">
+  <a class="rimba-feature" href="{{ '/commands/merge' | relative_url }}">
+    <h2>rimba merge</h2>
+    <p>Merge a worktree's branch into main or another worktree</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/sync' | relative_url }}">
+    <h2>rimba sync</h2>
+    <p>Sync worktree(s) with the main branch via rebase or merge</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/merge-plan' | relative_url }}">
+    <h2>rimba merge-plan</h2>
+    <p>Analyze file overlaps and recommend an optimal merge order</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/conflict-check' | relative_url }}">
+    <h2>rimba conflict-check</h2>
+    <p>Scan branches for files modified in multiple worktrees</p>
+  </a>
+</div>
 
 ---
 
 ## Bulk Operations
 
-| Command | Description |
-|---------|-------------|
-| [rimba exec](commands/exec) | Run a shell command in parallel across matching worktrees |
+<div class="rimba-features">
+  <a class="rimba-feature" href="{{ '/commands/exec' | relative_url }}">
+    <h2>rimba exec</h2>
+    <p>Run a shell command in parallel across matching worktrees</p>
+  </a>
+</div>
 
 ---
 
 ## Hooks
 
-| Command | Description |
-|---------|-------------|
-| [rimba hook](commands/hook) | Manage Git hooks for worktree workflow automation |
+<div class="rimba-features">
+  <a class="rimba-feature" href="{{ '/commands/hook' | relative_url }}">
+    <h2>rimba hook</h2>
+    <p>Manage Git hooks for worktree workflow automation</p>
+  </a>
+</div>
 
 ---
 
 ## Dependencies
 
-| Command | Description |
-|---------|-------------|
-| [rimba deps](commands/deps) | Detect, clone, and install worktree dependencies |
+<div class="rimba-features">
+  <a class="rimba-feature" href="{{ '/commands/deps' | relative_url }}">
+    <h2>rimba deps</h2>
+    <p>Detect, clone, and install worktree dependencies</p>
+  </a>
+</div>
 
 ---
 
 ## AI Integration
 
-| Command | Description |
-|---------|-------------|
-| [rimba mcp](commands/mcp) | Start an MCP server exposing rimba tools to AI coding agents |
+<div class="rimba-features">
+  <a class="rimba-feature" href="{{ '/commands/mcp' | relative_url }}">
+    <h2>rimba mcp</h2>
+    <p>Start an MCP server exposing rimba tools to AI coding agents</p>
+  </a>
+</div>
 
 ---
 
 ## Maintenance
 
-| Command | Description |
-|---------|-------------|
-| [rimba clean](commands/clean) | Prune stale references or remove merged/stale worktrees |
-| [rimba trust](commands/trust) | Review and approve committed shell commands for this repo |
-| [rimba update](commands/update) | Check for and install the latest rimba release |
-| [rimba version](commands/version) | Print version, commit, build date, and platform info |
-| [rimba completion](commands/completion) | Generate shell completion scripts |
+<div class="rimba-features">
+  <a class="rimba-feature" href="{{ '/commands/clean' | relative_url }}">
+    <h2>rimba clean</h2>
+    <p>Prune stale references or remove merged/stale worktrees</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/trust' | relative_url }}">
+    <h2>rimba trust</h2>
+    <p>Review and approve committed shell commands for this repo</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/update' | relative_url }}">
+    <h2>rimba update</h2>
+    <p>Check for and install the latest rimba release</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/version' | relative_url }}">
+    <h2>rimba version</h2>
+    <p>Print version, commit, build date, and platform info</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/commands/completion' | relative_url }}">
+    <h2>rimba completion</h2>
+    <p>Generate shell completion scripts</p>
+  </a>
+</div>

--- a/docs/commands/add.md
+++ b/docs/commands/add.md
@@ -1,6 +1,6 @@
 ---
 title: rimba add
-parent: Command Reference
+parent: Command
 nav_order: 2
 ---
 

--- a/docs/commands/archive.md
+++ b/docs/commands/archive.md
@@ -1,6 +1,6 @@
 ---
 title: rimba archive
-parent: Command Reference
+parent: Command
 nav_order: 6
 ---
 

--- a/docs/commands/clean.md
+++ b/docs/commands/clean.md
@@ -1,6 +1,6 @@
 ---
 title: rimba clean
-parent: Command Reference
+parent: Command
 nav_order: 20
 ---
 

--- a/docs/commands/completion.md
+++ b/docs/commands/completion.md
@@ -1,6 +1,6 @@
 ---
 title: rimba completion
-parent: Command Reference
+parent: Command
 nav_order: 24
 ---
 

--- a/docs/commands/conflict-check.md
+++ b/docs/commands/conflict-check.md
@@ -1,6 +1,6 @@
 ---
 title: rimba conflict-check
-parent: Command Reference
+parent: Command
 nav_order: 15
 ---
 

--- a/docs/commands/deps.md
+++ b/docs/commands/deps.md
@@ -1,6 +1,6 @@
 ---
 title: rimba deps
-parent: Command Reference
+parent: Command
 nav_order: 18
 ---
 

--- a/docs/commands/duplicate.md
+++ b/docs/commands/duplicate.md
@@ -1,6 +1,6 @@
 ---
 title: rimba duplicate
-parent: Command Reference
+parent: Command
 nav_order: 5
 ---
 

--- a/docs/commands/exec.md
+++ b/docs/commands/exec.md
@@ -1,6 +1,6 @@
 ---
 title: rimba exec
-parent: Command Reference
+parent: Command
 nav_order: 16
 ---
 

--- a/docs/commands/hook.md
+++ b/docs/commands/hook.md
@@ -1,6 +1,6 @@
 ---
 title: rimba hook
-parent: Command Reference
+parent: Command
 nav_order: 17
 ---
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -1,6 +1,6 @@
 ---
 title: rimba init
-parent: Command Reference
+parent: Command
 nav_order: 1
 ---
 

--- a/docs/commands/list.md
+++ b/docs/commands/list.md
@@ -1,6 +1,6 @@
 ---
 title: rimba list
-parent: Command Reference
+parent: Command
 nav_order: 8
 ---
 

--- a/docs/commands/log.md
+++ b/docs/commands/log.md
@@ -1,6 +1,6 @@
 ---
 title: rimba log
-parent: Command Reference
+parent: Command
 nav_order: 10
 ---
 

--- a/docs/commands/mcp.md
+++ b/docs/commands/mcp.md
@@ -1,6 +1,6 @@
 ---
 title: rimba mcp
-parent: Command Reference
+parent: Command
 nav_order: 19
 ---
 

--- a/docs/commands/merge-plan.md
+++ b/docs/commands/merge-plan.md
@@ -1,6 +1,6 @@
 ---
 title: rimba merge-plan
-parent: Command Reference
+parent: Command
 nav_order: 14
 ---
 

--- a/docs/commands/merge.md
+++ b/docs/commands/merge.md
@@ -1,6 +1,6 @@
 ---
 title: rimba merge
-parent: Command Reference
+parent: Command
 nav_order: 12
 ---
 

--- a/docs/commands/open.md
+++ b/docs/commands/open.md
@@ -1,6 +1,6 @@
 ---
 title: rimba open
-parent: Command Reference
+parent: Command
 nav_order: 11
 ---
 

--- a/docs/commands/open.md
+++ b/docs/commands/open.md
@@ -55,7 +55,7 @@ rimba open my-feature npm run lint
 ```
 
 {: .warning }
-> `--ide`, `--agent`, and `--with` are mutually exclusive with each other and with inline command arguments. Shortcuts are configured in the `[open]` section of `.rimba/settings.toml` — see [Configuration](../configuration.md).
+> `--ide`, `--agent`, and `--with` are mutually exclusive with each other and with inline command arguments. Shortcuts are configured in the `[open]` section of `.rimba/settings.toml` — see [Configuration]({{ '/configuration' | relative_url }}).
 
 ## Flags
 

--- a/docs/commands/remove.md
+++ b/docs/commands/remove.md
@@ -1,6 +1,6 @@
 ---
 title: rimba remove
-parent: Command Reference
+parent: Command
 nav_order: 3
 ---
 

--- a/docs/commands/rename.md
+++ b/docs/commands/rename.md
@@ -1,6 +1,6 @@
 ---
 title: rimba rename
-parent: Command Reference
+parent: Command
 nav_order: 4
 ---
 

--- a/docs/commands/restore.md
+++ b/docs/commands/restore.md
@@ -1,6 +1,6 @@
 ---
 title: rimba restore
-parent: Command Reference
+parent: Command
 nav_order: 7
 ---
 

--- a/docs/commands/status.md
+++ b/docs/commands/status.md
@@ -1,6 +1,6 @@
 ---
 title: rimba status
-parent: Command Reference
+parent: Command
 nav_order: 9
 ---
 

--- a/docs/commands/sync.md
+++ b/docs/commands/sync.md
@@ -1,6 +1,6 @@
 ---
 title: rimba sync
-parent: Command Reference
+parent: Command
 nav_order: 13
 ---
 

--- a/docs/commands/trust.md
+++ b/docs/commands/trust.md
@@ -1,6 +1,6 @@
 ---
 title: rimba trust
-parent: Command Reference
+parent: Command
 nav_order: 21
 ---
 

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -1,6 +1,6 @@
 ---
 title: rimba update
-parent: Command Reference
+parent: Command
 nav_order: 22
 ---
 

--- a/docs/commands/version.md
+++ b/docs/commands/version.md
@@ -1,6 +1,6 @@
 ---
 title: rimba version
-parent: Command Reference
+parent: Command
 nav_order: 23
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ nav_order: 3
 
 # Configuration Reference
 
-> See also: [Command](commands.md)
+> See also: [Command]({{ '/commands' | relative_url }})
 
 Configure rimba via `.rimba/settings.toml` (team-shared) and `.rimba/settings.local.toml` (personal overrides) — all fields are optional with sensible defaults.
 {: .fs-6 .fw-300 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,9 @@ nav_order: 3
 
 > See also: [Command](commands.md)
 
+Configure rimba via `.rimba/settings.toml` (team-shared) and `.rimba/settings.local.toml` (personal overrides) — all fields are optional with sensible defaults.
+{: .fs-6 .fw-300 }
+
 ---
 
 ## Overview

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ nav_order: 3
 
 # Configuration Reference
 
-> See also: [Command Reference](commands.md)
+> See also: [Command](commands.md)
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,6 @@ rimba merge
 
 ## Reference
 
-- [Command Reference](commands.md) — all commands, flags, and examples
+- [Command](commands.md) — all commands, flags, and examples
 - [Configuration](configuration.md) — `.rimba/settings.toml` options
 - [Troubleshooting](troubleshooting.md) — error messages, hints, and fixes

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,6 @@ rimba merge
 
 ## Reference
 
-- [Command](commands.md) — all commands, flags, and examples
-- [Configuration](configuration.md) — `.rimba/settings.toml` options
-- [Troubleshooting](troubleshooting.md) — error messages, hints, and fixes
+- [Command]({{ '/commands' | relative_url }}) — all commands, flags, and examples
+- [Configuration]({{ '/configuration' | relative_url }}) — `.rimba/settings.toml` options
+- [Troubleshooting]({{ '/troubleshooting' | relative_url }}) — error messages, hints, and fixes

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,343 +1,73 @@
 ---
 title: Troubleshooting
 nav_order: 4
+has_children: true
 ---
 
 # Troubleshooting
 
-> See also: [Commands](commands.md) · [Configuration](configuration.md)
-
----
+> See also: [Command](commands.md) · [Configuration](configuration.md)
 
 rimba prints an actionable `To fix:` hint with most failures. Each section below shows the exact
 error, why it happens, and the command to resolve it.
+{: .fs-6 .fw-300 }
 
 ---
 
-## Trust & consent gate
-
-rimba will not run committed shell commands until they are approved. See
-[README § Consent gate](https://github.com/lugassawan/rimba#consent-gate) for the full background on the approval flow.
-
-### `committed shell commands require approval`
-
-```
-committed shell commands require approval
-To fix: review the commands above, then run 'rimba trust' (or pass --yes / set RIMBA_TRUST_YES=1 in CI)
-```
-
-**Why:** The interactive prompt was declined (answered "N") or stdin was non-interactive (EOF).
-
-**Fix:**
-
-```sh
-rimba trust            # review commands and approve interactively
-rimba trust --yes      # approve without prompt
-RIMBA_TRUST_YES=1 rimba add my-task   # CI / non-interactive
-```
-
-### `committed shell commands are not trusted for this repo`
-
-```
-committed shell commands are not trusted for this repo
-To fix: run 'rimba trust' to approve them, or set RIMBA_TRUST_YES=1 for CI
-```
-
-**Why:** Emitted by the MCP non-interactive path (`rimba mcp`) when committed commands exist but have
-not been approved and `RIMBA_TRUST_YES` is unset.
-
-**Fix:**
-
-```sh
-rimba trust            # approve from the CLI, then retry via MCP
-RIMBA_TRUST_YES=1 ...  # or pre-approve in the environment
-```
+<div class="rimba-features">
+  <a class="rimba-feature" href="{{ '/troubleshooting/trust-consent' | relative_url }}">
+    <h2>Trust &amp; consent gate</h2>
+    <p>Committed shell commands require approval before running. Resolve approval errors and CI non-interactive flows.</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/troubleshooting/selecting-worktrees' | relative_url }}">
+    <h2>Selecting worktrees</h2>
+    <p>Errors from <code>rimba exec</code> when no target selector or invalid type is provided.</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/troubleshooting/syncing' | relative_url }}">
+    <h2>Syncing</h2>
+    <p>Uncommitted-changes and push-rejection errors from <code>rimba sync</code>.</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/troubleshooting/adding-promoting' | relative_url }}">
+    <h2>Adding / promoting</h2>
+    <p>Flag-conflict errors when using <code>rimba add</code> in branch or PR mode.</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/troubleshooting/removing' | relative_url }}">
+    <h2>Removing</h2>
+    <p>Dirty-state errors that block <code>rimba remove</code> from discarding work.</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/troubleshooting/init-setup' | relative_url }}">
+    <h2>Init &amp; setup</h2>
+    <p>Flag errors, permission failures, and worktree-directory creation problems from <code>rimba init</code>.</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/troubleshooting/configuration-loading' | relative_url }}">
+    <h2>Configuration loading</h2>
+    <p>Missing config file and TOML syntax errors surfaced on every command invocation.</p>
+  </a>
+  <a class="rimba-feature" href="{{ '/troubleshooting/debugging-git' | relative_url }}">
+    <h2>Debugging git operations</h2>
+    <p>Enable <code>--debug</code> or <code>RIMBA_DEBUG=1</code> to trace git commands and timings to stderr.</p>
+  </a>
+</div>
 
 ---
 
-## Selecting worktrees (`exec`)
-
-### `provide --all or --type to select worktrees`
-
-```
-provide --all or --type to select worktrees
-To fix: run: rimba exec --all <cmd>  OR  rimba exec --type <prefix> <cmd>
-```
-
-**Why:** `rimba exec` was called without specifying which worktrees to target.
-
-**Fix:**
-
-```sh
-rimba exec --all "git status"
-rimba exec --type feature "npm test"
-```
-
-### `invalid type "<x>"; valid types: ...`
-
-```
-invalid type "foo"; valid types: feature, bugfix, hotfix, docs, test, chore
-To fix: choose one of the built-in prefix types: feature, bugfix, hotfix, docs, test, chore
-```
-
-**Why:** The value passed to `--type` is not a recognized prefix type.
-
-**Fix:** Choose one of the types printed in the error message (`feature`, `bugfix`, `hotfix`, `docs`,
-`test`, `chore`).
-
-```sh
-rimba exec --type feature "npm test"
-```
-
-### `--concurrency must be >= 0`
-
-```
---concurrency must be >= 0
-To fix: run: rimba exec --concurrency <n>  (n >= 0; 0 = unlimited)
-```
-
-**Why:** A negative value was passed to `--concurrency`.
-
-**Fix:**
-
-```sh
-rimba exec --all --concurrency 4 "npm test"   # limit to 4 parallel
-rimba exec --all --concurrency 0 "npm test"   # unlimited (default)
-```
-
----
-
-## Syncing
-
-### `worktree "<task>" has uncommitted changes`
-
-```
-worktree "auth" has uncommitted changes
-To fix: Commit or stash changes before syncing: cd /path/to/worktree
-```
-
-**Why:** `rimba sync <task>` was called on a worktree with a dirty working tree. rimba refuses to
-rebase or merge over uncommitted work to avoid data loss.
-
-**Fix:**
-
-```sh
-cd /path/to/worktree
-git stash          # or: git commit -am "WIP"
-rimba sync auth
-```
-
-{: .note }
-> `rimba sync --all` does *not* error on dirty worktrees — it skips them and prints
-> `Skipping <branch> (dirty)` so the rest continue. Run `rimba sync <task>` individually after
-> cleaning up.
-
-### `push failed for <branch>: ...`
-
-```
-push failed for feature/auth: exit status 1
-To fix: cd /path/to/worktree && git push --force-with-lease
-```
-
-**Why:** The remote rejected the push after a rebase (non-fast-forward). With `--merge`, the push
-is a fast-forward so the hint changes to a plain `git push`.
-
-**Fix (after rebase):**
-
-```sh
-cd /path/to/worktree && git push --force-with-lease
-```
-
-**Fix (after `--merge`):**
-
-```sh
-cd /path/to/worktree && git push
-```
-
----
-
-## Adding / promoting
-
-### `--source is not valid in branch: mode`
-
-```
---source is not valid in branch: mode
-To fix: remove the --source flag: branch: promotes an existing branch, not a new one
-```
-
-**Why:** `rimba add branch:<branch> --source <ref>` was used. `branch:` mode promotes the currently
-checked-out branch as-is; it does not create a new branch from a source ref.
-
-**Fix:**
-
-```sh
-rimba add branch:feature/my-feature   # no --source
-```
-
-### `--task requires a pr:<num> argument`
-
-```
---task requires a pr:<num> argument
-To fix: pass a PR argument: rimba add pr:<num> --task <name>
-```
-
-**Why:** `--task` was passed without a `pr:<num>` positional argument. The flag is only valid in PR
-mode to override the auto-derived task name.
-
-**Fix:**
-
-```sh
-rimba add pr:123 --task review/auth
-```
-
----
-
-## Removing
-
-### Uncommitted changes block removal
-
-```
-<git error about dirty state>
-To fix: commit or stash changes, or use --force to discard
-```
-
-**Why:** `rimba remove <task>` found uncommitted changes in the worktree. The default behavior is
-safe — it refuses to discard work.
-
-**Fix:**
-
-```sh
-cd /path/to/worktree
-git stash                       # save changes
-rimba remove auth               # then remove cleanly
-
-# OR, to discard changes permanently:
-rimba remove auth --force
-```
-
----
-
-## Init & setup
-
-### `--local requires --agents`
-
-```
---local requires --agents
-To fix: run: rimba init --agents --local
-```
-
-**Why:** `rimba init --local` was run without `--agents`. `--local` controls the install tier for
-agent files and only makes sense alongside `--agents`.
-
-**Fix:**
-
-```sh
-rimba init --agents --local
-```
-
-### `--uninstall requires -g or --agents`
-
-```
---uninstall requires -g or --agents
-To fix: run: rimba init -g --uninstall  OR  rimba init --agents --uninstall
-```
-
-**Why:** `rimba init --uninstall` was run without specifying which tier to uninstall from.
-
-**Fix:**
-
-```sh
-rimba init -g --uninstall                    # remove user-level files
-rimba init --agents --uninstall              # remove project-team files
-rimba init --agents --local --uninstall      # remove project-local files
-```
-
-### `failed to create worktree directory: ...`
-
-```
-failed to create worktree directory: mkdir /path/...: permission denied
-To fix: check directory permissions for the worktree dir, or set worktree.dir in .rimba/settings.toml
-```
-
-**Why:** rimba could not create the sibling worktree directory (default: `../<repo>-worktrees`).
-
-**Fix:** Check that the parent directory is writable, or point `worktree.dir` to a different path:
-
-```toml
-# .rimba/settings.toml
-[worktree]
-dir = "../my-worktrees"
-```
-
-See [docs/configuration.md](configuration.md) for all `[worktree]` options.
-
-### Agent-file / MCP-server permission errors
-
-```
-agent files: <error>
-To fix: check write permissions for the install dir
-```
-
-```
-mcp servers: <error>
-To fix: check write permissions for MCP client configs (.mcp.json, .cursor/mcp.json, ~/.claude.json)
-```
-
-**Why:** `rimba init --agents` (or `-g`) could not write agent instruction files or register the MCP
-server in client config files.
-
-**Fix:** Ensure the target directory is writable. For user-level (`-g`) installs the target is `~/`.
-For project-level installs the target is the repo root.
-
----
-
-## Configuration loading
-
-### `config not found: ...` — run `rimba init`
-
-```
-config not found: .rimba/settings.toml does not exist
-To fix: run 'rimba init' to create a default .rimba/settings.toml
-```
-
-**Why:** rimba could not find `.rimba/settings.toml`. This happens in a fresh clone or when running
-outside a rimba-initialized repo.
-
-**Fix:**
-
-```sh
-rimba init
-```
-
-### `invalid config <file>: ...` — TOML syntax error
-
-```
-failed to read team config: invalid config settings.toml: toml: line N: <description>
-To fix: fix the TOML syntax in /path/to/.rimba/settings.toml
-```
-
-**Why:** `.rimba/settings.toml` (or `settings.local.toml`) contains a TOML syntax error.
-`loadRaw()` emits `invalid config <filename>: ...`; `LoadDir()` wraps it with
-`failed to read team config: ...` (or `failed to read local config: ...` for `settings.local.toml`).
-
-**Fix:** Open the file and correct the syntax. Common mistakes: missing quotes around strings with
-special characters, mismatched brackets, or stray commas.
-
-> Field-level validation errors (wrong types, out-of-range values) also print their own `To fix:`
-> hints with the exact field name and expected value.
-
----
-
-## Debugging git operations
-
-Pass `--debug` to any command (or set `RIMBA_DEBUG=1`) to log every git command and its timing to
-stderr. This is useful for diagnosing slow operations or unexpected git output.
-
-```sh
-rimba list --debug
-rimba sync auth --debug
-RIMBA_DEBUG=1 rimba exec --all "git status"
-```
-
-The debug output shows the command, arguments, working directory, and elapsed time. Compare against
-what you'd expect from running the git commands directly to narrow down the problem.
+## Quick reference — error message → page
+
+| Error message | Page |
+|---|---|
+| `committed shell commands require approval` | [Trust & consent gate](troubleshooting/trust-consent) |
+| `committed shell commands are not trusted for this repo` | [Trust & consent gate](troubleshooting/trust-consent) |
+| `provide --all or --type to select worktrees` | [Selecting worktrees](troubleshooting/selecting-worktrees) |
+| `invalid type "<x>"; valid types: ...` | [Selecting worktrees](troubleshooting/selecting-worktrees) |
+| `--concurrency must be >= 0` | [Selecting worktrees](troubleshooting/selecting-worktrees) |
+| `worktree "<task>" has uncommitted changes` | [Syncing](troubleshooting/syncing) |
+| `push failed for <branch>: ...` | [Syncing](troubleshooting/syncing) |
+| `--source is not valid in branch: mode` | [Adding / promoting](troubleshooting/adding-promoting) |
+| `--task requires a pr:<num> argument` | [Adding / promoting](troubleshooting/adding-promoting) |
+| `<git error about dirty state>` (remove) | [Removing](troubleshooting/removing) |
+| `--local requires --agents` | [Init & setup](troubleshooting/init-setup) |
+| `--uninstall requires -g or --agents` | [Init & setup](troubleshooting/init-setup) |
+| `failed to create worktree directory: ...` | [Init & setup](troubleshooting/init-setup) |
+| `agent files: <error>` | [Init & setup](troubleshooting/init-setup) |
+| `config not found: ...` | [Configuration loading](troubleshooting/configuration-loading) |
+| `invalid config <file>: ...` | [Configuration loading](troubleshooting/configuration-loading) |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,7 +6,7 @@ has_children: true
 
 # Troubleshooting
 
-> See also: [Command](commands.md) · [Configuration](configuration.md)
+> See also: [Command]({{ '/commands' | relative_url }}) · [Configuration]({{ '/configuration' | relative_url }})
 
 rimba prints an actionable `To fix:` hint with most failures. Each section below shows the exact
 error, why it happens, and the command to resolve it.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,19 +55,19 @@ error, why it happens, and the command to resolve it.
 
 | Error message | Page |
 |---|---|
-| `committed shell commands require approval` | [Trust & consent gate](troubleshooting/trust-consent) |
-| `committed shell commands are not trusted for this repo` | [Trust & consent gate](troubleshooting/trust-consent) |
-| `provide --all or --type to select worktrees` | [Selecting worktrees](troubleshooting/selecting-worktrees) |
-| `invalid type "<x>"; valid types: ...` | [Selecting worktrees](troubleshooting/selecting-worktrees) |
-| `--concurrency must be >= 0` | [Selecting worktrees](troubleshooting/selecting-worktrees) |
-| `worktree "<task>" has uncommitted changes` | [Syncing](troubleshooting/syncing) |
-| `push failed for <branch>: ...` | [Syncing](troubleshooting/syncing) |
-| `--source is not valid in branch: mode` | [Adding / promoting](troubleshooting/adding-promoting) |
-| `--task requires a pr:<num> argument` | [Adding / promoting](troubleshooting/adding-promoting) |
-| `<git error about dirty state>` (remove) | [Removing](troubleshooting/removing) |
-| `--local requires --agents` | [Init & setup](troubleshooting/init-setup) |
-| `--uninstall requires -g or --agents` | [Init & setup](troubleshooting/init-setup) |
-| `failed to create worktree directory: ...` | [Init & setup](troubleshooting/init-setup) |
-| `agent files: <error>` | [Init & setup](troubleshooting/init-setup) |
-| `config not found: ...` | [Configuration loading](troubleshooting/configuration-loading) |
-| `invalid config <file>: ...` | [Configuration loading](troubleshooting/configuration-loading) |
+| `committed shell commands require approval` | [Trust & consent gate]({{ '/troubleshooting/trust-consent' | relative_url }}) |
+| `committed shell commands are not trusted for this repo` | [Trust & consent gate]({{ '/troubleshooting/trust-consent' | relative_url }}) |
+| `provide --all or --type to select worktrees` | [Selecting worktrees]({{ '/troubleshooting/selecting-worktrees' | relative_url }}) |
+| `invalid type "<x>"; valid types: ...` | [Selecting worktrees]({{ '/troubleshooting/selecting-worktrees' | relative_url }}) |
+| `--concurrency must be >= 0` | [Selecting worktrees]({{ '/troubleshooting/selecting-worktrees' | relative_url }}) |
+| `worktree "<task>" has uncommitted changes` | [Syncing]({{ '/troubleshooting/syncing' | relative_url }}) |
+| `push failed for <branch>: ...` | [Syncing]({{ '/troubleshooting/syncing' | relative_url }}) |
+| `--source is not valid in branch: mode` | [Adding / promoting]({{ '/troubleshooting/adding-promoting' | relative_url }}) |
+| `--task requires a pr:<num> argument` | [Adding / promoting]({{ '/troubleshooting/adding-promoting' | relative_url }}) |
+| `<git error about dirty state>` (remove) | [Removing]({{ '/troubleshooting/removing' | relative_url }}) |
+| `--local requires --agents` | [Init & setup]({{ '/troubleshooting/init-setup' | relative_url }}) |
+| `--uninstall requires -g or --agents` | [Init & setup]({{ '/troubleshooting/init-setup' | relative_url }}) |
+| `failed to create worktree directory: ...` | [Init & setup]({{ '/troubleshooting/init-setup' | relative_url }}) |
+| `agent files: <error>` | [Init & setup]({{ '/troubleshooting/init-setup' | relative_url }}) |
+| `config not found: ...` | [Configuration loading]({{ '/troubleshooting/configuration-loading' | relative_url }}) |
+| `invalid config <file>: ...` | [Configuration loading]({{ '/troubleshooting/configuration-loading' | relative_url }}) |

--- a/docs/troubleshooting/adding-promoting.md
+++ b/docs/troubleshooting/adding-promoting.md
@@ -1,0 +1,39 @@
+---
+title: Adding / promoting
+parent: Troubleshooting
+nav_order: 4
+---
+
+# Adding / promoting
+
+### `--source is not valid in branch: mode`
+
+```
+--source is not valid in branch: mode
+To fix: remove the --source flag: branch: promotes an existing branch, not a new one
+```
+
+**Why:** `rimba add branch:<branch> --source <ref>` was used. `branch:` mode promotes the currently
+checked-out branch as-is; it does not create a new branch from a source ref.
+
+**Fix:**
+
+```sh
+rimba add branch:feature/my-feature   # no --source
+```
+
+### `--task requires a pr:<num> argument`
+
+```
+--task requires a pr:<num> argument
+To fix: pass a PR argument: rimba add pr:<num> --task <name>
+```
+
+**Why:** `--task` was passed without a `pr:<num>` positional argument. The flag is only valid in PR
+mode to override the auto-derived task name.
+
+**Fix:**
+
+```sh
+rimba add pr:123 --task review/auth
+```

--- a/docs/troubleshooting/configuration-loading.md
+++ b/docs/troubleshooting/configuration-loading.md
@@ -1,0 +1,40 @@
+---
+title: Configuration loading
+parent: Troubleshooting
+nav_order: 7
+---
+
+# Configuration loading
+
+### `config not found: ...` — run `rimba init`
+
+```
+config not found: .rimba/settings.toml does not exist
+To fix: run 'rimba init' to create a default .rimba/settings.toml
+```
+
+**Why:** rimba could not find `.rimba/settings.toml`. This happens in a fresh clone or when running
+outside a rimba-initialized repo.
+
+**Fix:**
+
+```sh
+rimba init
+```
+
+### `invalid config <file>: ...` — TOML syntax error
+
+```
+failed to read team config: invalid config settings.toml: toml: line N: <description>
+To fix: fix the TOML syntax in /path/to/.rimba/settings.toml
+```
+
+**Why:** `.rimba/settings.toml` (or `settings.local.toml`) contains a TOML syntax error.
+`loadRaw()` emits `invalid config <filename>: ...`; `LoadDir()` wraps it with
+`failed to read team config: ...` (or `failed to read local config: ...` for `settings.local.toml`).
+
+**Fix:** Open the file and correct the syntax. Common mistakes: missing quotes around strings with
+special characters, mismatched brackets, or stray commas.
+
+> Field-level validation errors (wrong types, out-of-range values) also print their own `To fix:`
+> hints with the exact field name and expected value.

--- a/docs/troubleshooting/debugging-git.md
+++ b/docs/troubleshooting/debugging-git.md
@@ -1,0 +1,19 @@
+---
+title: Debugging git operations
+parent: Troubleshooting
+nav_order: 8
+---
+
+# Debugging git operations
+
+Pass `--debug` to any command (or set `RIMBA_DEBUG=1`) to log every git command and its timing to
+stderr. This is useful for diagnosing slow operations or unexpected git output.
+
+```sh
+rimba list --debug
+rimba sync auth --debug
+RIMBA_DEBUG=1 rimba exec --all "git status"
+```
+
+The debug output shows the command, arguments, working directory, and elapsed time. Compare against
+what you'd expect from running the git commands directly to narrow down the problem.

--- a/docs/troubleshooting/init-setup.md
+++ b/docs/troubleshooting/init-setup.md
@@ -56,7 +56,7 @@ To fix: check directory permissions for the worktree dir, or set worktree.dir in
 dir = "../my-worktrees"
 ```
 
-See [Configuration]({{ '../configuration' | relative_url }}) for all `[worktree]` options.
+See [Configuration]({{ '/configuration' | relative_url }}) for all `[worktree]` options.
 
 ### Agent-file / MCP-server permission errors
 

--- a/docs/troubleshooting/init-setup.md
+++ b/docs/troubleshooting/init-setup.md
@@ -1,0 +1,77 @@
+---
+title: Init & setup
+parent: Troubleshooting
+nav_order: 6
+---
+
+# Init & setup
+
+### `--local requires --agents`
+
+```
+--local requires --agents
+To fix: run: rimba init --agents --local
+```
+
+**Why:** `rimba init --local` was run without `--agents`. `--local` controls the install tier for
+agent files and only makes sense alongside `--agents`.
+
+**Fix:**
+
+```sh
+rimba init --agents --local
+```
+
+### `--uninstall requires -g or --agents`
+
+```
+--uninstall requires -g or --agents
+To fix: run: rimba init -g --uninstall  OR  rimba init --agents --uninstall
+```
+
+**Why:** `rimba init --uninstall` was run without specifying which tier to uninstall from.
+
+**Fix:**
+
+```sh
+rimba init -g --uninstall                    # remove user-level files
+rimba init --agents --uninstall              # remove project-team files
+rimba init --agents --local --uninstall      # remove project-local files
+```
+
+### `failed to create worktree directory: ...`
+
+```
+failed to create worktree directory: mkdir /path/...: permission denied
+To fix: check directory permissions for the worktree dir, or set worktree.dir in .rimba/settings.toml
+```
+
+**Why:** rimba could not create the sibling worktree directory (default: `../<repo>-worktrees`).
+
+**Fix:** Check that the parent directory is writable, or point `worktree.dir` to a different path:
+
+```toml
+# .rimba/settings.toml
+[worktree]
+dir = "../my-worktrees"
+```
+
+See [Configuration]({{ '../configuration' | relative_url }}) for all `[worktree]` options.
+
+### Agent-file / MCP-server permission errors
+
+```
+agent files: <error>
+To fix: check write permissions for the install dir
+```
+
+```
+mcp servers: <error>
+To fix: check write permissions for MCP client configs (.mcp.json, .cursor/mcp.json, ~/.claude.json)
+```
+
+**Why:** `rimba init --agents` (or `-g`) could not write agent instruction files or register the MCP
+server in client config files.
+
+**Fix:** Ensure the target directory is writable. For user-level (`-g`) installs the target is `~/`.
+For project-level installs the target is the repo root.

--- a/docs/troubleshooting/removing.md
+++ b/docs/troubleshooting/removing.md
@@ -1,0 +1,28 @@
+---
+title: Removing
+parent: Troubleshooting
+nav_order: 5
+---
+
+# Removing
+
+### Uncommitted changes block removal
+
+```
+<git error about dirty state>
+To fix: commit or stash changes, or use --force to discard
+```
+
+**Why:** `rimba remove <task>` found uncommitted changes in the worktree. The default behavior is
+safe — it refuses to discard work.
+
+**Fix:**
+
+```sh
+cd /path/to/worktree
+git stash                       # save changes
+rimba remove auth               # then remove cleanly
+
+# OR, to discard changes permanently:
+rimba remove auth --force
+```

--- a/docs/troubleshooting/selecting-worktrees.md
+++ b/docs/troubleshooting/selecting-worktrees.md
@@ -1,0 +1,55 @@
+---
+title: Selecting worktrees (exec)
+parent: Troubleshooting
+nav_order: 2
+---
+
+# Selecting worktrees (`exec`)
+
+### `provide --all or --type to select worktrees`
+
+```
+provide --all or --type to select worktrees
+To fix: run: rimba exec --all <cmd>  OR  rimba exec --type <prefix> <cmd>
+```
+
+**Why:** `rimba exec` was called without specifying which worktrees to target.
+
+**Fix:**
+
+```sh
+rimba exec --all "git status"
+rimba exec --type feature "npm test"
+```
+
+### `invalid type "<x>"; valid types: ...`
+
+```
+invalid type "foo"; valid types: feature, bugfix, hotfix, docs, test, chore
+To fix: choose one of the built-in prefix types: feature, bugfix, hotfix, docs, test, chore
+```
+
+**Why:** The value passed to `--type` is not a recognized prefix type.
+
+**Fix:** Choose one of the types printed in the error message (`feature`, `bugfix`, `hotfix`, `docs`,
+`test`, `chore`).
+
+```sh
+rimba exec --type feature "npm test"
+```
+
+### `--concurrency must be >= 0`
+
+```
+--concurrency must be >= 0
+To fix: run: rimba exec --concurrency <n>  (n >= 0; 0 = unlimited)
+```
+
+**Why:** A negative value was passed to `--concurrency`.
+
+**Fix:**
+
+```sh
+rimba exec --all --concurrency 4 "npm test"   # limit to 4 parallel
+rimba exec --all --concurrency 0 "npm test"   # unlimited (default)
+```

--- a/docs/troubleshooting/syncing.md
+++ b/docs/troubleshooting/syncing.md
@@ -1,0 +1,52 @@
+---
+title: Syncing
+parent: Troubleshooting
+nav_order: 3
+---
+
+# Syncing
+
+### `worktree "<task>" has uncommitted changes`
+
+```
+worktree "auth" has uncommitted changes
+To fix: Commit or stash changes before syncing: cd /path/to/worktree
+```
+
+**Why:** `rimba sync <task>` was called on a worktree with a dirty working tree. rimba refuses to
+rebase or merge over uncommitted work to avoid data loss.
+
+**Fix:**
+
+```sh
+cd /path/to/worktree
+git stash          # or: git commit -am "WIP"
+rimba sync auth
+```
+
+{: .note }
+> `rimba sync --all` does *not* error on dirty worktrees — it skips them and prints
+> `Skipping <branch> (dirty)` so the rest continue. Run `rimba sync <task>` individually after
+> cleaning up.
+
+### `push failed for <branch>: ...`
+
+```
+push failed for feature/auth: exit status 1
+To fix: cd /path/to/worktree && git push --force-with-lease
+```
+
+**Why:** The remote rejected the push after a rebase (non-fast-forward). With `--merge`, the push
+is a fast-forward so the hint changes to a plain `git push`.
+
+**Fix (after rebase):**
+
+```sh
+cd /path/to/worktree && git push --force-with-lease
+```
+
+**Fix (after `--merge`):**
+
+```sh
+cd /path/to/worktree && git push
+```

--- a/docs/troubleshooting/trust-consent.md
+++ b/docs/troubleshooting/trust-consent.md
@@ -1,0 +1,44 @@
+---
+title: Trust & consent gate
+parent: Troubleshooting
+nav_order: 1
+---
+
+# Trust & consent gate
+
+rimba will not run committed shell commands until they are approved. See
+[README § Consent gate](https://github.com/lugassawan/rimba#consent-gate) for the full background on the approval flow.
+
+### `committed shell commands require approval`
+
+```
+committed shell commands require approval
+To fix: review the commands above, then run 'rimba trust' (or pass --yes / set RIMBA_TRUST_YES=1 in CI)
+```
+
+**Why:** The interactive prompt was declined (answered "N") or stdin was non-interactive (EOF).
+
+**Fix:**
+
+```sh
+rimba trust            # review commands and approve interactively
+rimba trust --yes      # approve without prompt
+RIMBA_TRUST_YES=1 rimba add my-task   # CI / non-interactive
+```
+
+### `committed shell commands are not trusted for this repo`
+
+```
+committed shell commands are not trusted for this repo
+To fix: run 'rimba trust' to approve them, or set RIMBA_TRUST_YES=1 for CI
+```
+
+**Why:** Emitted by the MCP non-interactive path (`rimba mcp`) when committed commands exist but have
+not been approved and `RIMBA_TRUST_YES` is unset.
+
+**Fix:**
+
+```sh
+rimba trust            # approve from the CLI, then retry via MCP
+RIMBA_TRUST_YES=1 ...  # or pre-approve in the environment
+```


### PR DESCRIPTION
## Summary

- Rename nav section "Command Reference" → "Command" (`docs/commands.md` title + H1, all 24 `docs/commands/*.md` `parent:` values, display links in `index.md` and `configuration.md`)
- Split `docs/troubleshooting.md` into 8 per-section child pages under `docs/troubleshooting/` (mirrors the command reference structure); parent page becomes an index with a card grid and quick-reference error→page table
- Elevate remaining pages from plain Markdown to styled content: lead paragraphs (`{: .fs-6 .fw-300 }`), command index converted from category tables to clickable `.rimba-feature` card grids, `configuration.md` gets a lead paragraph
- Add `a.rimba-feature` SCSS rule so index cards work as block-level anchors with `$link-color` headings

## Test Plan

- [x] `bundle exec jekyll build` — success, 0 SCSS errors, 0 missing-parent warnings
- [x] `grep -rn "Command Reference" docs/` — clean (no `parent:`/`title:` hits remain)
- [x] `grep` for broken same-dir links in `docs/troubleshooting/` children — clean
- [x] All 8 troubleshooting child pages present in `_site/troubleshooting/`
- [x] Go test suite: 2153 passed (no Go files changed)
- [x] `make lint` — 0 issues

## Issue

Issue: N/A — docs UI follow-up to #321 (command reference split)