### PR TITLE
[fix] Add Jekyll default layout so docs pages render with the theme

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,11 +32,15 @@ jobs:
       - name: Assert pages render with the theme layout
         working-directory: docs
         run: |
-          for f in _site/commands/init.html _site/configuration.html _site/troubleshooting.html; do
+          for f in _site/commands/init.html _site/commands/add.html \
+                   _site/configuration.html \
+                   _site/troubleshooting.html _site/troubleshooting/adding-promoting.html; do
             [[ -f "$f" ]] || { echo "::error::expected built file $f not found"; exit 1; }
             grep -q '<html' "$f" \
               && grep -q 'class="site-header"' "$f" \
               || { echo "::error file=$f::page rendered without theme layout (missing _config.yml defaults?)"; exit 1; }
+            # class="site-header" is emitted by just-the-docs _layouts/default.html.
+            # If the gem is upgraded, verify this sentinel still matches and update if needed.
           done
           echo "OK: representative pages include the theme layout"
       - uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,16 @@ jobs:
         working-directory: docs
         env:
           JEKYLL_ENV: production
+      - name: Assert pages render with the theme layout
+        working-directory: docs
+        run: |
+          for f in _site/commands/init.html _site/configuration.html _site/troubleshooting.html; do
+            [[ -f "$f" ]] || { echo "::error::expected built file $f not found"; exit 1; }
+            grep -q '<html' "$f" \
+              && grep -q 'class="site-header"' "$f" \
+              || { echo "::error file=$f::page rendered without theme layout (missing _config.yml defaults?)"; exit 1; }
+          done
+          echo "OK: representative pages include the theme layout"
       - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_site

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -30,3 +30,9 @@ callouts:
   warning:
     title: Warning
     color: red
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default


### PR DESCRIPTION
## Summary
- Add a `defaults` block to `docs/_config.yml` setting `layout: default` for all pages — the root cause of every non-index docs page rendering as bare converted markdown with no theme, no sidebar, and no stylesheet link.
- Add a build-time assertion step in `.github/workflows/pages.yml` that fails CI if representative built pages (init.html, configuration.html, troubleshooting.html) are missing the theme layout wrapper, converting this class of regression into a hard build failure.

## Test Plan
- [ ] Unit tests pass (`make test`) — N/A, no Go files changed
- [ ] Linter passes (`make lint`) — N/A, no Go files changed
- [ ] E2E tests pass (`make test-e2e`) — N/A, no Go files changed

### Type-tailored checks ([fix])
- [x] Reproduce: before the `defaults` block, `bundle exec jekyll build` produced pages with no `<html>` (bare markdown conversion only)
- [x] Verify: after fix, `grep -q '<html' _site/commands/init.html && grep -q 'class="site-header"' _site/commands/init.html` — both match on all three checked pages
- [x] `index.md`'s explicit `layout: home` still wins over the global default (Jekyll front-matter precedence confirmed locally and via reviewer)
- [x] CI guard assertion step passes locally against the fixed build output
- [ ] Post-merge: `curl -sL https://lugassawan.github.io/rimba/commands/init.html | grep -c '<html'` returns `1` after Pages deploy

## Issue

Issue: N/A — site-wide docs rendering regression found via plain-HTML report (all non-index pages missing theme layout due to absent `defaults` block in `_config.yml`)
