### PR TITLE
[fix] Block option injection in git worktree add + add subprocess deadline (#330)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ rimba uses a two-tier test layout:
 Use `cmd/add.go` as the canonical recent reference (added in #138 with the `pr:<num>` variant).
 
 1. Create `cmd/<name>.go`. Declare per-file `flag*` / `hint*` consts at the top.
-2. Declare `var <name>Cmd = &cobra.Command{Use, Short, Long, Args, RunE}`. In `RunE`, read config via `config.FromContext(cmd.Context())`, build a `git.Runner` via `newRunner()`, and (if needed) a `gh.Runner` via the package-level overridable `var newGHRunner = gh.Default` so tests can swap it.
+2. Declare `var <name>Cmd = &cobra.Command{Use, Short, Long, Args, RunE}`. In `RunE`, read config via `config.FromContext(cmd.Context())`, build a `git.Runner` via `newRunner(cmd.Context())`, and (if needed) a `gh.Runner` via `newGHRunner(cmd.Context())` — both are package-level `func(context.Context) Runner` vars that tests override via `overrideNewRunner` / `overrideGHRunner` in `cmd/mock_runner_test.go`.
 3. Keep business logic out of `cmd/`. Delegate to `internal/operations/<name>.go` so the same pipeline can back an MCP tool (see `internal/operations.ListWorktrees` / `internal/mcp/tool_list.go`).
 4. Wrap user-facing errors with `errhint.WithFix(err, "<actionable fix>")`.
 5. Bind flags and register the command in `init()` via `rootCmd.AddCommand(<name>Cmd)`.
@@ -82,7 +82,7 @@ Use `cmd/add.go` as the canonical recent reference (added in #138 with the `pr:<
 
 ## Project Conventions
 
-- **`internal/gh`** — thin wrapper around the `gh` CLI. `runner.go` defines the `Runner` interface; package-level helpers: `IsAvailable` (`detect.go`), `CheckAuth` (`auth.go`), `FetchPRMeta` (`pr_meta.go`), `QueryPRStatus` (`pr_status.go`). Use `gh.Default()` in production; inject a fake in tests.
+- **`internal/gh`** — thin wrapper around the `gh` CLI. `runner.go` defines the `Runner` interface; package-level helpers: `IsAvailable` (`detect.go`), `CheckAuth` (`auth.go`), `FetchPRMeta` (`pr_meta.go`), `QueryPRStatus` (`pr_status.go`). Use `gh.Default(timeout)` in production (timeout flows from `config.EffectiveCommandTimeout()`); inject a fake in tests.
 - **`internal/operations.ListWorktrees`** (`internal/operations/list_worktrees.go`) — the shared pipeline behind both `cmd/list.go` and the MCP `list` tool (`internal/mcp/tool_list.go`). Mirror this pattern when adding a subcommand that should also be reachable from MCP.
 - **`internal/errhint.WithFix`** (`internal/errhint/errhint.go`) — wrap user-facing errors with an actionable fix line. Preserves sentinel via `%w`. See `cmd/add.go`, `cmd/exec.go`, `cmd/sync.go` for examples.
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -28,8 +28,6 @@ const (
 var prArgRe = regexp.MustCompile(`^pr:(\d+)$`)
 var branchArgRe = regexp.MustCompile(`^branch:(.+)$`)
 
-var newGHRunner = gh.Default
-
 var addCmd = &cobra.Command{
 	Use:   "add <task|pr:<num>|branch:<branch>> or add <service>/<task>",
 	Short: "Create a new worktree for a task, GitHub PR, or promote the current branch",
@@ -54,7 +52,7 @@ main repo and is not the default branch. --source is not valid in branch: mode.`
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.FromContext(cmd.Context())
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
@@ -73,7 +71,7 @@ main repo and is not the default branch. --source is not valid in branch: mode.`
 			if err := ensureTrust(cmd, repoRoot, cfg); err != nil {
 				return err
 			}
-			return runAddPR(cmd, r, newGHRunner(), prNum, postOpts, s)
+			return runAddPR(cmd, r, newGHRunner(cmd.Context()), prNum, postOpts, s)
 		}
 
 		// branch: mode promotes an existing branch without running hooks — no trust gate.

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lugassawan/rimba/internal/errhint"
 	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/git"
+	"github.com/lugassawan/rimba/internal/gitref"
 	"github.com/lugassawan/rimba/internal/hint"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/resolver"
@@ -131,6 +132,8 @@ func runAddTask(cmd *cobra.Command, r git.Runner, arg string, cfg *config.Config
 	source, _ := cmd.Flags().GetString(flagSource)
 	if source == "" {
 		source = cfg.DefaultSource
+	} else if err := gitref.Validate(source); err != nil {
+		return fmt.Errorf("--source: %w", err)
 	}
 
 	hint.New(cmd, hintPainter(cmd)).

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -718,6 +718,34 @@ func conflictBranchRunInDirFn(stashDropped *bool) func(dir string, args ...strin
 	}
 }
 
+func TestAddTaskRejectsUnsafeSource(t *testing.T) {
+	cfg := &config.Config{WorktreeDir: "worktrees", DefaultSource: "main"}
+	r := &mockRunner{
+		run:      func(_ ...string) (string, error) { return "", nil },
+		runInDir: noopRunInDir,
+	}
+	restore := overrideNewRunner(r)
+	defer restore()
+
+	cmd, _ := newTestCmd()
+	addPrefixFlags(cmd)
+	_ = cmd.Flags().String(flagSource, "", "")
+	_ = cmd.Flags().String(flagTask, "", "")
+	_ = cmd.Flags().Bool(flagSkipDeps, false, "")
+	_ = cmd.Flags().Bool(flagSkipHooks, false, "")
+	_ = cmd.Flags().SetAnnotation(flagNoColor, cobra.BashCompOneRequiredFlag, nil)
+	cmd.SetContext(config.WithConfig(context.Background(), cfg))
+	_ = cmd.Flags().Set(flagSource, "-foo")
+
+	err := addCmd.RunE(cmd, []string{"my-task"})
+	if err == nil {
+		t.Fatal("expected error for --source=-foo, got nil")
+	}
+	if !strings.Contains(err.Error(), "leading dash") {
+		t.Errorf("error %q should mention 'leading dash'", err)
+	}
+}
+
 func TestAddBranchStashApplyConflict(t *testing.T) {
 	repoDir := t.TempDir()
 	wtDir := filepath.Join(repoDir, "worktrees")

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -733,7 +733,6 @@ func TestAddTaskRejectsUnsafeSource(t *testing.T) {
 	_ = cmd.Flags().String(flagTask, "", "")
 	_ = cmd.Flags().Bool(flagSkipDeps, false, "")
 	_ = cmd.Flags().Bool(flagSkipHooks, false, "")
-	_ = cmd.Flags().SetAnnotation(flagNoColor, cobra.BashCompOneRequiredFlag, nil)
 	cmd.SetContext(config.WithConfig(context.Background(), cfg))
 	_ = cmd.Flags().Set(flagSource, "-foo")
 

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -28,7 +28,7 @@ var archiveCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		task := args[0]
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		wt, err := findWorktree(cmd.Context(), r, task)
 		if err != nil {

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -35,7 +35,7 @@ var cleanCmd = &cobra.Command{
   rimba clean --stale --stale-days 7`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		r := newRunner()
+		r := newRunner(cmd.Context())
 		merged, _ := cmd.Flags().GetBool(flagMerged)
 		stale, _ := cmd.Flags().GetBool(flagStale)
 

--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -46,9 +45,9 @@ func init() {
 }
 
 // completeWorktreeTasks returns task names for shell completion.
-func completeWorktreeTasks(_ *cobra.Command, toComplete string) []string {
-	r := newRunner()
-	entries, err := git.ListWorktrees(context.Background(), r)
+func completeWorktreeTasks(cmd *cobra.Command, toComplete string) []string {
+	r := newRunner(cmd.Context())
+	entries, err := git.ListWorktrees(cmd.Context(), r)
 	if err != nil {
 		return nil
 	}
@@ -85,9 +84,9 @@ func completeOpenShortcuts(cmd *cobra.Command, toComplete string) []string {
 }
 
 // completeArchivedTasks returns task names from archived branches (branches not in any active worktree).
-func completeArchivedTasks(_ *cobra.Command, toComplete string) []string {
-	r := newRunner()
-	ctx := context.Background()
+func completeArchivedTasks(cmd *cobra.Command, toComplete string) []string {
+	r := newRunner(cmd.Context())
+	ctx := cmd.Context()
 
 	mainBranch, _ := resolveMainBranch(ctx, r)
 
@@ -108,9 +107,9 @@ func completeArchivedTasks(_ *cobra.Command, toComplete string) []string {
 }
 
 // completeBranchNames returns branch names for shell completion.
-func completeBranchNames(_ *cobra.Command, toComplete string) []string {
-	r := newRunner()
-	out, err := r.Run(context.Background(), "branch", "--format=%(refname:short)")
+func completeBranchNames(cmd *cobra.Command, toComplete string) []string {
+	r := newRunner(cmd.Context())
+	out, err := r.Run(cmd.Context(), "branch", "--format=%(refname:short)")
 	if err != nil {
 		return nil
 	}

--- a/cmd/conflict_check.go
+++ b/cmd/conflict_check.go
@@ -37,7 +37,7 @@ var conflictCheckCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cfg := config.FromContext(cmd.Context())
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		worktrees, err := listWorktreeInfos(cmd.Context(), r)
 		if err != nil {

--- a/cmd/deps.go
+++ b/cmd/deps.go
@@ -34,7 +34,7 @@ var depsStatusCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.FromContext(cmd.Context())
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 		worktrees, err := listWorktreeInfos(cmd.Context(), r)
 		if err != nil {
 			return err
@@ -139,7 +139,7 @@ var depsInstallCmd = &cobra.Command{
 		task := args[0]
 		cfg := config.FromContext(cmd.Context())
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {

--- a/cmd/duplicate.go
+++ b/cmd/duplicate.go
@@ -40,7 +40,7 @@ var duplicateCmd = &cobra.Command{
 		task := args[0]
 		cfg := config.FromContext(cmd.Context())
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 		ctx := cmd.Context()
 
 		repoRoot, err := git.MainRepoRoot(ctx, r)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -44,7 +44,7 @@ var execCmd = &cobra.Command{
   rimba exec --type bugfix "npm test"`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runExec(cmd, args, newRunner(), executor.Run)
+		return runExec(cmd, args, newRunner(cmd.Context()), executor.Run)
 	},
 }
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lugassawan/rimba/internal/config"
 	"github.com/lugassawan/rimba/internal/debug"
+	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/git"
 	"github.com/lugassawan/rimba/internal/operations"
 	"github.com/lugassawan/rimba/internal/output"
@@ -18,8 +19,22 @@ import (
 // newRunner creates a git.Runner for command execution.
 // Defined as a variable to allow test overrides (same pattern as newUpdater).
 // When RIMBA_DEBUG is set, wraps the runner with timing instrumentation.
-var newRunner = func() git.Runner {
-	return debug.WrapRunner(&git.ExecRunner{})
+// The timeout is sourced from config in ctx; falls back to DefaultCommandTimeout.
+var newRunner = func(ctx context.Context) git.Runner {
+	timeout := config.DefaultCommandTimeout
+	if cfg := config.FromContext(ctx); cfg != nil {
+		timeout = cfg.EffectiveCommandTimeout()
+	}
+	return debug.WrapRunner(&git.ExecRunner{Timeout: timeout})
+}
+
+// newGHRunner creates a gh.Runner with a timeout sourced from config in ctx.
+var newGHRunner = func(ctx context.Context) gh.Runner {
+	timeout := config.DefaultCommandTimeout
+	if cfg := config.FromContext(ctx); cfg != nil {
+		timeout = cfg.EffectiveCommandTimeout()
+	}
+	return gh.Default(timeout)
 }
 
 // hintPainter returns a termcolor.Painter derived from the cobra command flags.

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -21,7 +21,7 @@ var hookInstallCmd = &cobra.Command{
 	Short:   "Install post-merge and pre-commit hooks",
 	Example: "  rimba hook install",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		branch, err := resolveMainBranch(cmd.Context(), r)
 		if err != nil {
@@ -64,7 +64,7 @@ var hookUninstallCmd = &cobra.Command{
 	Short:   "Remove post-merge and pre-commit hooks",
 	Example: "  rimba hook uninstall",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		hooksDir, err := git.HooksDir(cmd.Context(), r)
 		if err != nil {
@@ -108,7 +108,7 @@ var hookStatusCmd = &cobra.Command{
 	Short:   "Show hook status",
 	Example: "  rimba hook status",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		hooksDir, err := git.HooksDir(cmd.Context(), r)
 		if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -72,7 +72,7 @@ register MCP — it only updates agent files. Registration is idempotent.`,
 			return runInitGlobal(cmd, m.uninstall)
 		}
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		ctx := cmd.Context()
 		repoRoot, err := git.RepoRoot(ctx, r)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -49,7 +49,7 @@ and CI rollup. CI symbols: ✓ success · ● pending · ✗ failure · – unkn
 
 		ctx := cmd.Context()
 		if opts.archived {
-			r := newRunner()
+			r := newRunner(cmd.Context())
 			mainBranch, err := resolveMainBranch(ctx, r)
 			if err != nil {
 				return err
@@ -61,7 +61,7 @@ and CI rollup. CI symbols: ✓ success · ● pending · ✗ failure · – unkn
 			return err
 		}
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 		cfg := config.FromContext(cmd.Context())
 		repoRoot, err := git.MainRepoRoot(ctx, r)
 		if err != nil {
@@ -71,7 +71,7 @@ and CI rollup. CI symbols: ✓ success · ● pending · ✗ failure · – unkn
 
 		var ghR gh.Runner
 		if opts.full {
-			ghR = gh.Default()
+			ghR = newGHRunner(cmd.Context())
 		}
 
 		listShowHints(cmd)

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -42,7 +42,7 @@ var logCmd = &cobra.Command{
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		mainBranch, err := resolveMainBranch(ctx, r)
 		if err != nil {

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 
 	"github.com/lugassawan/rimba/internal/config"
-	"github.com/lugassawan/rimba/internal/gh"
 	"github.com/lugassawan/rimba/internal/git"
 	mcppkg "github.com/lugassawan/rimba/internal/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -21,7 +20,7 @@ Any MCP-compatible client can connect to this server to discover and invoke
 rimba commands with structured parameters and typed responses.`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
@@ -41,7 +40,7 @@ rimba commands with structured parameters and typed responses.`,
 
 		hctx := &mcppkg.HandlerContext{
 			Runner:   r,
-			GH:       gh.Default(),
+			GH:       newGHRunner(cmd.Context()),
 			Config:   cfg,
 			RepoRoot: repoRoot,
 			Version:  version,

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -39,7 +39,7 @@ var mergeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.FromContext(cmd.Context())
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {

--- a/cmd/merge_plan.go
+++ b/cmd/merge_plan.go
@@ -21,7 +21,7 @@ var mergePlanCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cfg := config.FromContext(cmd.Context())
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		worktrees, err := listWorktreeInfos(cmd.Context(), r)
 		if err != nil {

--- a/cmd/mock_runner_test.go
+++ b/cmd/mock_runner_test.go
@@ -115,7 +115,7 @@ func newTestCmd() (*cobra.Command, *bytes.Buffer) {
 // overrideNewRunner temporarily replaces the newRunner function for testing.
 func overrideNewRunner(r git.Runner) func() {
 	orig := newRunner
-	newRunner = func() git.Runner { return r }
+	newRunner = func(_ context.Context) git.Runner { return r }
 	return func() { newRunner = orig }
 }
 
@@ -131,6 +131,6 @@ func (m *mockGhRunner) Run(ctx context.Context, args ...string) ([]byte, error) 
 // overrideGHRunner temporarily replaces the newGHRunner function for testing.
 func overrideGHRunner(r gh.Runner) func() {
 	orig := newGHRunner
-	newGHRunner = func() gh.Runner { return r }
+	newGHRunner = func(_ context.Context) gh.Runner { return r }
 	return func() { newGHRunner = orig }
 }

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -48,7 +48,7 @@ Shortcuts are configured in .rimba/settings.toml:
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		task := args[0]
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		wt, err := findWorktree(cmd.Context(), r, task)
 		if err != nil {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -33,7 +33,7 @@ var removeCmd = &cobra.Command{
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		task := args[0]
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		wt, err := findWorktree(cmd.Context(), r, task)
 		if err != nil {

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -37,7 +37,7 @@ var renameCmd = &cobra.Command{
 		}
 		cfg := config.FromContext(cmd.Context())
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -33,7 +33,7 @@ to see available archived branches.`,
 		return completeArchivedTasks(cmd, toComplete), cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		r := newRunner()
+		r := newRunner(cmd.Context())
 
 		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,7 +67,7 @@ Persistent flags (available on every command):
 			}
 		}
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
 			return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -29,7 +29,7 @@ in the last 7 days. With --detail, rows are sorted largest-first.`,
   rimba status --stale-days 7    # consider worktrees stale after 7 days`,
 	Annotations: map[string]string{"skipConfig": "true"},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		r := newRunner()
+		r := newRunner(cmd.Context())
 		staleDays, _ := cmd.Flags().GetInt(flagStaleDays)
 		detail, _ := cmd.Flags().GetBool(flagDetail)
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -64,7 +64,7 @@ var syncCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.FromContext(cmd.Context())
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 		all, _ := cmd.Flags().GetBool(flagAll)
 		useMerge, _ := cmd.Flags().GetBool(flagSyncMerge)
 		includeInherited, _ := cmd.Flags().GetBool(flagIncludeInherited)

--- a/cmd/trust.go
+++ b/cmd/trust.go
@@ -30,7 +30,7 @@ Use --yes to approve without prompting (e.g. in CI, combined with RIMBA_TRUST_YE
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := config.FromContext(cmd.Context())
 
-		r := newRunner()
+		r := newRunner(cmd.Context())
 		repoRoot, err := git.MainRepoRoot(cmd.Context(), r)
 		if err != nil {
 			return err

--- a/cmd/update_agent_hint.go
+++ b/cmd/update_agent_hint.go
@@ -40,7 +40,7 @@ func anyInstalled(statuses []agentfile.FileStatus) bool {
 func resolvePostUpdateTipPaths() (string, string) {
 	home, _ := os.UserHomeDir()
 	var repoRoot string
-	if root, err := git.RepoRoot(context.Background(), newRunner()); err == nil {
+	if root, err := git.RepoRoot(context.Background(), newRunner(context.Background())); err == nil {
 		repoRoot = root
 	}
 	return home, repoRoot

--- a/cmd/update_agent_hint.go
+++ b/cmd/update_agent_hint.go
@@ -40,7 +40,7 @@ func anyInstalled(statuses []agentfile.FileStatus) bool {
 func resolvePostUpdateTipPaths() (string, string) {
 	home, _ := os.UserHomeDir()
 	var repoRoot string
-	if root, err := git.RepoRoot(context.Background(), newRunner(context.Background())); err == nil {
+	if root, err := git.RepoRoot(context.Background(), newRunner(context.Background())); err == nil { //nolint:contextcheck // no cobra cmd here — falls back to DefaultCommandTimeout
 		repoRoot = root
 	}
 	return home, repoRoot

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,10 +7,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	toml "github.com/pelletier/go-toml/v2"
 
 	"github.com/lugassawan/rimba/internal/errhint"
+	"github.com/lugassawan/rimba/internal/gitref"
 )
 
 // FileName is the legacy config file name used by rimba.
@@ -25,15 +27,32 @@ const (
 	LocalGlob = "*.local.toml" // gitignore glob for personal *.local.toml overrides
 )
 
+// DefaultCommandTimeout is the subprocess deadline used when command_timeout is unset.
+const DefaultCommandTimeout = 120 * time.Second
+
 type Config struct {
-	WorktreeDir   string   `toml:"worktree_dir,omitempty"`
-	DefaultSource string   `toml:"default_source,omitempty"`
-	CopyFiles     []string `toml:"copy_files"`
-	PostCreate    []string `toml:"post_create,omitempty"`
-	PostRename    []string `toml:"post_rename,omitempty"`
+	WorktreeDir    string   `toml:"worktree_dir,omitempty"`
+	DefaultSource  string   `toml:"default_source,omitempty"`
+	CommandTimeout string   `toml:"command_timeout,omitempty"`
+	CopyFiles      []string `toml:"copy_files"`
+	PostCreate     []string `toml:"post_create,omitempty"`
+	PostRename     []string `toml:"post_rename,omitempty"`
 
 	Deps *DepsConfig       `toml:"deps,omitempty"`
 	Open map[string]string `toml:"open,omitempty"`
+}
+
+// EffectiveCommandTimeout returns the parsed CommandTimeout, or DefaultCommandTimeout
+// when the field is empty, unparseable, or non-positive.
+func (c *Config) EffectiveCommandTimeout() time.Duration {
+	if c.CommandTimeout == "" {
+		return DefaultCommandTimeout
+	}
+	d, err := time.ParseDuration(c.CommandTimeout)
+	if err != nil || d <= 0 {
+		return DefaultCommandTimeout
+	}
+	return d
 }
 
 // DepsConfig holds optional dependency management settings.
@@ -97,6 +116,8 @@ func (c *Config) FillDefaults(repoName, defaultBranch string) {
 func (c *Config) Validate() error {
 	var errs []error
 	errs = appendIf(errs, validateWorktreeDir(c.WorktreeDir)...)
+	errs = appendIf(errs, validateDefaultSource(c.DefaultSource)...)
+	errs = appendIf(errs, validateCommandTimeout(c.CommandTimeout)...)
 	errs = appendIf(errs, validateDeps(c.Deps)...)
 	errs = appendIf(errs, validateOpen(c.Open)...)
 	return errors.Join(errs...)
@@ -151,6 +172,9 @@ func Merge(team, local *Config) *Config {
 	}
 	if local.DefaultSource != "" {
 		merged.DefaultSource = local.DefaultSource
+	}
+	if local.CommandTimeout != "" {
+		merged.CommandTimeout = local.CommandTimeout
 	}
 	if local.CopyFiles != nil {
 		merged.CopyFiles = local.CopyFiles
@@ -318,4 +342,31 @@ func validateOpen(open map[string]string) []error {
 		}
 	}
 	return errs
+}
+
+// validateDefaultSource rejects default_source values that could inject options
+// into git commands. Empty is allowed — FillDefaults supplies the git default branch.
+func validateDefaultSource(src string) []error {
+	if src == "" {
+		return nil
+	}
+	if err := gitref.Validate(src); err != nil {
+		return []error{fmt.Errorf("default_source: %w", err)}
+	}
+	return nil
+}
+
+// validateCommandTimeout rejects non-empty durations that are unparseable or non-positive.
+func validateCommandTimeout(s string) []error {
+	if s == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return []error{fmt.Errorf("command_timeout: invalid duration %q: %w", s, err)}
+	}
+	if d <= 0 {
+		return []error{fmt.Errorf("command_timeout: duration must be positive, got %q", s)}
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lugassawan/rimba/internal/config"
 )
@@ -698,6 +699,32 @@ func TestConfigValidate(t *testing.T) {
 			cfg:     &config.Config{},
 			wantErr: false,
 		},
+		{
+			name: "valid default_source",
+			cfg: &config.Config{
+				WorktreeDir:   "../wt",
+				DefaultSource: "develop",
+			},
+			wantErr: false,
+		},
+		{
+			name: "default_source with leading dash rejected",
+			cfg: &config.Config{
+				WorktreeDir:   "../wt",
+				DefaultSource: "-foo",
+			},
+			wantErr:    true,
+			wantSubstr: []string{"default_source", "leading dash"},
+		},
+		{
+			name: "default_source with dotdot rejected",
+			cfg: &config.Config{
+				WorktreeDir:   "../wt",
+				DefaultSource: "../x",
+			},
+			wantErr:    true,
+			wantSubstr: []string{"default_source", "contains .."},
+		},
 	}
 
 	for _, tt := range tests {
@@ -785,5 +812,77 @@ func TestDepsConcurrency(t *testing.T) {
 				t.Errorf("DepsConcurrency() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestEffectiveCommandTimeout(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+		want  time.Duration
+	}{
+		{name: "unset returns 120s default", field: "", want: 120 * time.Second},
+		{name: "explicit 30s", field: "30s", want: 30 * time.Second},
+		{name: "explicit 2m", field: "2m", want: 2 * time.Minute},
+		{name: "negative duration falls back to default", field: "-5s", want: 120 * time.Second},
+		{name: "zero duration falls back to default", field: "0s", want: 120 * time.Second},
+		{name: "garbage falls back to default", field: "not-a-duration", want: 120 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{CommandTimeout: tt.field}
+			got := cfg.EffectiveCommandTimeout()
+			if got != tt.want {
+				t.Errorf("EffectiveCommandTimeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateCommandTimeout(t *testing.T) {
+	tests := []struct {
+		name       string
+		field      string
+		wantErr    bool
+		wantSubstr string
+	}{
+		{name: "empty is valid", field: ""},
+		{name: "valid duration", field: "30s"},
+		{name: "valid 2m", field: "2m"},
+		{name: "negative rejected", field: "-5s", wantErr: true, wantSubstr: "command_timeout"},
+		{name: "zero rejected", field: "0s", wantErr: true, wantSubstr: "command_timeout"},
+		{name: "garbage rejected", field: "bad", wantErr: true, wantSubstr: "command_timeout"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{WorktreeDir: "../wt", CommandTimeout: tt.field}
+			err := cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Validate() returned nil, want error containing %q", tt.wantSubstr)
+				}
+				if tt.wantSubstr != "" && !strings.Contains(err.Error(), tt.wantSubstr) {
+					t.Errorf("Validate() error = %q, want %q", err, tt.wantSubstr)
+				}
+			} else if err != nil {
+				t.Errorf("Validate() returned unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestMergeCommandTimeout(t *testing.T) {
+	team := &config.Config{WorktreeDir: "../wt", CommandTimeout: "60s"}
+	local := &config.Config{CommandTimeout: "30s"}
+	merged := config.Merge(team, local)
+	if merged.CommandTimeout != "30s" {
+		t.Errorf("Merge CommandTimeout = %q, want %q", merged.CommandTimeout, "30s")
+	}
+
+	// local empty → team value preserved
+	localEmpty := &config.Config{}
+	merged2 := config.Merge(team, localEmpty)
+	if merged2.CommandTimeout != "60s" {
+		t.Errorf("Merge CommandTimeout with empty local = %q, want %q", merged2.CommandTimeout, "60s")
 	}
 }

--- a/internal/gh/pr_meta.go
+++ b/internal/gh/pr_meta.go
@@ -9,14 +9,11 @@ import (
 	"strings"
 
 	"github.com/lugassawan/rimba/internal/errhint"
+	"github.com/lugassawan/rimba/internal/gitref"
 )
 
 // safeNameRe matches strings safe to embed in git remote names and URLs.
 var safeNameRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
-
-// branchNameRe matches valid branch names. Allows slashes for namespaced refs
-// (e.g. feature/foo, dependabot/go_modules/x) but excludes shell-special chars.
-var branchNameRe = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
 
 const ghShapeHint = "gh CLI returned an unexpected response shape — update gh: gh --version"
 
@@ -89,15 +86,8 @@ func FetchPRMeta(ctx context.Context, r Runner, num int) (PRMeta, error) {
 // validateBranchName rejects headRefName values that could inject options or
 // traverse paths when used in git commands.
 func validateBranchName(num int, name string) error {
-	switch {
-	case strings.HasPrefix(name, "-"):
-		return errhint.WithFix(fmt.Errorf("PR #%d: unsafe headRefName %q (leading dash)", num, name), ghShapeHint)
-	case strings.Contains(name, ".."):
-		return errhint.WithFix(fmt.Errorf("PR #%d: unsafe headRefName %q (contains ..)", num, name), ghShapeHint)
-	case strings.HasPrefix(name, "/"):
-		return errhint.WithFix(fmt.Errorf("PR #%d: unsafe headRefName %q (leading slash)", num, name), ghShapeHint)
-	case !branchNameRe.MatchString(name):
-		return errhint.WithFix(fmt.Errorf("PR #%d: unsafe headRefName %q", num, name), ghShapeHint)
+	if err := gitref.Validate(name); err != nil {
+		return errhint.WithFix(fmt.Errorf("PR #%d: %w", num, err), ghShapeHint)
 	}
 	return nil
 }

--- a/internal/gh/pr_meta_test.go
+++ b/internal/gh/pr_meta_test.go
@@ -252,8 +252,8 @@ func TestFetchPRMetaHeadRefNameValidation(t *testing.T) {
 		{"-foo", "leading dash"},
 		{"../etc/passwd", "contains .."},
 		{"/abs/path", "leading slash"},
-		{"a;b", "unsafe headRefName"},
-		{"a b", "unsafe headRefName"},
+		{"a;b", "unsafe git ref name"},
+		{"a b", "unsafe git ref name"},
 	}
 	for _, tt := range invalid {
 		t.Run("reject "+tt.ref, func(t *testing.T) {

--- a/internal/gh/runner.go
+++ b/internal/gh/runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Runner runs `gh` commands. Tests inject a fake.
@@ -13,13 +14,21 @@ type Runner interface {
 }
 
 // Default returns a Runner backed by the real `gh` binary.
-func Default() Runner {
-	return &execRunner{}
+// When timeout is positive, each invocation is bounded by that deadline.
+func Default(timeout time.Duration) Runner {
+	return &execRunner{timeout: timeout}
 }
 
-type execRunner struct{}
+type execRunner struct {
+	timeout time.Duration
+}
 
 func (r *execRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	if r.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.timeout)
+		defer cancel()
+	}
 	out, err := exec.CommandContext(ctx, "gh", args...).CombinedOutput()
 	if err != nil {
 		return out, fmt.Errorf("gh %s: %s: %w", strings.Join(args, " "), strings.TrimSpace(string(out)), err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Runner abstracts git command execution for testability.
@@ -18,10 +19,19 @@ type Runner interface {
 type ExecRunner struct {
 	// Dir is the working directory for git commands. If empty, uses the current directory.
 	Dir string
+	// Timeout, when positive, applies a per-invocation deadline to every subprocess.
+	// Zero means no timeout (relies solely on the caller's context).
+	Timeout time.Duration
 }
 
 // RunInDir is the single execution primitive: all other methods delegate here.
 func (r *ExecRunner) RunInDir(ctx context.Context, dir string, args ...string) (string, error) {
+	if r.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.Timeout)
+		defer cancel()
+	}
+
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Env = stableGitEnv(os.Environ())
 	if dir != "" {

--- a/internal/git/git_ctx_test.go
+++ b/internal/git/git_ctx_test.go
@@ -40,7 +40,7 @@ func TestExecRunnerTimeoutExpires(t *testing.T) {
 		t.Fatal("expected error from nanosecond timeout, got nil")
 	}
 	if !strings.Contains(err.Error(), "context deadline exceeded") {
-		t.Errorf("expected 'context deadline exceeded', got: %v", err)
+		t.Fatalf("expected 'context deadline exceeded', got: %v", err)
 	}
 }
 

--- a/internal/git/git_ctx_test.go
+++ b/internal/git/git_ctx_test.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRunInDirCancelled(t *testing.T) {
@@ -26,6 +27,28 @@ func TestRunDelegatesToRunInDir(t *testing.T) {
 	out, err := r.Run(context.Background(), "--version")
 	if err != nil {
 		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(out, "git") {
+		t.Errorf("expected git version output, got: %q", out)
+	}
+}
+
+func TestExecRunnerTimeoutExpires(t *testing.T) {
+	r := &ExecRunner{Timeout: time.Nanosecond}
+	_, err := r.Run(context.Background(), "--version")
+	if err == nil {
+		t.Fatal("expected error from nanosecond timeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Errorf("expected 'context deadline exceeded', got: %v", err)
+	}
+}
+
+func TestExecRunnerZeroTimeoutNoDeadline(t *testing.T) {
+	r := &ExecRunner{Timeout: 0}
+	out, err := r.Run(context.Background(), "--version")
+	if err != nil {
+		t.Fatalf("Run with zero timeout: %v", err)
 	}
 	if !strings.Contains(out, "git") {
 		t.Errorf("expected git version output, got: %q", out)

--- a/internal/git/mock_runner_test.go
+++ b/internal/git/mock_runner_test.go
@@ -1095,3 +1095,26 @@ func TestAddWorktreeFromBranchInsertsDashDash(t *testing.T) {
 		t.Errorf("args = %v, want %v", capturedArgs, want)
 	}
 }
+
+func TestAddWorktreeInsertsDashDash(t *testing.T) {
+	const (
+		branch = "feature/my-task"
+		source = "main"
+	)
+	var capturedArgs []string
+	r := &mockRunner{
+		run: func(args ...string) (string, error) {
+			capturedArgs = args
+			return "", nil
+		},
+	}
+
+	if err := AddWorktree(context.Background(), r, fakePath, branch, source); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+
+	want := []string{cmdWorktree, "add", "-b", branch, "--", fakePath, source}
+	if !slices.Equal(capturedArgs, want) {
+		t.Errorf("args = %v, want %v", capturedArgs, want)
+	}
+}

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -28,7 +28,7 @@ type WorktreeEntry struct {
 
 // AddWorktree creates a new worktree at the given path with a new branch from source.
 func AddWorktree(ctx context.Context, r Runner, path, branch, source string) error {
-	_, err := r.Run(ctx, cmdWorktree, "add", "-b", branch, path, source)
+	_, err := r.Run(ctx, cmdWorktree, "add", "-b", branch, "--", path, source)
 	return err
 }
 

--- a/internal/gitref/gitref.go
+++ b/internal/gitref/gitref.go
@@ -10,7 +10,8 @@ import (
 // ErrUnsafeRefName is the sentinel returned by Validate for unsafe ref names.
 var ErrUnsafeRefName = errors.New("unsafe git ref name")
 
-// refNameRe matches ref names that are safe to use as git branch/source arguments.
+// refNameRe is a structural allowlist; git itself enforces remaining naming rules
+// (e.g. no trailing dot, no .lock suffix, no consecutive dots within a component).
 var refNameRe = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
 
 // Validate returns ErrUnsafeRefName (wrapped) if name is unsafe for use as a

--- a/internal/gitref/gitref.go
+++ b/internal/gitref/gitref.go
@@ -1,0 +1,31 @@
+package gitref
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ErrUnsafeRefName is the sentinel returned by Validate for unsafe ref names.
+var ErrUnsafeRefName = errors.New("unsafe git ref name")
+
+// refNameRe matches ref names that are safe to use as git branch/source arguments.
+var refNameRe = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
+
+// Validate returns ErrUnsafeRefName (wrapped) if name is unsafe for use as a
+// git branch name or source argument. An empty name is not validated here —
+// callers that treat empty as "use default" should check before calling.
+func Validate(name string) error {
+	switch {
+	case strings.HasPrefix(name, "-"):
+		return fmt.Errorf("%w %q (leading dash)", ErrUnsafeRefName, name)
+	case strings.Contains(name, ".."):
+		return fmt.Errorf("%w %q (contains ..)", ErrUnsafeRefName, name)
+	case strings.HasPrefix(name, "/"):
+		return fmt.Errorf("%w %q (leading slash)", ErrUnsafeRefName, name)
+	case !refNameRe.MatchString(name):
+		return fmt.Errorf("%w %q", ErrUnsafeRefName, name)
+	}
+	return nil
+}

--- a/internal/gitref/gitref_test.go
+++ b/internal/gitref/gitref_test.go
@@ -1,0 +1,55 @@
+package gitref_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lugassawan/rimba/internal/gitref"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+		errFrag string
+	}{
+		{name: "simple branch", input: "main"},
+		{name: "namespaced branch", input: "feature/foo"},
+		{name: "release tag with dots", input: "release-1.2"},
+		{name: "alphanumeric", input: "abc123"},
+		{name: "underscores", input: "my_branch"},
+		{name: "leading dash", input: "-foo", wantErr: true, errFrag: "leading dash"},
+		{name: "double option", input: "--upload-pack=x", wantErr: true, errFrag: "leading dash"},
+		{name: "dotdot traversal", input: "../x", wantErr: true, errFrag: "contains .."},
+		{name: "embedded dotdot", input: "a/../b", wantErr: true, errFrag: "contains .."},
+		{name: "leading slash", input: "/abs/path", wantErr: true, errFrag: "leading slash"},
+		{name: "semicolon injection", input: "a;b", wantErr: true},
+		{name: "space injection", input: "a b", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := gitref.Validate(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Validate(%q) = nil, want error", tc.input)
+				}
+				if !errors.Is(err, gitref.ErrUnsafeRefName) {
+					t.Errorf("Validate(%q): want errors.Is ErrUnsafeRefName, got %v", tc.input, err)
+				}
+				if tc.errFrag != "" {
+					if msg := err.Error(); !contains(msg, tc.errFrag) {
+						t.Errorf("Validate(%q) error = %q, want %q in message", tc.input, msg, tc.errFrag)
+					}
+				}
+			} else if err != nil {
+				t.Fatalf("Validate(%q) = %v, want nil", tc.input, err)
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	return strings.Contains(s, sub)
+}


### PR DESCRIPTION
## Summary

- **Security (High):** Add `--` end-of-options separator to `git worktree add` in `internal/git/worktree.go`, preventing a user/config-supplied `source` value beginning with `-` from being parsed by git as a flag
- **Security (High):** Introduce `internal/gitref` package with `Validate()` and `ErrUnsafeRefName` sentinel; validates `default_source` in config at load time and `--source` CLI flag at invocation time, giving a clear error before any subprocess runs
- **Reliability (Medium):** Add `ExecRunner.Timeout` field in `internal/git/git.go` and mirror it in `internal/gh/runner.go`; a `context.WithTimeout` wraps every subprocess call, composing with the existing signal context via earliest-deadline-wins
- **Config:** New `command_timeout` TOML field (e.g. `"30s"`) with `EffectiveCommandTimeout()` accessor; defaults to 120 s; validated in `Config.Validate()`; threaded through all `cmd/` call sites via `newRunner(cmd.Context())` and `newGHRunner(cmd.Context())`
- **Refactor:** `gh.Default(timeout)` now takes an explicit deadline; `newRunner`/`newGHRunner` in `cmd/helpers.go` source the timeout from `config.FromContext(ctx)` in one place

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Linter passes (`make lint`)
- [x] E2E tests pass (`make test-e2e`)
- [x] Coverage ≥ 97% (`go test ./... -coverprofile=...` → 97.2%)
- [x] `TestAddWorktreeInsertsDashDash` — asserts `--` appears before path/source in args
- [x] `TestExecRunnerTimeoutExpires` — nanosecond timeout causes `context deadline exceeded`
- [x] `TestAddTaskRejectsUnsafeSource` — `--source=-foo` returns "leading dash" error
- [x] `TestValidate` (12 table cases) — all gitref allow/reject paths covered
- [x] `TestEffectiveCommandTimeout`, `TestValidateCommandTimeout`, `TestMergeCommandTimeout`

## Issue

Closes #330