### PR TITLE
[chore] Trigger Pages deploy on release tag + manual only, not every push to main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,7 +2,7 @@ name: Deploy docs to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    tags: ["v*"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Replace `push: branches: [main]` with `push: tags: ["v*"]` in `.github/workflows/pages.yml`
- Docs site now deploys only on release tag pushes and manual `workflow_dispatch`, not on every commit to `main`
- Mirrors the existing trigger convention in `release.yml:4-5`

## Test Plan
- [x] `actionlint .github/workflows/pages.yml` — 0 issues introduced (pre-existing SC2015 shellcheck note at line 34 is unchanged)
- [x] `pages.yml` no longer triggers on `push: branches: [main]`
- [x] `pages.yml` triggers on `push: tags: ["v*"]`
- [x] `workflow_dispatch` still present as escape-hatch
- [ ] ~~Unit tests pass (`make test`)~~ — N/A, no Go files changed
- [ ] ~~Linter passes (`make lint`)~~ — N/A, no Go files changed
- [ ] ~~E2E tests pass (`make test-e2e`)~~ — N/A, no Go files changed

> **Post-merge (owner action):** Verify Settings → Environments → `github-pages` allows tag refs (deployment-branch policy must not be locked to `main` only). Validate via a test tag or manual `workflow_dispatch` that the site builds and deploys correctly.

## Issue

Closes #343
