### PR TITLE
[fix] Adopt cosign new bundle format for goreleaser signing

### DIFF
--- a/.github/workflows/release-dryrun.yml
+++ b/.github/workflows/release-dryrun.yml
@@ -1,0 +1,36 @@
+name: Release Dry-Run
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".goreleaser.yaml"
+      - ".github/workflows/release.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".goreleaser.yaml"
+      - ".github/workflows/release.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release-dryrun:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,11 +34,10 @@ sboms:
 
 signs:
   - cmd: cosign
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.bundle"
     args:
       - sign-blob
-      - "--output-certificate=${certificate}"
-      - "--output-signature=${signature}"
+      - "--bundle=${signature}"
       - "${artifact}"
       - "--yes"
     artifacts: checksum


### PR DESCRIPTION
Issue: N/A — emergency fix for the failed v1.9.6 release trigger

## Summary

- cosign v3 (via `sigstore/cosign-installer@v4.1.2`) enables `--new-bundle-format` by default, which silently ignores `--output-signature` / `--output-certificate`
- Without a `--bundle` path, cosign opens an empty path → `create bundle file: open : no such file or directory`; this caused the v1.9.6 release to fail with no artifacts published
- Migrates `.goreleaser.yaml` `signs` block to `--bundle=${signature}`, producing `checksums.txt.bundle` (cert + sig in one Sigstore bundle JSON)
- Adds `release-dryrun.yml` — a PR/push CI job that exercises goreleaser + cosign on changes to release config, so this class of breakage is caught before tagging

## Root cause

The release config never changed. `sigstore/cosign-installer@v4.1.2` floated to cosign v3 which changed the default signing format. No pre-tag dry-run existed to catch it.

## Consumer verification change

Before: `cosign verify-blob --signature checksums.txt.sig --certificate checksums.txt.pem ...`
After: `cosign verify-blob --bundle checksums.txt.bundle --certificate-identity <...> --certificate-oidc-issuer <...> checksums.txt`

## Test plan

- [x] CI `release-dryrun` job runs on this PR (touches `.goreleaser.yaml`) and passes — confirms signing succeeds with the new bundle format
- [ ] After merge: re-tag the merged commit as `v1.9.6`, confirm `release.yml` completes and `gh release view 1.9.6` shows `checksums.txt` + `checksums.txt.bundle`